### PR TITLE
Add 8 diagnostic assessments for probability & information theory (se…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,12 +35,14 @@ const CURRICULUM = [
           "Variational inference (ELBO, mean-field) underpins VAEs, latent variable models, and the theoretical framework behind DPO\u2019s derivation. It\u2019s the bridge between Bayesian reasoning and tractable training."
         ],
         subtopics: [
-          "Exponential family distributions and sufficient statistics",
-          "KL divergence \u2014 forward vs. reverse, mode-seeking vs. mode-covering",
-          "f-divergences: chi-squared, Hellinger, R\u00E9nyi, Jensen-Shannon",
-          "Mutual information, entropy, cross-entropy",
-          "Concentration inequalities",
-          "Bayesian and variational inference fundamentals"
+          "Probability foundations: Bayes' theorem, conditional probability, common distributions",
+          "Entropy, cross-entropy, mutual information, and perplexity",
+          "Exponential family distributions, sufficient statistics, and MLE",
+          "KL divergence \u2014 forward vs. reverse, f-divergences, Jensen-Shannon, R\u00E9nyi",
+          "Bayesian inference, variational methods, ELBO, and amortized inference",
+          "Sampling methods: importance sampling, MCMC, rejection sampling, Gumbel-max",
+          "Concentration inequalities: Hoeffding, Chernoff, sub-Gaussian bounds",
+          "Information theory in practice: LLM loss, temperature, RLHF, bits-per-byte"
         ]
       },
       {

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,8 +1,30 @@
 import { easyModule as linAlgEasy, mediumModule as linAlgMedium, hardModule as linAlgHard } from './linear-algebra';
 import { easyModule, mediumModule, hardModule } from './info-theory-f-divergences';
+import { probabilityFoundationsAssessment } from './prob-assessment-foundations';
+import { exponentialFamilyAssessment } from './prob-assessment-exponential-family';
+import { entropyAssessment } from './prob-assessment-entropy';
+import { divergencesAssessment } from './prob-assessment-divergences';
+import { bayesianAssessment } from './prob-assessment-bayesian';
+import { samplingAssessment } from './prob-assessment-sampling';
+import { concentrationAssessment } from './prob-assessment-concentration';
+import { appliedInfoTheoryAssessment } from './prob-assessment-applied';
 
 // Registry: maps curriculum section IDs to available modules
 export const MODULES = {
   "0.1": [linAlgEasy, linAlgMedium, linAlgHard],
-  "0.2": [easyModule, mediumModule, hardModule],
+  "0.2": [
+    // Diagnostic assessments — take these first to identify gaps
+    probabilityFoundationsAssessment,
+    entropyAssessment,
+    exponentialFamilyAssessment,
+    divergencesAssessment,
+    bayesianAssessment,
+    samplingAssessment,
+    concentrationAssessment,
+    appliedInfoTheoryAssessment,
+    // Deep-dive teaching modules
+    easyModule,
+    mediumModule,
+    hardModule,
+  ],
 };

--- a/src/modules/prob-assessment-applied.js
+++ b/src/modules/prob-assessment-applied.js
@@ -1,0 +1,127 @@
+// Assessment: Information Theory in Practice — LLM Applications
+// Section 0.2: Diagnostic test — applying probability & info theory to LLM training, RLHF, generation
+// Pure assessment to gauge ability to connect theory to practice
+
+export const appliedInfoTheoryAssessment = {
+  id: "0.2-assess-applied",
+  sectionId: "0.2",
+  title: "Assessment: Information Theory in LLM Practice",
+  difficulty: "hard",
+  estimatedMinutes: 14,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Information Theory in LLM Practice",
+      content: "This is a **diagnostic assessment** testing your ability to connect probability and information theory to concrete LLM phenomena.\n\nEach question describes a real situation in LLM training, fine-tuning, or generation and asks you to identify the underlying theoretical principle.\n\nIf you score below 70%, work through the other assessments first, then return to this one — it integrates everything."
+    },
+    {
+      type: "mc",
+      question: "During LLM pre-training, the loss is $-\\frac{1}{T} \\sum_{t=1}^{T} \\log P_\\theta(w_t \\mid w_{<t})$. As training progresses, this loss decreases but eventually plateaus. The **irreducible** component of this loss corresponds to:",
+      options: [
+        "The numerical precision of float16 arithmetic",
+        "The **entropy of natural language** $H(W_t \\mid W_{<t})$ — the inherent unpredictability that no model can eliminate because language itself is stochastic",
+        "The size of the vocabulary",
+        "The number of parameters in the model"
+      ],
+      correct: 1,
+      explanation: "Cross-entropy loss $= H(P) + \\text{KL}(P \\| Q_\\theta)$. Even a perfect model ($Q = P$) achieves loss $H(P)$, the conditional entropy of the next token. This is the irreducible noise in language — given perfect context, many continuations are still plausible. The gap between the model's loss and $H(P)$ is the KL divergence, which measures model imperfection. Scaling laws describe how this KL component decreases with compute."
+    },
+    {
+      type: "mc",
+      question: "When you increase the **temperature** $\\tau$ in sampling ($P(w) \\propto \\exp(z_w / \\tau)$ where $z_w$ are logits), you are:",
+      options: [
+        "Changing the model's parameters",
+        "Interpolating between the model's learned distribution ($\\tau = 1$) and uniform ($\\tau \\to \\infty$), which increases entropy and diversity. At $\\tau \\to 0$, you get argmax (greedy) decoding",
+        "Applying dropout at inference time",
+        "Changing the loss function"
+      ],
+      correct: 1,
+      explanation: "Dividing logits by $\\tau > 1$ flattens the distribution (higher entropy, more random). Dividing by $\\tau < 1$ sharpens it (lower entropy, more deterministic). At $\\tau \\to 0$, all mass concentrates on the highest-logit token (argmax). At $\\tau \\to \\infty$, the distribution approaches uniform over the vocabulary. Temperature is a post-hoc entropy control that doesn't change the model — it's a monotonic transformation of the entropy of the output distribution."
+    },
+    {
+      type: "mc",
+      question: "In RLHF, increasing the KL penalty coefficient $\\beta$ in $\\max_\\pi \\mathbb{E}[r(x)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ causes the optimal policy to:",
+      options: [
+        "Maximize reward regardless of the reference policy",
+        "Stay closer to $\\pi_{\\text{ref}}$, trading off reward for distributional similarity — in the limit $\\beta \\to \\infty$, $\\pi^* = \\pi_{\\text{ref}}$",
+        "Become a uniform distribution",
+        "Increase its entropy independently of $\\pi_{\\text{ref}}$"
+      ],
+      correct: 1,
+      explanation: "The optimal policy is $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. As $\\beta \\to \\infty$, $\\exp(r/\\beta) \\to 1$, so $\\pi^* \\to \\pi_{\\text{ref}}$. As $\\beta \\to 0$, the reward dominates, and the policy concentrates on the highest-reward outputs regardless of naturalness. $\\beta$ controls the **rate-distortion trade-off**: how much \"distortion\" (reward sacrifice) you accept to stay within a certain \"rate\" (KL budget) from the reference."
+    },
+    {
+      type: "mc",
+      question: "A model trained on code achieves cross-entropy 0.5 nats/token on Python but 1.8 nats/token on Haskell. Assuming equal vocabulary, the **perplexity ratio** tells us:",
+      options: [
+        "Python is a better language than Haskell",
+        "The model has learned far more predictable structure in Python — perplexity is $e^{0.5} \\approx 1.65$ for Python vs $e^{1.8} \\approx 6.05$ for Haskell, meaning the model is ~3.7× more uncertain per token on Haskell",
+        "The Haskell tokenizer is broken",
+        "The Python test set is smaller"
+      ],
+      correct: 1,
+      explanation: "Perplexity $= e^{H(P,Q)}$. Lower cross-entropy → lower perplexity → more predictable. The ratio $e^{1.8}/e^{0.5} = e^{1.3} \\approx 3.67$ means the model's uncertainty per token is 3.7× higher on Haskell. This could reflect: less Haskell in training data, Haskell's inherently different structure, or poor tokenization. The information-theoretic view lets you decompose the loss into data entropy + model deficiency."
+    },
+    {
+      type: "mc",
+      question: "**Reward hacking** in RLHF occurs when the policy finds outputs that score high reward but are low-quality. From an information-theoretic perspective, this happens because:",
+      options: [
+        "The reward model has high entropy",
+        "The reward model is a learned approximation — as $\\pi$ moves far from $\\pi_{\\text{ref}}$ (high KL), it enters out-of-distribution regions where the reward model's predictions are unreliable, effectively exploiting the reward model's epistemic uncertainty",
+        "The KL penalty is too large",
+        "The vocabulary is too small"
+      ],
+      correct: 1,
+      explanation: "The reward model $r_\\phi$ was trained on data from $\\pi_{\\text{ref}}$. When $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is large, $\\pi$ generates text unlike anything the reward model saw during training. The reward model's predictions become meaningless — it may assign high scores to adversarial outputs. This is why the KL penalty is crucial: it keeps $\\pi$ in the region where $r_\\phi$ is calibrated. This is a distributional shift problem quantified by KL divergence."
+    },
+    {
+      type: "mc",
+      question: "During fine-tuning, you notice the model's **token-level entropy** $H(P_\\theta(\\cdot \\mid x))$ dropping rapidly. The attention entropy (entropy of attention weights) is also collapsing. This likely indicates:",
+      options: [
+        "The model is learning perfectly",
+        "The model is **overfitting and losing diversity** — it's becoming overconfident on training patterns, potentially memorizing rather than generalizing. Entropy collapse in attention means it's attending to fewer positions, losing contextual flexibility",
+        "The learning rate is too low",
+        "The model needs a larger vocabulary"
+      ],
+      correct: 1,
+      explanation: "Entropy collapse is a warning sign: the model assigns near-deterministic predictions and attends to very few positions. Low output entropy means the model \"thinks\" it's very certain — but on new inputs, this overconfidence leads to poor calibration and repetitive/degenerate outputs. Monitoring entropy during training is an information-theoretic diagnostic: healthy training should reduce entropy gradually (learning structure) without collapsing it (losing flexibility)."
+    },
+    {
+      type: "mc",
+      question: "The **bits-per-byte** (BPB) metric normalizes perplexity across different tokenizers. If model A has perplexity 15.2 with a BPE tokenizer averaging 3.8 bytes/token, and model B has perplexity 8.1 with a character-level tokenizer (1 byte/token), which is better?",
+      options: [
+        "Model B — it has lower perplexity",
+        "Must compare BPB: model A's BPB $= \\frac{\\log_2(15.2)}{3.8} \\approx 1.03$, model B's BPB $= \\frac{\\log_2(8.1)}{1.0} \\approx 3.02$. Model A is much better despite higher perplexity — it compresses information more efficiently per byte",
+        "Model A — it has a better tokenizer",
+        "They are equivalent"
+      ],
+      correct: 1,
+      explanation: "BPB = (bits per token) / (bytes per token) = $\\log_2(\\text{PPL}) / \\text{avg\\_bytes\\_per\\_token}$. Model A: $\\log_2(15.2)/3.8 \\approx 1.03$ BPB. Model B: $\\log_2(8.1)/1.0 \\approx 3.02$ BPB. Model A achieves much better compression per byte of text. Raw perplexity is misleading across tokenizers because a character-level model predicts many more (easier) tokens. BPB is the fair comparison metric."
+    },
+    {
+      type: "mc",
+      question: "In the **information bottleneck** framework, a representation $Z$ of input $X$ is optimized to maximize $I(Z; Y)$ (task-relevant information) while minimizing $I(Z; X)$ (total information retained). In the context of LLM representations, this means:",
+      options: [
+        "Layers should memorize all input details",
+        "Good representations should **compress away irrelevant details of the input** while retaining information needed for prediction — the $\\beta$ parameter controls this trade-off, analogous to the KL penalty in RLHF",
+        "All layers should have the same mutual information with the input",
+        "The output should be independent of the input"
+      ],
+      correct: 1,
+      explanation: "The IB objective $\\max_{p(z|x)} I(Z; Y) - \\beta I(Z; X)$ formalizes the compression/prediction trade-off. Small $\\beta$ keeps all information (overfitting); large $\\beta$ compresses aggressively (underfitting). This framework connects to: dropout (random compression), bottleneck layers (architectural compression), and the KL penalty in RLHF (behavioral compression). The parallel to $\\max \\mathbb{E}[r] - \\beta \\text{KL}$ is exact in structure."
+    },
+    {
+      type: "mc",
+      question: "When computing $\\log P(y \\mid x)$ for a long sequence $y = (y_1, \\dots, y_T)$, numerical issues arise because the log-probability is a sum of $T$ negative terms that can become very negative. The standard solution is:",
+      options: [
+        "Clipping the log-probabilities to a minimum value",
+        "Working in **log-space throughout** — using the log-sum-exp trick for normalization and accumulating log-probabilities additively, which is numerically stable and avoids underflow from multiplying many small probabilities",
+        "Using float64 instead of float32",
+        "Truncating sequences to a maximum length"
+      ],
+      correct: 1,
+      explanation: "Direct computation of $P(y|x) = \\prod_t P(y_t | y_{<t}, x)$ would underflow to zero for long sequences (multiplying many numbers < 1). Instead, we compute $\\log P(y|x) = \\sum_t \\log P(y_t | y_{<t}, x)$, keeping everything in log-space. The log-sum-exp trick $\\log \\sum_i e^{a_i} = A + \\log \\sum_i e^{a_i - A}$ (where $A = \\max_i a_i$) handles the softmax normalization. This is a universal pattern: always work in log-probability space."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-bayesian.js
+++ b/src/modules/prob-assessment-bayesian.js
@@ -1,0 +1,127 @@
+// Assessment: Bayesian Inference & Variational Methods
+// Section 0.2: Diagnostic test — priors, posteriors, ELBO, variational inference
+// Pure assessment to gauge depth of understanding
+
+export const bayesianAssessment = {
+  id: "0.2-assess-bayesian",
+  sectionId: "0.2",
+  title: "Assessment: Bayesian Inference & Variational Methods",
+  difficulty: "hard",
+  estimatedMinutes: 14,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Bayesian Inference & Variational Methods",
+      content: "This is a **diagnostic assessment** covering Bayesian reasoning, posterior inference, and variational methods.\n\nVariational inference underpins VAEs, the theoretical derivation of DPO, the ELBO in latent variable models, and the Bayesian perspective on regularization. These concepts bridge \"fitting a model\" to \"reasoning about uncertainty.\"\n\nIf you score below 70%, invest time in these fundamentals — they're harder to patch later."
+    },
+    {
+      type: "mc",
+      question: "Bayes' theorem states $P(\\theta \\mid \\mathcal{D}) = \\frac{P(\\mathcal{D} \\mid \\theta) P(\\theta)}{P(\\mathcal{D})}$. The denominator $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ is called the **evidence** or **marginal likelihood**. Why is it typically intractable?",
+      options: [
+        "Because $P(\\mathcal{D} \\mid \\theta)$ is unknown",
+        "Because the integral is over the entire parameter space, which is high-dimensional for neural networks — making it impossible to evaluate analytically or numerically",
+        "Because the prior $P(\\theta)$ is always improper",
+        "Because the data $\\mathcal{D}$ is too large"
+      ],
+      correct: 1,
+      explanation: "For a neural network with millions of parameters, $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ requires integrating over a million-dimensional space. This integral has no closed form (the likelihood is a complex nonlinear function of $\\theta$) and is too high-dimensional for numerical quadrature. This intractability motivates both MCMC (sampling) and variational inference (optimization) as approximation strategies."
+    },
+    {
+      type: "mc",
+      question: "In variational inference, we approximate the intractable posterior $P(\\theta \\mid \\mathcal{D})$ with a tractable distribution $q(\\theta)$ by minimizing $\\text{KL}(q(\\theta) \\| P(\\theta \\mid \\mathcal{D}))$. This is **reverse KL**. What consequence does this have?",
+      options: [
+        "$q$ will cover all modes of the posterior (mode-covering)",
+        "$q$ will tend to concentrate on a single mode of the posterior (mode-seeking), potentially underestimating uncertainty",
+        "$q$ will exactly match the posterior",
+        "$q$ will be uniform over the parameter space"
+      ],
+      correct: 1,
+      explanation: "Reverse KL is mode-seeking: $q$ will lock onto one mode of the posterior and fit it tightly, ignoring other modes. This means variational inference systematically **underestimates** posterior uncertainty. For multimodal posteriors, $q$ may miss important modes. This is the fundamental trade-off of variational inference vs. MCMC (which can in principle explore all modes)."
+    },
+    {
+      type: "mc",
+      question: "The **ELBO** (Evidence Lower Bound) is $\\mathcal{L}(q) = \\mathbb{E}_q[\\log P(\\mathcal{D} \\mid \\theta)] - \\text{KL}(q(\\theta) \\| P(\\theta))$. Why is it called a \"lower bound\"?",
+      options: [
+        "Because it lower-bounds the KL divergence",
+        "Because $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q \\| P(\\theta \\mid \\mathcal{D})) \\geq \\mathcal{L}(q)$, since KL $\\geq 0$ — so the ELBO lower-bounds the log-evidence",
+        "Because the expected log-likelihood is always negative",
+        "Because the prior term is always a penalty"
+      ],
+      correct: 1,
+      explanation: "We can decompose: $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q(\\theta) \\| P(\\theta \\mid \\mathcal{D}))$. Since KL is always $\\geq 0$, we get $\\log P(\\mathcal{D}) \\geq \\mathcal{L}(q)$. Maximizing the ELBO simultaneously (1) tightens the bound on the evidence, and (2) minimizes $\\text{KL}(q \\| P(\\theta \\mid \\mathcal{D}))$, making $q$ a better posterior approximation. The ELBO equals the evidence when $q$ equals the true posterior."
+    },
+    {
+      type: "mc",
+      question: "In the VAE (Variational Autoencoder), the ELBO for a single datapoint is $\\mathcal{L}(x) = \\mathbb{E}_{q(z|x)}[\\log p(x \\mid z)] - \\text{KL}(q(z \\mid x) \\| p(z))$. The two terms correspond to:",
+      options: [
+        "Accuracy and speed",
+        "**Reconstruction** (how well can we decode $z$ back to $x$) and **regularization** (how close is the encoder's posterior to the prior)",
+        "Training loss and validation loss",
+        "Bias and variance of the model"
+      ],
+      correct: 1,
+      explanation: "The first term $\\mathbb{E}_{q(z|x)}[\\log p(x|z)]$ encourages accurate reconstruction — $z$ must contain enough information to reproduce $x$. The second term $\\text{KL}(q(z|x) \\| p(z))$ regularizes the latent space, pushing $q(z|x)$ toward the prior $p(z) = \\mathcal{N}(0, I)$. The tension between these creates a learned compression: encode enough to reconstruct, but stay close to a simple prior."
+    },
+    {
+      type: "mc",
+      question: "The **reparameterization trick** in VAEs writes $z = \\mu(x) + \\sigma(x) \\odot \\epsilon$ where $\\epsilon \\sim \\mathcal{N}(0, I)$. Why is this needed?",
+      options: [
+        "To make the latent space continuous",
+        "To move the stochasticity outside the computational graph, enabling backpropagation through the sampling operation via the deterministic path $\\mu(x)$ and $\\sigma(x)$",
+        "To ensure $z$ follows a Gaussian distribution",
+        "To reduce the dimensionality of $z$"
+      ],
+      correct: 1,
+      explanation: "You can't backpropagate through a random sampling operation $z \\sim q(z|x)$. The reparameterization trick rewrites this as a deterministic function of learned parameters ($\\mu, \\sigma$) plus fixed noise ($\\epsilon$). Now gradients flow through $\\mu$ and $\\sigma$ to the encoder. This same idea (making gradients flow through stochastic operations) appears in policy gradient methods and Gumbel-softmax for discrete distributions."
+    },
+    {
+      type: "mc",
+      question: "**Mean-field variational inference** assumes the variational distribution factorizes: $q(\\theta) = \\prod_i q_i(\\theta_i)$. What does this independence assumption sacrifice?",
+      options: [
+        "The ability to model the mean of each parameter",
+        "All correlations between parameters — it cannot capture posterior dependencies, often leading to underestimated uncertainty",
+        "The ability to compute the ELBO",
+        "Convergence guarantees"
+      ],
+      correct: 1,
+      explanation: "Mean-field assumes all parameters are independent in the posterior, which is almost never true. In neural networks, weight correlations are rampant (e.g., a large weight in one layer affects optimal weights in the next). This means mean-field posteriors are overconfident — they give tight marginals that ignore how parameters co-vary. Despite this limitation, mean-field VI is widely used because it's tractable."
+    },
+    {
+      type: "mc",
+      question: "The derivation of **DPO** (Direct Preference Optimization) starts from the KL-constrained RLHF objective and finds its closed-form optimal policy. The derivation critically uses:",
+      options: [
+        "The Lagrangian dual of the KL constraint, yielding $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$ — a Gibbs/Boltzmann distribution where the partition function acts as a value function",
+        "Monte Carlo sampling of the reward function",
+        "The gradient of the JS divergence",
+        "The central limit theorem applied to token probabilities"
+      ],
+      correct: 0,
+      explanation: "The RLHF objective $\\max_\\pi \\mathbb{E}[r] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ has the closed-form solution $\\pi^*(y|x) = \\frac{1}{Z(x)} \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$ where $Z(x) = \\sum_y \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. This is derived by taking the functional derivative and solving. The key insight is rearranging to express $r$ in terms of $\\pi^*/\\pi_{\\text{ref}}$, then substituting into the Bradley-Terry preference model to eliminate the reward entirely."
+    },
+    {
+      type: "mc",
+      question: "**Bayesian model comparison** uses the evidence $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta, M) P(\\theta \\mid M) d\\theta$ to compare models $M_1$ and $M_2$ via the Bayes factor $\\frac{P(\\mathcal{D} \\mid M_1)}{P(\\mathcal{D} \\mid M_2)}$. How does this naturally implement Occam's razor?",
+      options: [
+        "It penalizes models with more parameters through an explicit penalty term",
+        "Complex models spread their prior mass over many possible datasets, so they assign lower prior probability to any specific dataset — the evidence automatically balances fit and complexity",
+        "It uses cross-validation internally",
+        "It selects the model with the highest likelihood on the training data"
+      ],
+      correct: 1,
+      explanation: "A complex model can fit many possible datasets but must spread its prior predictive probability $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ thinly over all of them. A simple model concentrates its probability on fewer datasets but assigns higher probability to those. The evidence thus naturally penalizes unnecessary complexity — no regularization parameter needed. This is called the \"Bayesian Occam's razor.\""
+    },
+    {
+      type: "mc",
+      question: "**Amortized inference** (as in VAEs) trains an encoder $q_\\phi(z \\mid x)$ to approximate the posterior for any $x$, rather than optimizing $q$ separately for each $x$. The key advantage is:",
+      options: [
+        "It guarantees exact posterior inference",
+        "After training, inference for a new $x$ is a single forward pass through the encoder — no iterative optimization needed. This trades per-datapoint optimality for speed",
+        "It eliminates the need for the ELBO",
+        "It makes the posterior always Gaussian"
+      ],
+      correct: 1,
+      explanation: "Traditional VI optimizes $q(z)$ separately per datapoint (expensive). Amortized inference learns a single function $q_\\phi(z|x)$ (the encoder) that maps any $x$ to an approximate posterior in one forward pass. The trade-off: the \"amortization gap\" — the shared encoder may not be as good as per-datapoint optimization. But the speedup (one pass vs. iterative optimization) makes it practical for large datasets."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-concentration.js
+++ b/src/modules/prob-assessment-concentration.js
@@ -1,0 +1,115 @@
+// Assessment: Concentration Inequalities & Tail Bounds
+// Section 0.2: Diagnostic test — Markov, Chebyshev, Hoeffding, Chernoff, sub-Gaussian
+// Pure assessment to gauge depth of understanding
+
+export const concentrationAssessment = {
+  id: "0.2-assess-concentration",
+  sectionId: "0.2",
+  title: "Assessment: Concentration Inequalities & Tail Bounds",
+  difficulty: "hard",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Concentration Inequalities & Tail Bounds",
+      content: "This is a **diagnostic assessment** covering concentration inequalities — the mathematical tools for bounding how much a random variable deviates from its expectation.\n\nThese inequalities underpin: generalization bounds, PAC learning theory, why large-batch training works, confidence intervals for evaluation metrics, and the theory of gradient estimation in SGD.\n\nIf you score below 70%, review these — they form the backbone of statistical learning theory."
+    },
+    {
+      type: "mc",
+      question: "**Markov's inequality** states that for a non-negative random variable $X$ and $a > 0$: $P(X \\geq a) \\leq \\frac{\\mathbb{E}[X]}{a}$. This bound is:",
+      options: [
+        "Tight for all distributions",
+        "Very loose in general (it only uses the mean), but important because it requires minimal assumptions — just non-negativity",
+        "Only valid for Gaussian distributions",
+        "Tighter than Chebyshev's inequality"
+      ],
+      correct: 1,
+      explanation: "Markov's inequality is the weakest but most general bound — it only requires $X \\geq 0$ and finite mean. It's rarely used directly because it's very loose, but it's the foundation from which all stronger bounds are derived (Chebyshev applies Markov to $(X - \\mu)^2$, Chernoff applies Markov to $e^{tX}$). Its value is conceptual: it shows that heavy-tailed behavior is constrained by the mean."
+    },
+    {
+      type: "mc",
+      question: "**Chebyshev's inequality** states $P(|X - \\mu| \\geq t) \\leq \\frac{\\sigma^2}{t^2}$. For a sample mean $\\bar{X}_n$ of $n$ i.i.d. variables with variance $\\sigma^2$, what does Chebyshev give for $P(|\\bar{X}_n - \\mu| \\geq \\epsilon)$?",
+      options: [
+        "$\\frac{\\sigma^2}{\\epsilon^2}$ — independent of $n$",
+        "$\\frac{\\sigma^2}{n \\epsilon^2}$ — the bound tightens linearly with $n$, giving a $1/n$ convergence rate",
+        "$\\frac{\\sigma}{\\sqrt{n} \\epsilon}$",
+        "$e^{-n\\epsilon^2 / 2\\sigma^2}$"
+      ],
+      correct: 1,
+      explanation: "$\\text{Var}(\\bar{X}_n) = \\sigma^2/n$, so Chebyshev gives $P(|\\bar{X}_n - \\mu| \\geq \\epsilon) \\leq \\sigma^2 / (n\\epsilon^2)$. This is a **polynomial** (not exponential) bound in $n$. To get $P \\leq \\delta$, you need $n \\geq \\sigma^2 / (\\epsilon^2 \\delta)$ — which can be impractically large. This motivates sub-Gaussian bounds that give exponential concentration."
+    },
+    {
+      type: "mc",
+      question: "**Hoeffding's inequality** for i.i.d. bounded random variables $X_i \\in [a, b]$ states $P(|\\bar{X}_n - \\mu| \\geq t) \\leq 2\\exp\\left(-\\frac{2nt^2}{(b-a)^2}\\right)$. Compared to Chebyshev, this gives:",
+      options: [
+        "A weaker bound that uses more assumptions",
+        "An **exponentially** decreasing tail bound in $n$ (vs. polynomial for Chebyshev) — the price is requiring bounded variables",
+        "The same rate but with a better constant",
+        "A bound that doesn't depend on the range $[a, b]$"
+      ],
+      correct: 1,
+      explanation: "Hoeffding gives $e^{-\\Theta(n)}$ decay vs. Chebyshev's $1/n$ decay. To achieve failure probability $\\delta$, Hoeffding needs $n = O(\\log(1/\\delta) / t^2)$ samples — logarithmic in $1/\\delta$ vs. Chebyshev's linear $O(1/\\delta)$. This exponential concentration is crucial in practice: it means evaluation metrics converge quickly and generalization bounds are meaningful."
+    },
+    {
+      type: "mc",
+      question: "A random variable $X$ is **sub-Gaussian** with parameter $\\sigma$ if $\\mathbb{E}[e^{t(X - \\mu)}] \\leq e^{\\sigma^2 t^2 / 2}$ for all $t$. Why is the sub-Gaussian property important in deep learning?",
+      options: [
+        "All neural network weights are sub-Gaussian",
+        "It implies exponential tail concentration $P(|X - \\mu| \\geq t) \\leq 2e^{-t^2/(2\\sigma^2)}$, which applies to bounded random variables, Gaussian variables, and sums thereof — covering most quantities we care about in training and evaluation",
+        "It guarantees convergence of SGD",
+        "It means the distribution is exactly Gaussian"
+      ],
+      correct: 1,
+      explanation: "Sub-Gaussianity is a tail condition: the tails decay at least as fast as a Gaussian with variance $\\sigma^2$. Bounded variables ($[a,b]$) are sub-Gaussian with $\\sigma = (b-a)/2$, and sums of sub-Gaussians are sub-Gaussian. This covers sample means, bounded losses, and many gradient estimators. The tail bound gives sharp concentration — the foundation for PAC-Bayes bounds, uniform convergence, and confidence intervals."
+    },
+    {
+      type: "mc",
+      question: "In SGD, the gradient estimate $g = \\nabla L(x_i; \\theta)$ for a random mini-batch is an unbiased estimator of $\\nabla L(\\theta)$. The **variance** of this estimate relates to concentration via:",
+      options: [
+        "Higher variance means faster convergence due to exploration",
+        "Gradient variance $\\text{Var}(g)$ scales as $\\sigma^2_g / B$ for batch size $B$ — doubling batch size halves the variance but also halves the number of parameter updates per epoch",
+        "Variance is irrelevant because SGD converges regardless",
+        "Variance only matters for the final few iterations"
+      ],
+      correct: 1,
+      explanation: "The mini-batch gradient is a sample mean, so $\\text{Var}(\\bar{g}_B) = \\sigma^2_g / B$. This means larger batches give more concentrated (less noisy) gradient estimates. But the total computation is $B \\times \\text{updates}$, and doubling $B$ halves updates per epoch. The \"critical batch size\" is where further increases in $B$ no longer improve wall-clock convergence — below this, gradient noise is too high; above it, you're wasting compute on variance reduction that doesn't help."
+    },
+    {
+      type: "mc",
+      question: "**McDiarmid's inequality** generalizes Hoeffding to functions of independent variables: if changing any one input $x_i$ changes $f(x_1, \\ldots, x_n)$ by at most $c_i$, then $P(f - \\mathbb{E}[f] \\geq t) \\leq \\exp\\left(-\\frac{2t^2}{\\sum_i c_i^2}\\right)$. This is useful in ML for bounding:",
+      options: [
+        "The training loss only",
+        "The **generalization gap** — since train/test metrics are functions of i.i.d. data points, and changing one datapoint has bounded effect (bounded differences), McDiarmid gives exponential concentration of empirical risk around its expectation",
+        "The norm of the weight matrix",
+        "The number of epochs needed"
+      ],
+      correct: 1,
+      explanation: "The empirical risk $\\hat{R} = \\frac{1}{n} \\sum_i L(f(x_i), y_i)$ is a function of $n$ i.i.d. data points. Changing one point changes $\\hat{R}$ by at most $c_i = M/n$ (if the loss is bounded by $M$). McDiarmid gives $P(|\\hat{R} - R| \\geq t) \\leq 2e^{-2nt^2/M^2}$. This is a key ingredient in VC theory and PAC learning bounds."
+    },
+    {
+      type: "mc",
+      question: "The **Chernoff bound** technique optimizes over the parameter in the moment generating function: $P(X \\geq a) \\leq \\min_{t > 0} e^{-ta} \\mathbb{E}[e^{tX}]$. This gives the **tightest exponential bound** because:",
+      options: [
+        "It uses all moments of the distribution simultaneously (through the MGF), not just the mean or variance — the optimization over $t$ selects the tightest exponential rate for each specific tail probability",
+        "It only requires the mean",
+        "It works for any distribution including heavy-tailed ones",
+        "It is always tighter than the exact probability"
+      ],
+      correct: 0,
+      explanation: "The Chernoff method applies Markov's inequality to $e^{tX}$ for any $t > 0$, then optimizes over $t$. Since $\\mathbb{E}[e^{tX}]$ encodes all moments (via Taylor expansion: $\\sum_k t^k \\mathbb{E}[X^k]/k!$), the optimization over $t$ extracts the best exponential bound the moment information can provide. For sub-Gaussian and sub-exponential variables, this gives sharp rates. It fails for truly heavy-tailed distributions where the MGF doesn't exist."
+    },
+    {
+      type: "mc",
+      question: "When evaluating an LLM on a benchmark with $n = 1000$ binary-scored questions, your model gets 72% accuracy. Using Hoeffding's inequality, a 95% confidence interval ($\\delta = 0.05$) for the true accuracy is approximately:",
+      options: [
+        "$72\\% \\pm 0.1\\%$ — very precise with 1000 samples",
+        "$72\\% \\pm 2.7\\%$ — from $\\epsilon = \\sqrt{\\frac{\\log(2/\\delta)}{2n}} \\approx 0.027$ for bounded $[0,1]$ variables",
+        "$72\\% \\pm 10\\%$ — 1000 samples is not enough",
+        "$72\\% \\pm 1.4\\%$ — using the normal approximation"
+      ],
+      correct: 1,
+      explanation: "Hoeffding gives $P(|\\hat{p} - p| \\geq \\epsilon) \\leq 2e^{-2n\\epsilon^2}$. Setting $2e^{-2(1000)\\epsilon^2} = 0.05$ gives $\\epsilon = \\sqrt{\\log(40)/2000} \\approx 0.043$, so about $\\pm 4.3\\%$. The tighter Clopper-Pearson or normal approximation ($\\pm 1.96\\sqrt{p(1-p)/n} \\approx \\pm 2.8\\%$) gives a narrower interval. The point: even 1000 samples leave meaningful uncertainty in benchmark scores, which is why comparing models that differ by 1-2% is statistically dubious."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-divergences.js
+++ b/src/modules/prob-assessment-divergences.js
@@ -1,0 +1,127 @@
+// Assessment: KL Divergence & Divergence Measures
+// Section 0.2: Diagnostic test — KL divergence, f-divergences, JS, Hellinger, Rényi
+// Pure assessment to gauge depth of understanding
+
+export const divergencesAssessment = {
+  id: "0.2-assess-divergences",
+  sectionId: "0.2",
+  title: "Assessment: KL Divergence & Divergence Measures",
+  difficulty: "medium",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: KL Divergence & Divergence Measures",
+      content: "This is a **diagnostic assessment** covering KL divergence, f-divergences, and related distance measures between distributions.\n\nThese measures are central to LLM training (cross-entropy = forward KL), RLHF (KL penalties), GANs (Jensen-Shannon), and evaluation (distributional comparison).\n\nIf you score below 70%, review these topics carefully — they appear everywhere in modern ML."
+    },
+    {
+      type: "mc",
+      question: "The KL divergence $\\text{KL}(P \\| Q) = \\mathbb{E}_P\\left[\\log \\frac{P(x)}{Q(x)}\\right]$ is NOT a true metric because:",
+      options: [
+        "It can be negative",
+        "It is asymmetric ($\\text{KL}(P\\|Q) \\neq \\text{KL}(Q\\|P)$) and does not satisfy the triangle inequality",
+        "It is always infinite",
+        "It is only defined for Gaussian distributions"
+      ],
+      correct: 1,
+      explanation: "KL divergence fails two metric properties: (1) asymmetry — $\\text{KL}(P \\| Q) \\neq \\text{KL}(Q \\| P)$ in general, and (2) no triangle inequality. It IS non-negative ($\\text{KL} \\geq 0$ by Gibbs' inequality) and equals zero iff $P = Q$. Despite not being a metric, it's the natural measure arising from likelihood-based training."
+    },
+    {
+      type: "mc",
+      question: "In RLHF, the objective is $\\max_\\pi \\mathbb{E}_{\\pi}[r(x)] - \\beta \\, \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$. The KL term $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is **forward KL** from $\\pi$ to $\\pi_{\\text{ref}}$. What behavior does this penalty enforce?",
+      options: [
+        "It forces $\\pi$ to match a single mode of $\\pi_{\\text{ref}}$",
+        "Wherever $\\pi$ places probability mass, $\\pi_{\\text{ref}}$ must also have mass — preventing $\\pi$ from generating text that $\\pi_{\\text{ref}}$ considers highly unlikely",
+        "It ensures $\\pi_{\\text{ref}}$ covers all modes of $\\pi$",
+        "It minimizes the entropy of $\\pi$"
+      ],
+      correct: 1,
+      explanation: "$\\text{KL}(\\pi \\| \\pi_{\\text{ref}}) = \\mathbb{E}_\\pi[\\log \\pi / \\pi_{\\text{ref}}]$ — the expectation is under $\\pi$. If $\\pi(x) > 0$ but $\\pi_{\\text{ref}}(x) \\approx 0$, the ratio explodes. So $\\pi$ is penalized for putting mass where the reference doesn't. This prevents \"reward hacking\" — generating text that scores high reward but is completely unlike natural text."
+    },
+    {
+      type: "mc",
+      question: "The **Jensen-Shannon divergence** $\\text{JS}(P \\| Q) = \\frac{1}{2}\\text{KL}(P \\| M) + \\frac{1}{2}\\text{KL}(Q \\| M)$ where $M = \\frac{1}{2}(P + Q)$ has which advantages over KL?",
+      options: [
+        "It is always larger than KL divergence",
+        "It is symmetric, bounded ($0 \\leq \\text{JS} \\leq \\log 2$), and well-defined even when supports don't fully overlap",
+        "It is easier to compute than KL",
+        "It converges faster during training"
+      ],
+      correct: 1,
+      explanation: "JS divergence is symmetric ($\\text{JS}(P\\|Q) = \\text{JS}(Q\\|P)$), bounded by $\\log 2$, and always finite even when $P$ and $Q$ have disjoint support (because $M$ covers both). Its square root is a true metric. The original GAN objective minimizes JS divergence, but the bounded/finite property actually causes problems (vanishing gradients when $P$ and $Q$ are far apart)."
+    },
+    {
+      type: "mc",
+      question: "**Reverse KL** $\\text{KL}(Q \\| P)$ is called \"mode-seeking\" because when fitting $Q$ to a multimodal $P$:",
+      options: [
+        "$Q$ covers all modes of $P$ uniformly",
+        "$Q$ tends to concentrate on a single mode of $P$, fitting it precisely while ignoring others",
+        "$Q$ places mass only between modes",
+        "$Q$ becomes uniform regardless of $P$"
+      ],
+      correct: 1,
+      explanation: "In reverse KL, the expectation is under $Q$: $\\mathbb{E}_Q[\\log Q/P]$. If $Q$ places mass where $P(x) \\approx 0$, $\\log(Q/P) \\to \\infty$, so $Q$ avoids regions where $P$ is small. But $Q$ pays no penalty for *ignoring* modes of $P$ (since it doesn't sample there). So $Q$ \"seeks\" a single mode and fits it tightly. This is the behavior of variational inference with reverse KL."
+    },
+    {
+      type: "mc",
+      question: "The **Rényi divergence** of order $\\alpha$ is $D_\\alpha(P \\| Q) = \\frac{1}{\\alpha - 1} \\log \\mathbb{E}_Q\\left[\\left(\\frac{P(x)}{Q(x)}\\right)^\\alpha\\right]$. As $\\alpha \\to 1$, it converges to:",
+      options: [
+        "The total variation distance",
+        "The KL divergence $\\text{KL}(P \\| Q)$",
+        "The Hellinger distance",
+        "Zero for all distributions"
+      ],
+      correct: 1,
+      explanation: "Rényi divergence is a one-parameter family that includes KL as a special case at $\\alpha \\to 1$ (by L'Hôpital's rule). At $\\alpha = 1/2$ it relates to the Hellinger distance, and at $\\alpha \\to \\infty$ it becomes the max-divergence $\\log \\max_x P(x)/Q(x)$. Different $\\alpha$ values weight tail behavior differently, making Rényi divergences useful for robust training objectives."
+    },
+    {
+      type: "mc",
+      question: "The **total variation distance** $\\text{TV}(P, Q) = \\frac{1}{2} \\sum_x |P(x) - Q(x)|$ relates to KL divergence through **Pinsker's inequality**:",
+      options: [
+        "$\\text{TV}(P, Q) \\leq \\text{KL}(P \\| Q)$",
+        "$\\text{TV}(P, Q) \\leq \\sqrt{\\frac{1}{2} \\text{KL}(P \\| Q)}$",
+        "$\\text{KL}(P \\| Q) \\leq \\text{TV}(P, Q)$",
+        "$\\text{TV}(P, Q) = \\text{KL}(P \\| Q)$ always"
+      ],
+      correct: 1,
+      explanation: "Pinsker's inequality: $\\text{TV}(P, Q) \\leq \\sqrt{\\frac{1}{2} \\text{KL}(P \\| Q)}$. This means small KL implies small TV, but not vice versa — TV can be small while KL is large (when the ratio $P/Q$ is extreme in regions with small mass). This inequality is fundamental in PAC-Bayes bounds and differential privacy proofs."
+    },
+    {
+      type: "mc",
+      question: "When two distributions $P$ and $Q$ have **disjoint supports** (no overlap), what happens to KL divergence, JS divergence, and total variation?",
+      options: [
+        "All three are zero",
+        "KL is undefined ($\\infty$), JS = $\\log 2$ (finite), TV = 1 (maximum)",
+        "All three are infinite",
+        "KL is finite, JS is infinite, TV = 0"
+      ],
+      correct: 1,
+      explanation: "With disjoint supports: KL is $+\\infty$ (dividing by zero in the log-ratio), JS is $\\log 2$ (its maximum, finite value), and TV is 1 (its maximum). This is why JS is preferred in some contexts — it gracefully handles non-overlapping distributions. However, this bounded behavior means JS gradients vanish when distributions are far apart, which was the original GAN training problem solved by Wasserstein distance."
+    },
+    {
+      type: "mc",
+      question: "The **f-divergence** framework defines $D_f(P \\| Q) = \\mathbb{E}_Q[f(P(x)/Q(x))]$ for convex $f$ with $f(1) = 0$. The **variational representation** $D_f(P \\| Q) = \\sup_T \\{\\mathbb{E}_P[T(x)] - \\mathbb{E}_Q[f^*(T(x))]\\}$ (where $f^*$ is the Fenchel conjugate) is important because:",
+      options: [
+        "It allows exact computation of any f-divergence",
+        "It converts divergence estimation into an optimization problem that a neural network (discriminator/critic) can solve — this is the foundation of f-GANs",
+        "It proves all f-divergences are equal",
+        "It eliminates the need for density ratio estimation"
+      ],
+      correct: 1,
+      explanation: "The variational representation turns f-divergence computation into a supremum over functions $T$ — which a neural network can approximate. The original GAN uses this for JS divergence (where $T$ is the discriminator), and f-GANs generalize this to arbitrary f-divergences. This is a powerful trick: you never need to know the density ratio explicitly; instead, you train a network to estimate it."
+    },
+    {
+      type: "mc",
+      question: "In DPO (Direct Preference Optimization), the loss involves $\\log \\frac{\\pi_\\theta(y_w \\mid x)}{\\pi_{\\text{ref}}(y_w \\mid x)} - \\log \\frac{\\pi_\\theta(y_l \\mid x)}{\\pi_{\\text{ref}}(y_l \\mid x)}$ where $y_w$ is preferred over $y_l$. The log-ratios $\\log \\frac{\\pi_\\theta}{\\pi_{\\text{ref}}}$ are called **implicit rewards**. This formulation implicitly uses which divergence concept?",
+      options: [
+        "The density ratio $\\pi_\\theta / \\pi_{\\text{ref}}$ that appears in KL divergence — DPO reparameterizes the RLHF objective's KL-constrained optimization into a supervised loss using the closed-form solution involving log-ratios",
+        "Jensen-Shannon divergence between preferred and dispreferred completions",
+        "Total variation distance between old and new policies",
+        "Wasserstein distance in token space"
+      ],
+      correct: 0,
+      explanation: "DPO derives from the RLHF objective $\\max_\\pi \\mathbb{E}[r(x)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, whose closed-form solution is $\\pi^*(y \\mid x) \\propto \\pi_{\\text{ref}}(y \\mid x) \\exp(r(y,x)/\\beta)$. Rearranging gives $r(y,x) = \\beta \\log \\frac{\\pi^*(y \\mid x)}{\\pi_{\\text{ref}}(y \\mid x)} + \\text{const}$. DPO substitutes this into the Bradley-Terry preference model, yielding a supervised loss that implicitly optimizes the KL-constrained objective."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-entropy.js
+++ b/src/modules/prob-assessment-entropy.js
@@ -1,0 +1,127 @@
+// Assessment: Entropy, Cross-Entropy & Mutual Information
+// Section 0.2: Diagnostic test — core information-theoretic quantities
+// Pure assessment to gauge depth of understanding
+
+export const entropyAssessment = {
+  id: "0.2-assess-entropy",
+  sectionId: "0.2",
+  title: "Assessment: Entropy, Cross-Entropy & Mutual Information",
+  difficulty: "easy",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Entropy, Cross-Entropy & Mutual Information",
+      content: "This is a **diagnostic assessment** covering the core information-theoretic quantities that underpin LLM training and evaluation.\n\nEntropy, cross-entropy, and mutual information are not just abstract concepts — they are literally the loss functions, evaluation metrics, and theoretical tools used throughout deep learning.\n\nIf you score below 70%, these topics deserve serious review."
+    },
+    {
+      type: "mc",
+      question: "The **entropy** $H(X) = -\\sum_x p(x) \\log p(x)$ of a discrete random variable is maximized when:",
+      options: [
+        "The distribution is concentrated on a single outcome (deterministic)",
+        "The distribution is uniform over all outcomes",
+        "The distribution is Gaussian",
+        "The distribution has the largest possible support"
+      ],
+      correct: 1,
+      explanation: "For a discrete variable with $K$ outcomes, entropy is maximized at $H = \\log K$ when $p(x) = 1/K$ (uniform). Any deviation from uniform reduces entropy. Intuitively, entropy measures uncertainty — maximum uncertainty means every outcome is equally likely. This is why temperature scaling in LLMs (which pushes the distribution toward uniform) increases entropy and diversity of outputs."
+    },
+    {
+      type: "mc",
+      question: "The **cross-entropy** $H(P, Q) = -\\mathbb{E}_P[\\log Q(x)]$ between the data distribution $P$ and model $Q$ relates to KL divergence and entropy as:",
+      options: [
+        "$H(P, Q) = H(P) - \\text{KL}(P \\| Q)$",
+        "$H(P, Q) = H(P) + \\text{KL}(P \\| Q)$",
+        "$H(P, Q) = \\text{KL}(P \\| Q) - H(P)$",
+        "$H(P, Q) = H(Q) + \\text{KL}(Q \\| P)$"
+      ],
+      correct: 1,
+      explanation: "$H(P, Q) = H(P) + \\text{KL}(P \\| Q)$. Since $H(P)$ is fixed (it depends only on the data), minimizing cross-entropy is equivalent to minimizing $\\text{KL}(P \\| Q)$. This is why cross-entropy loss works — it drives the model $Q$ toward the data distribution $P$ in the KL sense."
+    },
+    {
+      type: "mc",
+      question: "**Perplexity** of a language model on data $P$ is defined as $\\text{PPL} = 2^{H(P,Q)}$ (or $e^{H(P,Q)}$ in nats). A model with perplexity 50 on a vocabulary of 50,000 tokens means:",
+      options: [
+        "The model gets 50% of predictions correct",
+        "On average, the model is as uncertain as choosing uniformly among 50 equally likely tokens at each step",
+        "The model uses 50 bits per token",
+        "The vocabulary can be reduced to 50 tokens without loss"
+      ],
+      correct: 1,
+      explanation: "Perplexity is the exponential of cross-entropy. A perplexity of 50 means the model's uncertainty is equivalent to choosing uniformly from 50 options. Lower perplexity = more confident = better model. A uniform model over 50K tokens would have perplexity 50,000. Getting from 50,000 to 50 represents learning enormous amounts of structure."
+    },
+    {
+      type: "mc",
+      question: "The **mutual information** $I(X; Y) = H(X) - H(X \\mid Y)$ measures the reduction in uncertainty about $X$ after observing $Y$. Which of the following is TRUE?",
+      options: [
+        "$I(X; Y)$ can be negative when $Y$ adds confusion about $X$",
+        "$I(X; Y) = I(Y; X)$ — it is symmetric",
+        "$I(X; Y) = H(X) + H(Y)$ always",
+        "$I(X; Y) = 0$ implies $X$ and $Y$ are identically distributed"
+      ],
+      correct: 1,
+      explanation: "$I(X; Y) = H(X) - H(X \\mid Y) = H(Y) - H(Y \\mid X) = I(Y; X)$. It's symmetric, non-negative (since conditioning cannot increase entropy on average), and equals zero if and only if $X$ and $Y$ are independent. Mutual information is the key quantity in the **information bottleneck** principle and in understanding what representations learn."
+    },
+    {
+      type: "mc",
+      question: "**Conditional entropy** $H(X \\mid Y) = \\mathbb{E}_Y[H(X \\mid Y = y)]$. In the context of language modeling, $H(W_t \\mid W_{<t})$ represents:",
+      options: [
+        "The entropy of the vocabulary distribution",
+        "The average uncertainty about the next token given the context — the irreducible per-token loss for a perfect model",
+        "The probability of the most likely next token",
+        "The number of possible next tokens"
+      ],
+      correct: 1,
+      explanation: "$H(W_t \\mid W_{<t})$ is the conditional entropy of the next token given all previous tokens. For a *perfect* model $Q = P$, the cross-entropy equals $H(P) = H(W_t \\mid W_{<t})$ — this is the irreducible uncertainty. No model can beat this bound. The gap between a model's cross-entropy and this quantity is exactly $\\text{KL}(P \\| Q)$."
+    },
+    {
+      type: "mc",
+      question: "The **data processing inequality** states that for a Markov chain $X \\to Y \\to Z$, we have $I(X; Z) \\leq I(X; Y)$. What does this imply for neural network representations?",
+      options: [
+        "Deeper layers always lose information about the input",
+        "Each layer can only preserve or lose information about the input — never create new information about it",
+        "The final layer has zero mutual information with the input",
+        "All layers must have equal mutual information with the input"
+      ],
+      correct: 1,
+      explanation: "The data processing inequality says information can only be lost, never gained, through processing. If $X \\to \\text{layer}_1 \\to \\text{layer}_2$, then $I(X; \\text{layer}_2) \\leq I(X; \\text{layer}_1)$. This is the theoretical foundation of the **information bottleneck** view: good representations compress away irrelevant information while retaining information relevant to the task."
+    },
+    {
+      type: "mc",
+      question: "The **chain rule of mutual information** states $I(X; Y, Z) = I(X; Y) + I(X; Z \\mid Y)$. If a context window includes both recent tokens $Y$ and distant tokens $Z$, and $I(X; Z \\mid Y) \\approx 0$, this means:",
+      options: [
+        "Distant tokens are more important than recent tokens",
+        "Distant tokens provide no additional information about the next token beyond what recent tokens already provide",
+        "The model should ignore all context",
+        "Recent and distant tokens are independent of each other"
+      ],
+      correct: 1,
+      explanation: "$I(X; Z \\mid Y) \\approx 0$ means that once you condition on recent context $Y$, distant context $Z$ adds negligible information about next token $X$. This does NOT mean $Z$ is independent of $Y$ — just that $Z$'s predictive value is already captured by $Y$. This relates to why many practical tasks work well with limited context, and why efficient attention methods that prioritize local context can work."
+    },
+    {
+      type: "mc",
+      question: "The **entropy rate** of a stochastic process is $h = \\lim_{n \\to \\infty} \\frac{1}{n} H(X_1, \\dots, X_n)$. For English text, the entropy rate is estimated at roughly 1-1.5 bits per character. This means:",
+      options: [
+        "English text is completely random",
+        "Each character carries about 1-1.5 bits of information on average after accounting for all statistical patterns — English is highly redundant given its ~4.7-bit alphabet",
+        "You need 1-1.5 characters to encode each bit",
+        "A perfect language model would have perplexity between 1 and 1.5"
+      ],
+      correct: 1,
+      explanation: "With 26+ characters, a uniform distribution would give ~4.7 bits/char. The entropy rate of ~1.3 bits/char means English is about 72% redundant — most characters are highly predictable from context. This massive redundancy is what LLMs exploit. Shannon estimated this in 1951 using human prediction experiments. Modern LLMs approach (and perhaps reach) this bound."
+    },
+    {
+      type: "mc",
+      question: "When fine-tuning with **label smoothing** (mixing the hard target with a uniform distribution), the effective target becomes $P'(y) = (1 - \\alpha) \\cdot \\mathbf{1}[y = y^*] + \\alpha / K$. How does this affect the cross-entropy loss landscape?",
+      options: [
+        "It has no effect on training dynamics",
+        "It prevents the model from driving logits to $\\pm \\infty$ — the optimal logit gap becomes finite, acting as implicit regularization on confidence",
+        "It makes the model converge to a uniform distribution",
+        "It increases the entropy of the model to match the entropy of the smoothed labels"
+      ],
+      correct: 1,
+      explanation: "Without label smoothing, the optimal logits are $+\\infty$ for the correct class and $-\\infty$ for others. Label smoothing caps the optimal logit gap at a finite value (proportional to $\\log((1-\\alpha)K/\\alpha)$), preventing overconfident predictions. This acts as entropy regularization — the model's output entropy stays bounded away from zero, improving calibration and generalization."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-exponential-family.js
+++ b/src/modules/prob-assessment-exponential-family.js
@@ -1,0 +1,115 @@
+// Assessment: Exponential Family & Maximum Likelihood Estimation
+// Section 0.2: Diagnostic test — exponential families, sufficient statistics, MLE
+// Pure assessment to gauge whether you need deeper study
+
+export const exponentialFamilyAssessment = {
+  id: "0.2-assess-exp-family",
+  sectionId: "0.2",
+  title: "Assessment: Exponential Families & MLE",
+  difficulty: "medium",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Exponential Families & Maximum Likelihood",
+      content: "This is a **diagnostic assessment** covering exponential family distributions, sufficient statistics, and maximum likelihood estimation.\n\nThese concepts underpin why cross-entropy loss works, how softmax relates to log-linear models, and why certain parameterizations are natural for gradient-based optimization.\n\nIf you score below 70%, consider reviewing these topics before proceeding."
+    },
+    {
+      type: "mc",
+      question: "An exponential family distribution has the form $p(x \\mid \\theta) = h(x) \\exp(\\eta(\\theta)^\\top T(x) - A(\\theta))$. What role does $A(\\theta)$ (the log-partition function) play?",
+      options: [
+        "It defines the prior distribution over $\\theta$",
+        "It is a normalization constant ensuring the distribution sums/integrates to 1",
+        "It computes the mode of the distribution",
+        "It measures the divergence between the model and the true distribution"
+      ],
+      correct: 1,
+      explanation: "$A(\\theta) = \\log \\int h(x) \\exp(\\eta(\\theta)^\\top T(x))\\, dx$ is the log-partition function. It ensures normalization. Crucially, its derivatives give the moments: $\\nabla_\\eta A = \\mathbb{E}[T(x)]$ and $\\nabla^2_\\eta A = \\text{Cov}[T(x)]$. This means the log-partition function encodes everything about the distribution's moments."
+    },
+    {
+      type: "mc",
+      question: "The softmax output layer of an LLM defines a **categorical distribution** over tokens. In exponential family form, the natural parameters $\\eta_i$ correspond to:",
+      options: [
+        "The token embeddings",
+        "The logits (pre-softmax scores)",
+        "The softmax probabilities themselves",
+        "The attention weights"
+      ],
+      correct: 1,
+      explanation: "The categorical distribution in exponential family form is $P(w = i) = \\exp(\\eta_i - A(\\eta))$ where $A(\\eta) = \\log \\sum_j \\exp(\\eta_j)$ (the log-sum-exp). The logits **are** the natural parameters. This is why working in logit space (rather than probability space) is natural for optimization — gradients in the natural parameterization have nice properties."
+    },
+    {
+      type: "mc",
+      question: "A **sufficient statistic** $T(x)$ for parameter $\\theta$ means that $T(x)$ captures all information about $\\theta$ in the data. For the Gaussian $\\mathcal{N}(\\mu, \\sigma^2)$, the sufficient statistics of a sample $x_1, \\dots, x_n$ are:",
+      options: [
+        "The sample median and range",
+        "$\\sum_i x_i$ and $\\sum_i x_i^2$ (or equivalently, sample mean and sample variance)",
+        "The minimum and maximum values",
+        "All individual data points — no compression is possible"
+      ],
+      correct: 1,
+      explanation: "For the Gaussian, $T(X) = (\\sum x_i, \\sum x_i^2)$ are sufficient for $(\\mu, \\sigma^2)$. This means you can throw away the raw data and keep only these two numbers without losing any information about the parameters. For exponential families in general, the sufficient statistics are exactly the $T(x)$ appearing in the exponential family form."
+    },
+    {
+      type: "mc",
+      question: "The MLE for an exponential family distribution satisfies the **moment matching** condition. What does this mean?",
+      options: [
+        "The MLE parameters are the sample moments themselves",
+        "The model's expected sufficient statistics equal the empirical sufficient statistics: $\\mathbb{E}_{\\hat{\\theta}}[T(x)] = \\frac{1}{n}\\sum_i T(x_i)$",
+        "All moments of the model distribution must be finite",
+        "The distribution must have the same number of moments as parameters"
+      ],
+      correct: 1,
+      explanation: "Setting the gradient of the log-likelihood to zero gives $\\nabla_\\eta A(\\hat{\\eta}) = \\frac{1}{n} \\sum_i T(x_i)$. Since $\\nabla_\\eta A = \\mathbb{E}[T(x)]$, the MLE solution matches model moments to empirical moments. This is why cross-entropy training of a language model matches the model's predicted token frequencies to the training data's token frequencies."
+    },
+    {
+      type: "mc",
+      question: "Why is the **negative log-likelihood** loss function convex in the natural parameters $\\eta$ for exponential family models?",
+      options: [
+        "Because neural networks are convex models",
+        "Because $A(\\eta)$ is convex (its Hessian $\\nabla^2 A = \\text{Cov}[T(x)]$ is positive semi-definite), and the NLL is $A(\\eta) - \\eta^\\top T(x)$ which is convex in $\\eta$",
+        "Because the data is always well-conditioned",
+        "Convexity is not guaranteed — it depends on the data"
+      ],
+      correct: 1,
+      explanation: "The NLL per sample is $-\\log p(x \\mid \\eta) = A(\\eta) - \\eta^\\top T(x) + \\text{const}$. The Hessian w.r.t. $\\eta$ is $\\nabla^2 A(\\eta) = \\text{Cov}[T(x)] \\succeq 0$, which is PSD. So the NLL is convex in $\\eta$. Note: for neural networks, $\\eta$ is a nonlinear function of the weights, so the overall loss is non-convex in the weights — but the final layer (logits → loss) is convex."
+    },
+    {
+      type: "mc",
+      question: "The **Fisher information matrix** $\\mathcal{I}(\\theta) = \\mathbb{E}\\left[\\nabla \\log p(x \\mid \\theta) \\nabla \\log p(x \\mid \\theta)^\\top\\right]$ plays what role in MLE?",
+      options: [
+        "It determines the learning rate for SGD",
+        "It gives the asymptotic covariance of the MLE: $\\hat{\\theta}_{\\text{MLE}} \\sim \\mathcal{N}(\\theta, \\mathcal{I}(\\theta)^{-1}/n)$ as $n \\to \\infty$",
+        "It measures the distance between the model and the data",
+        "It equals the Hessian of the log-prior"
+      ],
+      correct: 1,
+      explanation: "The Cramér-Rao bound says no unbiased estimator can have variance lower than $\\mathcal{I}(\\theta)^{-1}/n$, and the MLE achieves this bound asymptotically. The Fisher matrix also defines the **natural gradient** $\\mathcal{I}^{-1} \\nabla \\ell$ — a direction that accounts for the geometry of the parameter space. This connects to Adam (which approximates diagonal Fisher) and to natural gradient methods in RL."
+    },
+    {
+      type: "mc",
+      question: "In practice, we train LLMs by minimizing cross-entropy on finite data. MLE is known to **overfit** without regularization. From a Bayesian perspective, L2 regularization ($\\lambda \\|\\theta\\|^2$) corresponds to:",
+      options: [
+        "A uniform prior over $\\theta$",
+        "A Gaussian prior $\\theta \\sim \\mathcal{N}(0, \\frac{1}{2\\lambda} I)$ — making the loss a MAP estimate",
+        "A Laplace prior over $\\theta$",
+        "Minimizing the Fisher information"
+      ],
+      correct: 1,
+      explanation: "Adding $\\lambda \\|\\theta\\|^2$ to the NLL gives $-\\log p(x \\mid \\theta) + \\lambda \\|\\theta\\|^2 = -\\log p(x \\mid \\theta) - \\log p(\\theta) + \\text{const}$ where $p(\\theta) \\propto \\exp(-\\lambda \\|\\theta\\|^2)$ is a Gaussian. This makes the solution a **MAP** (maximum a posteriori) estimate rather than pure MLE. L1 regularization corresponds to a Laplace prior and promotes sparsity."
+    },
+    {
+      type: "mc",
+      question: "When computing the MLE for a mixture model $p(x) = \\sum_k \\pi_k p_k(x \\mid \\theta_k)$, the log-likelihood has a log-sum that makes direct optimization hard. What standard algorithm addresses this?",
+      options: [
+        "Gradient descent on the log-likelihood directly",
+        "The EM (Expectation-Maximization) algorithm, which alternates between computing posterior cluster assignments (E-step) and updating parameters (M-step)",
+        "Gibbs sampling from the posterior",
+        "Grid search over all parameter values"
+      ],
+      correct: 1,
+      explanation: "EM handles the intractable log-sum by introducing latent variables $z$ (cluster assignments). The E-step computes $q(z) = P(z \\mid x, \\theta^{\\text{old}})$, and the M-step maximizes $\\mathbb{E}_q[\\log p(x, z \\mid \\theta)]$. Each iteration is guaranteed to increase the log-likelihood. EM is a special case of variational inference where the E-step is exact."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-foundations.js
+++ b/src/modules/prob-assessment-foundations.js
@@ -1,0 +1,127 @@
+// Assessment: Probability Foundations
+// Section 0.2: Diagnostic test — Bayes' theorem, conditional probability, distributions, expectations
+// Pure assessment (no info steps) to gauge whether you need to study these topics
+
+export const probabilityFoundationsAssessment = {
+  id: "0.2-assess-prob-foundations",
+  sectionId: "0.2",
+  title: "Assessment: Probability Foundations",
+  difficulty: "easy",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Probability Foundations",
+      content: "This is a **diagnostic assessment** — there are no teaching steps. Answer each question to gauge whether you need to study probability foundations in more depth.\n\nTopics covered: conditional probability, Bayes' theorem, common distributions, expectations, and the law of total probability.\n\nIf you score below 70%, consider reviewing these fundamentals before proceeding."
+    },
+    {
+      type: "mc",
+      question: "A language model assigns probability $P(w_t \\mid w_{<t})$ to each token. By the chain rule of probability, the joint probability of a sequence $w_1, \\dots, w_T$ is:",
+      options: [
+        "$\\sum_{t=1}^{T} P(w_t \\mid w_{<t})$",
+        "$\\prod_{t=1}^{T} P(w_t \\mid w_{<t})$",
+        "$\\frac{1}{T} \\sum_{t=1}^{T} P(w_t \\mid w_{<t})$",
+        "$\\max_{t} P(w_t \\mid w_{<t})$"
+      ],
+      correct: 1,
+      explanation: "The chain rule of probability says $P(w_1, \\dots, w_T) = \\prod_{t=1}^{T} P(w_t \\mid w_1, \\dots, w_{t-1})$. This is the foundational factorization that autoregressive language models exploit — they model each conditional factor in the product."
+    },
+    {
+      type: "mc",
+      question: "You have a classifier with 95% true positive rate ($P(\\text{pos} \\mid \\text{spam}) = 0.95$) and 3% false positive rate ($P(\\text{pos} \\mid \\text{ham}) = 0.03$). If only 1% of emails are spam ($P(\\text{spam}) = 0.01$), what is $P(\\text{spam} \\mid \\text{pos})$ approximately?",
+      options: [
+        "About 95% — the classifier is very accurate",
+        "About 50% — it's a coin flip",
+        "About 24% — the low base rate dominates",
+        "About 1% — the prior barely changes"
+      ],
+      correct: 2,
+      explanation: "By Bayes' theorem: $P(\\text{spam} \\mid \\text{pos}) = \\frac{0.95 \\times 0.01}{0.95 \\times 0.01 + 0.03 \\times 0.99} = \\frac{0.0095}{0.0095 + 0.0297} \\approx 0.242$. This is the base rate fallacy — even with a good classifier, a low prior dramatically reduces the posterior. This is critical intuition for understanding how priors interact with likelihoods."
+    },
+    {
+      type: "mc",
+      question: "Which property distinguishes the **Gaussian distribution** from other distributions, making it appear so frequently in machine learning?",
+      options: [
+        "It is the only distribution with finite variance",
+        "Among all distributions with a given mean and variance, it maximizes entropy",
+        "It is the only continuous distribution that is also an exponential family member",
+        "It is the only distribution closed under multiplication"
+      ],
+      correct: 1,
+      explanation: "The Gaussian is the **maximum entropy distribution** for a given mean and variance. This means it makes the fewest assumptions beyond those two constraints. This is why Gaussian assumptions appear everywhere — they're the most \"uninformative\" choice given first and second moments. The central limit theorem reinforces this: sums of many independent variables converge to Gaussian regardless of individual distributions."
+    },
+    {
+      type: "mc",
+      question: "In a language model's output layer, the **softmax** function converts logits $z_i$ to probabilities. Which distribution does this define over the vocabulary?",
+      options: [
+        "A Bernoulli distribution",
+        "A multinomial (categorical) distribution",
+        "A Poisson distribution",
+        "A Dirichlet distribution"
+      ],
+      correct: 1,
+      explanation: "Softmax produces a **categorical distribution** over the vocabulary: $P(w = i) = \\frac{e^{z_i}}{\\sum_j e^{z_j}}$. Each token gets a probability, probabilities sum to 1, and we sample one token. When we sample multiple tokens with replacement, the counts follow a multinomial. The Dirichlet would be a distribution *over* such probability vectors, not a single draw."
+    },
+    {
+      type: "mc",
+      question: "The **law of total expectation** states $\\mathbb{E}[X] = \\mathbb{E}[\\mathbb{E}[X \\mid Y]]$. In the context of language modeling, if $X$ is the log-probability of a sequence and $Y$ is the topic, this means:",
+      options: [
+        "The overall log-probability equals the best topic-conditional log-probability",
+        "The overall expected log-probability is the topic-weighted average of per-topic expected log-probabilities",
+        "The log-probability is independent of the topic",
+        "You must know the topic to compute the log-probability"
+      ],
+      correct: 1,
+      explanation: "The law of total expectation says you can decompose an unconditional expectation by first conditioning on $Y$, computing the conditional expectation, then averaging over $Y$. Here: $\\mathbb{E}[\\log P] = \\sum_{\\text{topic}} P(\\text{topic}) \\cdot \\mathbb{E}[\\log P \\mid \\text{topic}]$. This is fundamental to understanding mixture models and how perplexity varies across data subsets."
+    },
+    {
+      type: "mc",
+      question: "Random variables $X$ and $Y$ are **independent** if and only if:",
+      options: [
+        "$\\mathbb{E}[XY] = 0$",
+        "$P(X, Y) = P(X) \\cdot P(Y)$ for all values",
+        "$\\text{Cov}(X, Y) = 0$",
+        "$P(X \\mid Y) > P(X)$ for all values"
+      ],
+      correct: 1,
+      explanation: "Independence means the joint factorizes: $P(X, Y) = P(X) P(Y)$. This is stronger than zero covariance — uncorrelated variables can still be dependent (e.g., $X \\sim \\text{Uniform}(-1,1)$ and $Y = X^2$ have $\\text{Cov}(X,Y) = 0$ but are clearly dependent). In LLMs, tokens are NOT independent — the whole point of the model is to capture dependencies."
+    },
+    {
+      type: "mc",
+      question: "The **law of total probability** says $P(A) = \\sum_i P(A \\mid B_i) P(B_i)$ for a partition $\\{B_i\\}$. When marginalizing over latent variable $z$ in a latent variable model, we compute:",
+      options: [
+        "$P(x) = \\max_z P(x \\mid z) P(z)$",
+        "$P(x) = \\sum_z P(x \\mid z) P(z)$ (or $\\int$ for continuous $z$)",
+        "$P(x) = P(x \\mid z^*) $ where $z^* = \\arg\\max P(z)$",
+        "$P(x) = \\sum_z P(z \\mid x) P(x)$"
+      ],
+      correct: 1,
+      explanation: "Marginalization is exactly the law of total probability applied to a latent variable: $P(x) = \\sum_z P(x, z) = \\sum_z P(x \\mid z) P(z)$. This integral is often intractable, which is why we need variational inference (ELBO) or sampling methods. The max version gives the MAP estimate, not the marginal."
+    },
+    {
+      type: "mc",
+      question: "For a discrete random variable $X$ with PMF $p(x)$, the **variance** $\\text{Var}(X)$ can be computed as:",
+      options: [
+        "$\\mathbb{E}[X]^2 - \\mathbb{E}[X^2]$",
+        "$\\mathbb{E}[X^2] - \\mathbb{E}[X]^2$",
+        "$\\mathbb{E}[|X - \\mathbb{E}[X]|]$",
+        "$\\sqrt{\\mathbb{E}[(X - \\mathbb{E}[X])^2]}$"
+      ],
+      correct: 1,
+      explanation: "$\\text{Var}(X) = \\mathbb{E}[X^2] - (\\mathbb{E}[X])^2$. This is the \"raw second moment minus squared first moment\" identity, essential for deriving variance of estimators, understanding gradient variance in SGD, and computing variance of importance weights in off-policy RL."
+    },
+    {
+      type: "mc",
+      question: "A token $w$ is drawn from a categorical distribution with probabilities $p_1 = 0.5, p_2 = 0.3, p_3 = 0.2$. What is $\\mathbb{E}[-\\log_2 p(w)]$, the expected number of bits needed to encode this draw?",
+      options: [
+        "$-\\log_2(0.5) = 1$ bit",
+        "$0.5 \\cdot 1 + 0.3 \\cdot \\log_2(10/3) + 0.2 \\cdot \\log_2(5) \\approx 1.49$ bits",
+        "$\\log_2(3) \\approx 1.58$ bits",
+        "$3$ bits"
+      ],
+      correct: 1,
+      explanation: "This is the **entropy** $H(W) = -\\sum_i p_i \\log_2 p_i = 0.5(1) + 0.3(1.737) + 0.2(2.322) \\approx 1.49$ bits. It's less than $\\log_2(3) \\approx 1.58$ (the uniform case) because the distribution is non-uniform. Entropy is maximized when all outcomes are equally likely."
+    }
+  ]
+};

--- a/src/modules/prob-assessment-sampling.js
+++ b/src/modules/prob-assessment-sampling.js
@@ -1,0 +1,127 @@
+// Assessment: Sampling Methods & Monte Carlo
+// Section 0.2: Diagnostic test — importance sampling, MCMC, rejection sampling
+// Pure assessment to gauge depth of understanding
+
+export const samplingAssessment = {
+  id: "0.2-assess-sampling",
+  sectionId: "0.2",
+  title: "Assessment: Sampling Methods & Monte Carlo",
+  difficulty: "medium",
+  estimatedMinutes: 12,
+  assessmentOnly: true,
+  steps: [
+    {
+      type: "info",
+      title: "Diagnostic: Sampling Methods & Monte Carlo",
+      content: "This is a **diagnostic assessment** covering sampling and Monte Carlo methods.\n\nThese methods appear everywhere in LLMs: token sampling strategies (top-k, nucleus), importance sampling in off-policy RL, MCMC for Bayesian approaches, and Monte Carlo estimation of intractable expectations.\n\nIf you score below 70%, review these foundations — they're essential for understanding generation and training."
+    },
+    {
+      type: "mc",
+      question: "**Monte Carlo estimation** approximates $\\mathbb{E}_P[f(x)] \\approx \\frac{1}{N} \\sum_{i=1}^N f(x_i)$ where $x_i \\sim P$. The variance of this estimator decreases as:",
+      options: [
+        "$O(1/N^2)$",
+        "$O(1/N)$ — halving the variance requires doubling the samples, regardless of dimension",
+        "$O(1/\\sqrt{N})$",
+        "$O(e^{-N})$ — exponentially fast"
+      ],
+      correct: 1,
+      explanation: "By the CLT, the variance of the sample mean is $\\text{Var}[f(X)] / N$, so it decreases as $O(1/N)$. The standard error decreases as $O(1/\\sqrt{N})$. Crucially, this rate is **dimension-independent** — this is why Monte Carlo methods scale to high dimensions where grid-based methods fail exponentially. This $O(1/N)$ rate drives many design choices in how many samples to use."
+    },
+    {
+      type: "mc",
+      question: "**Importance sampling** estimates $\\mathbb{E}_P[f(x)]$ using samples from a different distribution $Q$ via $\\mathbb{E}_P[f(x)] = \\mathbb{E}_Q\\left[f(x) \\frac{P(x)}{Q(x)}\\right]$. The ratio $w(x) = P(x)/Q(x)$ is called the importance weight. When can this go badly wrong?",
+      options: [
+        "When $P$ and $Q$ are identical distributions",
+        "When $Q$ has lighter tails than $P$ — the weights $P(x)/Q(x)$ can become enormous in the tails, causing high variance and unstable estimates",
+        "When $f(x)$ is a constant function",
+        "When $N$ is very large"
+      ],
+      correct: 1,
+      explanation: "If $Q$ has lighter tails than $P$, then in regions where $P(x) \\gg Q(x)$, the weight $P(x)/Q(x)$ explodes. A few samples may dominate the entire estimate, giving high variance. This is the \"weight degeneracy\" problem. In off-policy RL, this manifests when the learned policy differs significantly from the behavior policy — importance weights become degenerate, which is why PPO clips them."
+    },
+    {
+      type: "mc",
+      question: "In **PPO** (Proximal Policy Optimization), the clipped surrogate objective involves $\\min\\left(r_t(\\theta) A_t, \\, \\text{clip}(r_t(\\theta), 1-\\epsilon, 1+\\epsilon) A_t\\right)$ where $r_t = \\frac{\\pi_\\theta(a_t|s_t)}{\\pi_{\\theta_{\\text{old}}}(a_t|s_t)}$ is an importance weight. The clipping addresses:",
+      options: [
+        "Numerical overflow in the softmax",
+        "The high-variance problem of importance sampling — by preventing the policy ratio from deviating too far, it bounds the variance of the policy gradient estimate",
+        "The mode-seeking behavior of reverse KL",
+        "The computational cost of computing the ratio"
+      ],
+      correct: 1,
+      explanation: "Without clipping, if $\\pi_\\theta$ diverges far from $\\pi_{\\theta_{\\text{old}}}$, the importance ratio $r_t$ can become very large, causing destructively large policy updates. Clipping $r_t$ to $[1-\\epsilon, 1+\\epsilon]$ bounds the effective step size, keeping the new policy close to the old. This is a practical solution to the importance sampling variance problem, complementary to the KL penalty approach in earlier TRPO."
+    },
+    {
+      type: "mc",
+      question: "**Top-k sampling** from an LLM restricts sampling to the $k$ highest-probability tokens and redistributes probability mass. From a sampling theory perspective, this is equivalent to:",
+      options: [
+        "Importance sampling with a uniform proposal",
+        "Sampling from a truncated version of the original distribution — renormalizing the top-k probabilities",
+        "Rejection sampling where we reject low-probability tokens",
+        "Gibbs sampling over the vocabulary"
+      ],
+      correct: 1,
+      explanation: "Top-k sets $P(w) = 0$ for all tokens outside the top $k$, then renormalizes: $P'(w) = P(w) / \\sum_{w' \\in \\text{top-k}} P(w')$ for $w \\in \\text{top-k}$. This is distribution truncation. Nucleus (top-p) sampling is similar but adaptive — it truncates at the smallest set whose cumulative probability exceeds $p$, making it more robust to varying entropy across positions."
+    },
+    {
+      type: "mc",
+      question: "**MCMC** (Markov Chain Monte Carlo) methods construct a Markov chain whose stationary distribution is the target $P$. The **Metropolis-Hastings** acceptance probability $\\alpha = \\min\\left(1, \\frac{P(x') Q(x|x')}{P(x) Q(x'|x)}\\right)$ ensures:",
+      options: [
+        "That the chain converges in finite time",
+        "**Detailed balance**: the chain is reversible with respect to $P$, guaranteeing $P$ is the stationary distribution",
+        "That all states are visited equally often",
+        "That the proposal $Q$ matches $P$ exactly"
+      ],
+      correct: 1,
+      explanation: "The acceptance ratio enforces detailed balance: $P(x) T(x'|x) = P(x') T(x|x')$ where $T$ is the transition kernel. Detailed balance implies $P$ is stationary (but is stronger — it also implies reversibility). Note that we only need the ratio $P(x')/P(x)$, so we don't need to know the normalizing constant of $P$ — this is why MCMC works for Bayesian posteriors where the evidence is intractable."
+    },
+    {
+      type: "mc",
+      question: "The **Gumbel-max trick** provides exact samples from a categorical distribution: $\\arg\\max_i (\\log p_i + G_i)$ where $G_i \\sim \\text{Gumbel}(0, 1)$ are i.i.d. The **Gumbel-Softmax** relaxation replaces argmax with softmax to make this:",
+      options: [
+        "More numerically stable",
+        "Differentiable — enabling gradient-based optimization through discrete sampling operations using a continuous relaxation with temperature $\\tau$",
+        "Faster to compute",
+        "Exact rather than approximate"
+      ],
+      correct: 1,
+      explanation: "The argmax is non-differentiable, blocking backpropagation. Gumbel-Softmax replaces it with $\\text{softmax}((\\log p_i + G_i)/\\tau)$, which is differentiable and approaches a one-hot vector as $\\tau \\to 0$. This enables end-to-end training of models with discrete choices (e.g., hard attention, discrete latent variables). The temperature $\\tau$ controls the bias-variance trade-off: low $\\tau$ is more accurate but higher variance."
+    },
+    {
+      type: "mc",
+      question: "When estimating $\\mathbb{E}_P[f(x)]$ with MCMC samples, the samples are **correlated** (not i.i.d.). The **effective sample size** (ESS) accounts for this. If you draw 10,000 MCMC samples but the ESS is 500, this means:",
+      options: [
+        "9,500 samples should be discarded as burn-in",
+        "The correlated chain provides the same statistical power as 500 independent samples — autocorrelation has reduced the information content by 20×",
+        "The chain has not converged",
+        "You need exactly 500 more samples"
+      ],
+      correct: 1,
+      explanation: "ESS = $N / (1 + 2\\sum_{k=1}^\\infty \\rho_k)$ where $\\rho_k$ is the autocorrelation at lag $k$. High autocorrelation (slow mixing) drastically reduces ESS. An ESS of 500 from 10,000 samples means consecutive samples are highly correlated — the chain is \"exploring slowly.\" This is why mixing time and thinning (keeping every $k$-th sample) matter. In practice, ESS guides how long to run the chain."
+    },
+    {
+      type: "mc",
+      question: "**Rejection sampling** draws $x \\sim Q$, then accepts with probability $\\frac{P(x)}{M \\cdot Q(x)}$ where $M \\geq \\sup_x \\frac{P(x)}{Q(x)}$. In high dimensions, this method:",
+      options: [
+        "Becomes more efficient due to the law of large numbers",
+        "Becomes exponentially inefficient — the acceptance rate drops exponentially with dimension because $M$ must be exponentially large to bound $P/Q$ everywhere",
+        "Works exactly the same as in low dimensions",
+        "Is replaced by importance sampling, which has the same problem"
+      ],
+      correct: 1,
+      explanation: "In $d$ dimensions, the acceptance rate $1/M$ typically decays as $e^{-\\Theta(d)}$ because the proposal $Q$ must cover the tails of $P$ in all dimensions simultaneously. This is the \"curse of dimensionality\" for rejection sampling. MCMC avoids this by not requiring a global bound — it only needs local moves. This is why rejection sampling is practical only in low dimensions, while MCMC and variational methods scale to millions of parameters."
+    },
+    {
+      type: "mc",
+      question: "**Speculative decoding** uses a small draft model to generate $k$ candidate tokens, then verifies them against the large target model in parallel. The verification uses a form of:",
+      options: [
+        "Beam search with pruning",
+        "Rejection sampling — each draft token is accepted with probability $\\min(1, P_{\\text{target}}(w_t) / P_{\\text{draft}}(w_t))$, and on rejection, we resample from a corrected distribution, ensuring the final output distribution exactly matches the target model",
+        "Importance sampling with the draft model as the proposal",
+        "Gibbs sampling alternating between draft and target"
+      ],
+      correct: 1,
+      explanation: "Speculative decoding is mathematically exact: the output distribution matches what the target model would produce with standard autoregressive sampling. The trick is that acceptance probability $\\min(1, P_{\\text{target}}/P_{\\text{draft}})$ is high when the draft model is good, so most tokens are accepted without running the large model sequentially. On rejection, sampling from the residual $(P_{\\text{target}} - P_{\\text{draft}})_+$ corrects for the draft model's errors."
+    }
+  ]
+};


### PR DESCRIPTION
…ction 0.2)

Create comprehensive topic-coverage assessments to help identify knowledge gaps before diving into deep-dive teaching modules. Each assessment is purely multiple-choice (no teaching steps) with LLM-relevant questions and detailed explanations.

Assessments cover:
- Probability foundations (Bayes, distributions, expectations)
- Entropy, cross-entropy & mutual information
- Exponential families & maximum likelihood estimation
- KL divergence & divergence measures (f-divergences, JS, Rényi)
- Bayesian inference & variational methods (ELBO, VAEs, DPO derivation)
- Sampling methods & Monte Carlo (importance sampling, MCMC, speculative decoding)
- Concentration inequalities & tail bounds (Hoeffding, Chernoff, sub-Gaussian)
- Information theory in LLM practice (loss, temperature, RLHF, bits-per-byte)

Also updates section 0.2 subtopics in App.jsx to reflect expanded coverage.

https://claude.ai/code/session_01PcPPQ2p8d2ChhjbVFzanfB