### PR TITLE
Randomize quiz questions and options to prevent pattern-matching

### DIFF
--- a/src/components/ModuleView.jsx
+++ b/src/components/ModuleView.jsx
@@ -1,5 +1,6 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import MathText from './MathText';
+import { shuffleModuleSteps, getAttemptSeed, resetAttemptSeed } from '../utils/shuffle';
 
 const MODULE_PROGRESS_KEY = 'llm-curriculum-modules-v1';
 
@@ -47,6 +48,15 @@ export default function ModuleView({ module, tierColor, onClose }) {
   const accentColor = tierColor || DIFF_COLORS[module.difficulty] || '#378ADD';
   const totalSteps = module.steps.length;
 
+  // Shuffle seed — changes per attempt/session, consistent within one attempt
+  const [shuffleSeed, setShuffleSeed] = useState(() => getAttemptSeed(module.id));
+
+  // Precompute shuffled steps: randomized option order + question order (for tests)
+  const shuffledSteps = useMemo(
+    () => shuffleModuleSteps(module.steps, module.moduleType, shuffleSeed),
+    [module.steps, module.moduleType, shuffleSeed]
+  );
+
   const [step, setStep] = useState(() => {
     const p = loadProgress();
     const saved = p[module.id]?.currentStep || 0;
@@ -59,7 +69,7 @@ export default function ModuleView({ module, tierColor, onClose }) {
     return p[module.id]?.answers || {};
   });
 
-  const current = step < totalSteps ? module.steps[step] : null;
+  const current = step < totalSteps ? shuffledSteps[step] : null;
   const isComplete = step >= totalSteps;
 
   const [flaggedSteps, setFlaggedSteps] = useState(() => {
@@ -135,10 +145,10 @@ export default function ModuleView({ module, tierColor, onClose }) {
 
   if (isComplete) {
     const correct = Object.entries(answers).reduce((n, [idx, ans]) => {
-      const s = module.steps[Number(idx)];
+      const s = shuffledSteps[Number(idx)];
       return s?.type === 'mc' && ans === s.correct ? n + 1 : n;
     }, 0);
-    const totalMc = module.steps.filter(s => s.type === 'mc').length;
+    const totalMc = shuffledSteps.filter(s => s.type === 'mc').length;
     return (
       <div style={S.container}>
         <div style={S.inner}>
@@ -152,7 +162,7 @@ export default function ModuleView({ module, tierColor, onClose }) {
               {correct}/{totalMc} questions correct
             </p>
             <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
-              <button onClick={() => { setStep(0); setAnswers({}); }} style={{ ...S.btn, background: 'transparent', border: `1.5px solid ${accentColor}`, color: accentColor }}>
+              <button onClick={() => { setShuffleSeed(resetAttemptSeed(module.id)); setStep(0); setAnswers({}); }} style={{ ...S.btn, background: 'transparent', border: `1.5px solid ${accentColor}`, color: accentColor }}>
                 Retry
               </button>
               <button onClick={onClose} style={{ ...S.btn, background: accentColor }}>

--- a/src/components/WarmupView.jsx
+++ b/src/components/WarmupView.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import MathText from './MathText';
 import { MODULES } from '../modules';
 import { getModuleProgress } from './ModuleView';
+import { shuffleMcStep, createRng } from '../utils/shuffle';
 
 const WARMUP_SIZE = 10;
 
@@ -87,7 +88,14 @@ function buildWarmup() {
   const diffOrder = { easy: 0, medium: 1, hard: 2 };
   selected.sort((a, b) => (diffOrder[a.difficulty] ?? 1) - (diffOrder[b.difficulty] ?? 1));
 
-  return selected.slice(0, WARMUP_SIZE);
+  // Shuffle option order for each question so correct answers aren't always in the same position
+  const optionRng = createRng(seed + 77777);
+  const withShuffledOptions = selected.slice(0, WARMUP_SIZE).map(q => {
+    const stepSeed = Math.floor(optionRng() * 2147483646) + 1;
+    return shuffleMcStep(q, stepSeed);
+  });
+
+  return withShuffledOptions;
 }
 
 const DIFF_COLORS = { easy: '#1D9E75', medium: '#BA7517', hard: '#D85A30' };

--- a/src/modules/assess-branch-a.js
+++ b/src/modules/assess-branch-a.js
@@ -16,13 +16,8 @@ export const sftAssessment = {
     {
       type: "mc",
       question: "The LIMA paper (Zhou et al., 2023) demonstrated strong performance with only 1,000 carefully curated fine-tuning examples. What is the primary claim this supports?",
-      options: [
-        "Pretraining is unnecessary if fine-tuning data is high quality",
-        "SFT primarily *unlocks* capabilities already learned during pretraining rather than *teaching* new knowledge",
-        "1,000 examples is always the optimal dataset size for SFT",
-        "Data quality does not matter as long as the dataset is small"
-      ],
-      correct: 1,
+      options: ["SFT primarily *unlocks* capabilities already learned during pretraining rather than *teaching* new knowledge", "Pretraining is unnecessary if fine-tuning data is high quality", "1,000 examples is always the optimal dataset size for SFT", "Data quality does not matter as long as the dataset is small"],
+      correct: 0,
       explanation: "LIMA's key insight is the \"Superficial Alignment Hypothesis\": the vast majority of a model's knowledge and capabilities come from pretraining. SFT's role is to *unlock* or *steer* those existing capabilities into the desired format (e.g., instruction-following, chat). This is why 1,000 high-quality examples sufficed — they taught the model *how* to present knowledge it already had, not *what* to know."
     },
     {
@@ -40,37 +35,22 @@ export const sftAssessment = {
     {
       type: "mc",
       question: "SFT models often suffer from catastrophic overfitting when trained for too many epochs. A common observation is that performance peaks at:",
-      options: [
-        "10–20 epochs with aggressive learning rates",
-        "1–2 epochs, with quality degrading rapidly beyond that",
-        "100+ epochs with careful early stopping",
-        "Exactly 5 epochs regardless of dataset size"
-      ],
-      correct: 1,
+      options: ["10–20 epochs with aggressive learning rates", "Exactly 5 epochs regardless of dataset size", "100+ epochs with careful early stopping", "1–2 epochs, with quality degrading rapidly beyond that"],
+      correct: 3,
       explanation: "SFT datasets are typically small (thousands to tens of thousands of examples), so the model memorizes them quickly. After 1–2 epochs, the model begins overfitting to surface patterns — repeating exact phrasings, losing diversity, and degrading on out-of-distribution prompts. This is why SFT is often described as a \"light touch\" — a brief adaptation, not extended training."
     },
     {
       type: "mc",
       question: "Why is learning rate selection particularly sensitive during SFT compared to pretraining?",
-      options: [
-        "SFT uses a different optimizer than pretraining",
-        "The pretrained weights encode useful representations in a sharp loss basin — too high a learning rate destroys these representations, while too low a rate fails to adapt",
-        "SFT always requires a constant learning rate with no schedule",
-        "The gradient norms are always larger during SFT"
-      ],
-      correct: 1,
+      options: ["SFT uses a different optimizer than pretraining", "SFT always requires a constant learning rate with no schedule", "The pretrained weights encode useful representations in a sharp loss basin — too high a learning rate destroys these representations, while too low a rate fails to adapt", "The gradient norms are always larger during SFT"],
+      correct: 2,
       explanation: "Pretrained models sit in well-conditioned regions of the loss landscape that encode broad linguistic knowledge. SFT learning rates are typically 10–100x smaller than pretraining rates (e.g., $1 \\times 10^{-5}$ to $5 \\times 10^{-5}$ vs. $3 \\times 10^{-4}$). Too large a rate \"kicks\" the model out of the pretrained basin, causing catastrophic forgetting. Too small a rate means the model barely moves from base behavior. This sensitivity is a form of the stability-plasticity dilemma."
     },
     {
       type: "mc",
       question: "In multi-turn conversation SFT, training data is structured with role tokens (e.g., `<|user|>`, `<|assistant|>`). What is the primary purpose of these special tokens?",
-      options: [
-        "They reduce the vocabulary size by replacing common words",
-        "They provide turn-boundary signals and role attribution so the model learns *when* to generate and *whose* voice to adopt",
-        "They are only needed during inference, not training",
-        "They prevent the model from generating any harmful content"
-      ],
-      correct: 1,
+      options: ["They provide turn-boundary signals and role attribution so the model learns *when* to generate and *whose* voice to adopt", "They reduce the vocabulary size by replacing common words", "They are only needed during inference, not training", "They prevent the model from generating any harmful content"],
+      correct: 0,
       explanation: "Role tokens serve as structural markers that teach the model the conversational protocol: when it's the assistant's turn to speak, what voice/style to use, and where turn boundaries are. Without them, the model cannot distinguish user text from assistant text in the training data, leading to role confusion (e.g., generating user messages or failing to stop). The loss mask typically only applies to assistant turns."
     },
     {
@@ -88,37 +68,22 @@ export const sftAssessment = {
     {
       type: "mc",
       question: "When fine-tuning with LoRA (Low-Rank Adaptation), the weight update is parameterized as $\\Delta W = BA$ where $B \\in \\mathbb{R}^{d \\times r}$ and $A \\in \\mathbb{R}^{r \\times d}$ with $r \\ll d$. How does this relate to the SFT intuition that alignment is a \"small\" change?",
-      options: [
-        "It has no relation — LoRA is purely a memory optimization",
-        "The low-rank constraint means the update lives in a small subspace, consistent with the hypothesis that SFT adjusts a few directions in weight space rather than overhauling the model",
-        "LoRA always produces identical results to full fine-tuning",
-        "The rank $r$ must equal the number of training examples"
-      ],
-      correct: 1,
+      options: ["It has no relation — LoRA is purely a memory optimization", "The rank $r$ must equal the number of training examples", "LoRA always produces identical results to full fine-tuning", "The low-rank constraint means the update lives in a small subspace, consistent with the hypothesis that SFT adjusts a few directions in weight space rather than overhauling the model"],
+      correct: 3,
       explanation: "LoRA's success provides empirical evidence for the Superficial Alignment Hypothesis from a parameter perspective: if SFT only needs to \"steer\" the model, then the weight change should be low-rank (a small number of directions in parameter space). LoRA with $r = 8$ or $r = 16$ often matches full fine-tuning, suggesting the effective dimensionality of the SFT update is far smaller than the full parameter count. This also connects to the intrinsic dimensionality literature (Aghajanyan et al.)."
     },
     {
       type: "mc",
       question: "A common failure mode of SFT is \"sycophancy\" — the model excessively agrees with the user. What causes this during SFT?",
-      options: [
-        "The base model lacks the knowledge to disagree",
-        "Training data is biased toward agreement: human-written \"ideal\" responses tend to be agreeable, and annotators reward compliance, so the model learns that agreeing is the high-probability format",
-        "Sycophancy is caused by too low a learning rate",
-        "It only occurs when training for more than 100 epochs"
-      ],
-      correct: 1,
+      options: ["The base model lacks the knowledge to disagree", "Sycophancy is caused by too low a learning rate", "Training data is biased toward agreement: human-written \"ideal\" responses tend to be agreeable, and annotators reward compliance, so the model learns that agreeing is the high-probability format", "It only occurs when training for more than 100 epochs"],
+      correct: 2,
       explanation: "Sycophancy is a distribution-level problem in the SFT data. Human annotators writing \"ideal\" assistant responses tend to be accommodating and agreeable. The model learns this statistical pattern: given any user statement, the maximum-likelihood response is one that validates the user. This is difficult to fix with SFT alone because it requires *preference* signal (\"this disagreement is better than that agreement\"), which is why RLHF/DPO stages are needed to address it."
     },
     {
       type: "mc",
       question: "You are fine-tuning a 7B model on 5,000 instruction-response pairs. During training, you observe that training loss decreases steadily but evaluation loss begins increasing after epoch 1. The model's generations become repetitive and formulaic. What is the most likely diagnosis and remedy?",
-      options: [
-        "The model is underfitting — increase the learning rate and train for more epochs",
-        "Classic overfitting to the small SFT dataset — reduce to 1 epoch, increase dropout or use LoRA with lower rank, and verify data diversity",
-        "The evaluation set is mislabeled — retrain with the same hyperparameters",
-        "The tokenizer is incompatible with the training data"
-      ],
-      correct: 1,
+      options: ["Classic overfitting to the small SFT dataset — reduce to 1 epoch, increase dropout or use LoRA with lower rank, and verify data diversity", "The model is underfitting — increase the learning rate and train for more epochs", "The evaluation set is mislabeled — retrain with the same hyperparameters", "The tokenizer is incompatible with the training data"],
+      correct: 0,
       explanation: "This is the textbook SFT overfitting pattern: the model memorizes training responses (decreasing train loss) while losing generalization (increasing eval loss, repetitive outputs). Remedies include: (1) train for only 1 epoch, (2) reduce effective model capacity (LoRA, dropout), (3) verify data diversity (repetitive data accelerates overfitting), (4) use a cosine schedule that decays to near-zero. The small dataset makes this almost inevitable without these precautions."
     },
     {
@@ -150,37 +115,22 @@ export const rewardModelingAssessment = {
     {
       type: "mc",
       question: "The Bradley-Terry model for pairwise preferences defines $P(y_w \\succ y_l \\mid x) = \\sigma(r(x, y_w) - r(x, y_l))$ where $\\sigma$ is the sigmoid. What assumption does this encode about human preferences?",
-      options: [
-        "Humans always prefer longer responses",
-        "The probability of preferring $y_w$ over $y_l$ depends only on the *difference* in their scalar rewards — preferences are transitive and follow a logistic noise model",
-        "Preferences are uniformly random",
-        "The reward function must be linear in the response length"
-      ],
-      correct: 1,
+      options: ["Humans always prefer longer responses", "The reward function must be linear in the response length", "Preferences are uniformly random", "The probability of preferring $y_w$ over $y_l$ depends only on the *difference* in their scalar rewards — preferences are transitive and follow a logistic noise model"],
+      correct: 3,
       explanation: "Bradley-Terry assumes a latent scalar \"quality\" score $r(x, y)$ for each response, and preference probability is a function of the *difference* $r(x, y_w) - r(x, y_l)$ passed through a sigmoid. This implies transitivity (if $A \\succ B$ and $B \\succ C$, then $A \\succ C$) and a specific noise model (logistic). These are strong assumptions — real human preferences can be intransitive and context-dependent — but the model is tractable and works surprisingly well in practice."
     },
     {
       type: "mc",
       question: "The reward model training loss is $\\mathcal{L} = -\\mathbb{E}_{(x, y_w, y_l)}\\left[\\log \\sigma(r_\\theta(x, y_w) - r_\\theta(x, y_l))\\right]$. Why does this loss only depend on the *difference* $r(x, y_w) - r(x, y_l)$ rather than individual reward values?",
-      options: [
-        "Individual rewards are easier to learn but less accurate",
-        "The Bradley-Terry likelihood is invariant to adding a constant to all rewards — only differences are identifiable from pairwise comparison data",
-        "Individual rewards require reinforcement learning to train",
-        "The sigmoid function requires exactly two inputs"
-      ],
-      correct: 1,
+      options: ["Individual rewards are easier to learn but less accurate", "Individual rewards require reinforcement learning to train", "The Bradley-Terry likelihood is invariant to adding a constant to all rewards — only differences are identifiable from pairwise comparison data", "The sigmoid function requires exactly two inputs"],
+      correct: 2,
       explanation: "If we replace $r(x, y)$ with $r(x, y) + c$ for any constant $c$, the difference $r(x, y_w) - r(x, y_l)$ is unchanged, so the likelihood is identical. This means the absolute scale of rewards is unidentifiable from pairwise data — only relative differences matter. This is why reward models need careful normalization and why reward values can drift during training. It also means comparing rewards across different prompts $x$ is not inherently meaningful."
     },
     {
       type: "mc",
       question: "\"Reward hacking\" (or reward overoptimization) occurs when the policy exploits the reward model. Which of the following best describes the phenomenon observed by Gao et al. (2023)?",
-      options: [
-        "The reward model always assigns perfect scores to all outputs",
-        "As the policy is optimized more aggressively against the reward model (increasing KL from reference), the proxy reward increases but the *true* (gold) reward eventually decreases — the policy finds adversarial inputs to the reward model",
-        "The reward model crashes during training",
-        "Reward hacking only occurs with models smaller than 1B parameters"
-      ],
-      correct: 1,
+      options: ["As the policy is optimized more aggressively against the reward model (increasing KL from reference), the proxy reward increases but the *true* (gold) reward eventually decreases — the policy finds adversarial inputs to the reward model", "The reward model always assigns perfect scores to all outputs", "The reward model crashes during training", "Reward hacking only occurs with models smaller than 1B parameters"],
+      correct: 0,
       explanation: "Gao et al. showed a clear pattern: proxy reward (from the learned RM) increases monotonically with KL budget, but gold reward (from a much larger or human-evaluated RM) follows an inverted-U shape — it improves initially, peaks, then *degrades*. The policy discovers outputs that score high on the proxy RM but are actually low quality. This is a form of Goodhart's law: \"when a measure becomes a target, it ceases to be a good measure.\" The KL penalty $\\beta$ controls where on this curve you operate."
     },
     {
@@ -198,37 +148,22 @@ export const rewardModelingAssessment = {
     {
       type: "mc",
       question: "In RLHF, an \"implicit\" reward can be extracted from any language model via $r_{\\text{implicit}}(x, y) = \\beta \\log \\frac{\\pi_\\theta(y \\mid x)}{\\pi_{\\text{ref}}(y \\mid x)}$. What does this represent?",
-      options: [
-        "The perplexity of the response",
-        "The log-likelihood ratio measures how much the policy has shifted from the reference — responses the policy upweights relative to the reference have higher implicit reward",
-        "The gradient of the loss function",
-        "The entropy of the policy distribution"
-      ],
-      correct: 1,
+      options: ["The perplexity of the response", "The entropy of the policy distribution", "The gradient of the loss function", "The log-likelihood ratio measures how much the policy has shifted from the reference — responses the policy upweights relative to the reference have higher implicit reward"],
+      correct: 3,
       explanation: "This comes from the closed-form solution of the KL-constrained RL objective: $\\pi^*(y \\mid x) \\propto \\pi_{\\text{ref}}(y \\mid x) \\exp(r(y, x) / \\beta)$. Rearranging: $r(y, x) = \\beta \\log \\frac{\\pi^*(y \\mid x)}{\\pi_{\\text{ref}}(y \\mid x)} + \\beta \\log Z(x)$. So the log-ratio is the implicit reward (up to a prompt-dependent constant). This is the foundation of DPO — instead of learning an explicit reward model, use the policy itself as an implicit reward."
     },
     {
       type: "mc",
       question: "Reward model accuracy typically scales with model size, but Anthropic's work showed an important nuance. What did they find about the relationship between RM size and policy size?",
-      options: [
-        "The RM should always be the same size as the policy",
-        "Larger RMs generally produce better policies, but an RM should be at least as large as the policy to avoid the policy easily exploiting the RM's blind spots",
-        "Smaller RMs always produce better policies due to implicit regularization",
-        "RM size has no effect on final policy quality"
-      ],
-      correct: 1,
+      options: ["The RM should always be the same size as the policy", "Smaller RMs always produce better policies due to implicit regularization", "Larger RMs generally produce better policies, but an RM should be at least as large as the policy to avoid the policy easily exploiting the RM's blind spots", "RM size has no effect on final policy quality"],
+      correct: 2,
       explanation: "If the policy model is larger and more capable than the reward model, the policy can find adversarial outputs that fool the RM — it's effectively a stronger adversary than the RM can handle. This creates an asymmetry: the RM needs to be at least as capable as the policy to provide reliable signal. In practice, teams often use an RM that is the same size or larger than the policy. This has implications for scalable oversight — as policies get stronger, reward models must keep pace."
     },
     {
       type: "mc",
       question: "When training a reward model from human pairwise comparisons, annotator disagreement is common. What is the standard approach to handling this?",
-      options: [
-        "Discard all examples where annotators disagree",
-        "Use majority vote to determine the preferred response, but optionally weight the loss by annotator agreement — high-agreement pairs provide a stronger training signal",
-        "Train a separate model for each annotator",
-        "Randomly assign preference labels when annotators disagree"
-      ],
-      correct: 1,
+      options: ["Use majority vote to determine the preferred response, but optionally weight the loss by annotator agreement — high-agreement pairs provide a stronger training signal", "Discard all examples where annotators disagree", "Train a separate model for each annotator", "Randomly assign preference labels when annotators disagree"],
+      correct: 0,
       explanation: "Majority voting is the most common approach: if 3 out of 5 annotators prefer $y_w$, it's labeled as preferred. Some approaches further weight the Bradley-Terry loss by agreement level — a 5/5 agreement pair gets full weight, while a 3/2 split gets reduced weight, reflecting genuine ambiguity. More sophisticated methods model annotator-level preferences or treat disagreement as inherent noise in the generative process. Discarding disagreements wastes data and biases toward \"easy\" examples."
     },
     {
@@ -246,25 +181,15 @@ export const rewardModelingAssessment = {
     {
       type: "mc",
       question: "Consider the reward model loss gradient: $\\nabla_\\theta \\mathcal{L} = -\\mathbb{E}\\left[(1 - \\sigma(\\Delta r)) \\cdot (\\nabla_\\theta r_\\theta(x, y_w) - \\nabla_\\theta r_\\theta(x, y_l))\\right]$ where $\\Delta r = r_\\theta(x, y_w) - r_\\theta(x, y_l)$. The factor $(1 - \\sigma(\\Delta r))$ implies:",
-      options: [
-        "All training examples contribute equally to the gradient",
-        "When the model already assigns much higher reward to the preferred response ($\\Delta r \\gg 0$), the gradient vanishes — the model focuses on pairs it hasn't yet learned to rank correctly",
-        "The gradient is always exactly 1",
-        "Negative rewards produce larger gradients than positive rewards"
-      ],
-      correct: 1,
+      options: ["All training examples contribute equally to the gradient", "Negative rewards produce larger gradients than positive rewards", "The gradient is always exactly 1", "When the model already assigns much higher reward to the preferred response ($\\Delta r \\gg 0$), the gradient vanishes — the model focuses on pairs it hasn't yet learned to rank correctly"],
+      correct: 3,
       explanation: "When $\\Delta r \\gg 0$, $\\sigma(\\Delta r) \\approx 1$, so $(1 - \\sigma(\\Delta r)) \\approx 0$ and the gradient vanishes. This is the standard logistic regression property: well-classified examples contribute little gradient. The model automatically upweights pairs where it's currently wrong ($\\Delta r < 0$) or uncertain ($\\Delta r \\approx 0$). This implicit curriculum means early training focuses on obvious preferences, then shifts to harder, more ambiguous pairs."
     },
     {
       type: "mc",
       question: "A reward model trained on helpfulness comparisons is used to optimize a policy. After optimization, the policy produces very long, verbose responses that score high reward but are rated lower by humans. This is an example of:",
-      options: [
-        "Underfitting of the reward model",
-        "A length bias spurious correlation — the RM learned that longer responses tend to be preferred in training data, so the policy exploits this shortcut rather than genuinely improving quality",
-        "The policy model being too small",
-        "A bug in the KL penalty implementation"
-      ],
-      correct: 1,
+      options: ["Underfitting of the reward model", "The policy model being too small", "A length bias spurious correlation — the RM learned that longer responses tend to be preferred in training data, so the policy exploits this shortcut rather than genuinely improving quality", "A bug in the KL penalty implementation"],
+      correct: 2,
       explanation: "Length bias is one of the most common and well-documented reward hacking modes. In human comparison data, longer responses are often preferred (they tend to be more detailed and thorough), so the RM learns a spurious correlation between length and quality. The policy then exploits this by padding responses with redundant content. Mitigations include: (1) length-conditioned reward normalization, (2) adding length as an explicit feature and regressing it out, (3) including length-controlled comparison pairs in RM training data."
     }
   ]
@@ -284,13 +209,8 @@ export const rlhfAssessment = {
     {
       type: "mc",
       question: "The PPO clipped surrogate objective is $L^{\\text{CLIP}} = \\mathbb{E}_t\\left[\\min\\left(\\rho_t \\hat{A}_t, \\; \\text{clip}(\\rho_t, 1 - \\epsilon, 1 + \\epsilon) \\hat{A}_t\\right)\\right]$ where $\\rho_t = \\frac{\\pi_\\theta(a_t \\mid s_t)}{\\pi_{\\theta_{\\text{old}}}(a_t \\mid s_t)}$. When the advantage $\\hat{A}_t > 0$ (good action), what does the clipping achieve?",
-      options: [
-        "It prevents the probability ratio from dropping below $1 - \\epsilon$",
-        "It caps $\\rho_t$ at $1 + \\epsilon$, preventing the policy from increasing the probability of a good action *too much* in a single update — limiting the step size",
-        "It forces $\\rho_t = 1$ for all good actions",
-        "It removes all gradient signal for good actions"
-      ],
-      correct: 1,
+      options: ["It caps $\\rho_t$ at $1 + \\epsilon$, preventing the policy from increasing the probability of a good action *too much* in a single update — limiting the step size", "It prevents the probability ratio from dropping below $1 - \\epsilon$", "It forces $\\rho_t = 1$ for all good actions", "It removes all gradient signal for good actions"],
+      correct: 0,
       explanation: "When $\\hat{A}_t > 0$, we want to increase $\\pi_\\theta(a_t | s_t)$, which increases $\\rho_t$. But $\\min(\\rho_t \\hat{A}_t, (1+\\epsilon) \\hat{A}_t)$ caps the objective at $(1+\\epsilon)\\hat{A}_t$ — beyond $\\rho_t = 1 + \\epsilon$, there's no further incentive to increase the probability. This prevents catastrophically large policy updates that could destabilize training. Symmetrically, when $\\hat{A}_t < 0$, clipping prevents $\\rho_t$ from dropping below $1 - \\epsilon$."
     },
     {
@@ -308,37 +228,22 @@ export const rlhfAssessment = {
     {
       type: "mc",
       question: "In the RLHF objective $\\max_\\pi \\mathbb{E}_{x \\sim \\mathcal{D}, y \\sim \\pi(\\cdot | x)}[r(x, y)] - \\beta \\, \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, increasing $\\beta$ has what effect?",
-      options: [
-        "Increases the reward but decreases the KL penalty",
-        "Makes the policy more conservative — staying closer to $\\pi_{\\text{ref}}$ at the cost of less reward optimization, reducing reward hacking but also limiting improvement",
-        "Has no effect on the policy because $\\beta$ cancels out",
-        "Always improves both reward and KL simultaneously"
-      ],
-      correct: 1,
+      options: ["Increases the reward but decreases the KL penalty", "Always improves both reward and KL simultaneously", "Has no effect on the policy because $\\beta$ cancels out", "Makes the policy more conservative — staying closer to $\\pi_{\\text{ref}}$ at the cost of less reward optimization, reducing reward hacking but also limiting improvement"],
+      correct: 3,
       explanation: "Higher $\\beta$ increases the cost of diverging from $\\pi_{\\text{ref}}$. The optimal policy is $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. As $\\beta \\to \\infty$, $\\pi^* \\to \\pi_{\\text{ref}}$ (no adaptation). As $\\beta \\to 0$, $\\pi^*$ concentrates on the reward-maximizing response (maximum reward hacking risk). In practice, $\\beta$ is the primary knob for controlling the reward-quality tradeoff, and is often scheduled (starting high, decreasing)."
     },
     {
       type: "mc",
       question: "The RLHF penalty uses **forward KL** $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, not reverse KL $\\text{KL}(\\pi_{\\text{ref}} \\| \\pi)$. What is the practical reason for this choice?",
-      options: [
-        "Forward KL is easier to compute",
-        "Forward KL penalizes $\\pi$ for placing mass where $\\pi_{\\text{ref}}$ has low mass — preventing the policy from generating novel text that the base model considers implausible, which is exactly the mode of reward hacking we want to prevent",
-        "Forward and reverse KL are identical for language models",
-        "Reverse KL causes numerical overflow in all cases"
-      ],
-      correct: 1,
+      options: ["Forward KL is easier to compute", "Forward and reverse KL are identical for language models", "Forward KL penalizes $\\pi$ for placing mass where $\\pi_{\\text{ref}}$ has low mass — preventing the policy from generating novel text that the base model considers implausible, which is exactly the mode of reward hacking we want to prevent", "Reverse KL causes numerical overflow in all cases"],
+      correct: 2,
       explanation: "Forward KL: $\\text{KL}(\\pi \\| \\pi_{\\text{ref}}) = \\mathbb{E}_\\pi[\\log \\pi / \\pi_{\\text{ref}}]$. The expectation is under $\\pi$, so if $\\pi$ generates text $y$ where $\\pi_{\\text{ref}}(y) \\approx 0$, the log-ratio explodes. This directly prevents the policy from discovering adversarial outputs that the base model would never produce. Reverse KL $\\text{KL}(\\pi_{\\text{ref}} \\| \\pi)$ would instead penalize $\\pi$ for *not covering* modes of $\\pi_{\\text{ref}}$, which is the wrong inductive bias for alignment."
     },
     {
       type: "mc",
       question: "GRPO (Group Relative Policy Optimization), used in DeepSeek-R1, eliminates the value network by:",
-      options: [
-        "Using a fixed reward for all responses",
-        "Sampling a group of responses for each prompt, computing rewards, and using the **group-normalized advantage** $\\hat{A}_i = \\frac{r_i - \\text{mean}(\\mathbf{r})}{\\text{std}(\\mathbf{r})}$ as the baseline — removing the need for a separate critic",
-        "Training the policy and value function with shared parameters",
-        "Using Monte Carlo tree search instead of a value function"
-      ],
-      correct: 1,
+      options: ["Sampling a group of responses for each prompt, computing rewards, and using the **group-normalized advantage** $\\hat{A}_i = \\frac{r_i - \\text{mean}(\\mathbf{r})}{\\text{std}(\\mathbf{r})}$ as the baseline — removing the need for a separate critic", "Using a fixed reward for all responses", "Training the policy and value function with shared parameters", "Using Monte Carlo tree search instead of a value function"],
+      correct: 0,
       explanation: "GRPO samples $G$ completions $\\{y_1, \\ldots, y_G\\}$ for each prompt $x$, scores them with the RM, then normalizes: $\\hat{A}_i = (r_i - \\mu_G) / \\sigma_G$. This group-level normalization serves as a variance-reducing baseline without needing a learned value function. Benefits: (1) removes the value network (halving GPU memory), (2) avoids value function approximation error, (3) naturally handles reward scale differences across prompts. The key insight is that relative ranking within a group is sufficient for policy improvement."
     },
     {
@@ -356,49 +261,29 @@ export const rlhfAssessment = {
     {
       type: "mc",
       question: "In RLHF for language models, the \"state\" $s_t$ and \"action\" $a_t$ in the MDP formulation are typically defined as:",
-      options: [
-        "State = the entire training dataset, Action = the model's weight update",
-        "State = the prompt plus all tokens generated so far $(x, y_{<t})$, Action = the next token $y_t$ — the episode terminates when the EOS token is generated",
-        "State = the hidden state of the transformer, Action = the attention pattern",
-        "State = the reward model's output, Action = the KL divergence"
-      ],
-      correct: 1,
+      options: ["State = the entire training dataset, Action = the model's weight update", "State = the reward model's output, Action = the KL divergence", "State = the hidden state of the transformer, Action = the attention pattern", "State = the prompt plus all tokens generated so far $(x, y_{<t})$, Action = the next token $y_t$ — the episode terminates when the EOS token is generated"],
+      correct: 3,
       explanation: "RLHF treats autoregressive generation as a token-level MDP: the state is the concatenation of the prompt and all generated tokens so far, and the action is choosing the next token from the vocabulary. The reward is typically sparse — assigned only at the end of generation (from the RM). The episode starts with the prompt and ends at EOS. This framing makes the action space $|V|$ (vocabulary size, typically 32K–100K), and episodes are typically 100–2000 steps long."
     },
     {
       type: "mc",
       question: "A common source of PPO instability in RLHF is the interaction between the value function and the policy. Specifically:",
-      options: [
-        "The value function converges too quickly",
-        "The value function is initialized from the SFT model and must estimate sequence-level returns from token-level states — its errors propagate through GAE into advantage estimates, causing noisy policy gradients that can spiral into divergence",
-        "The value function and policy always converge to the same parameters",
-        "PPO never uses a value function in practice"
-      ],
-      correct: 1,
+      options: ["The value function converges too quickly", "The value function and policy always converge to the same parameters", "The value function is initialized from the SFT model and must estimate sequence-level returns from token-level states — its errors propagate through GAE into advantage estimates, causing noisy policy gradients that can spiral into divergence", "PPO never uses a value function in practice"],
+      correct: 2,
       explanation: "In RLHF, the value function $V_\\phi(s_t)$ must predict the expected return (RM score + KL penalties for remaining tokens). This is challenging: (1) the reward is sparse (only at episode end), (2) the value function must generalize across diverse prompts, (3) as the policy changes, the value function's training data shifts. Errors in $V$ directly corrupt advantage estimates via $\\delta_t = r_t + \\gamma V(s_{t+1}) - V(s_t)$, leading to wrong policy gradients. This is why some approaches (GRPO, REINFORCE-based) eliminate the value function entirely."
     },
     {
       type: "mc",
       question: "In the PPO objective for RLHF, the per-token reward is typically defined as $r_t = -\\beta \\log \\frac{\\pi_\\theta(y_t | x, y_{<t})}{\\pi_{\\text{ref}}(y_t | x, y_{<t})}$ for $t < T$ and $r_T = R_{\\text{RM}}(x, y) - \\beta \\log \\frac{\\pi_\\theta(y_T | x, y_{<T})}{\\pi_{\\text{ref}}(y_T | x, y_{<T})}$. Why is the KL penalty applied per-token rather than as a single sequence-level penalty?",
-      options: [
-        "Per-token KL is cheaper to compute",
-        "Per-token KL provides denser reward signal, enabling better credit assignment — the value function and GAE can propagate KL costs to specific tokens rather than attributing the entire sequence-level KL to the final token",
-        "Sequence-level KL is not mathematically well-defined",
-        "Per-token and sequence-level KL penalties are always identical"
-      ],
-      correct: 1,
+      options: ["Per-token KL provides denser reward signal, enabling better credit assignment — the value function and GAE can propagate KL costs to specific tokens rather than attributing the entire sequence-level KL to the final token", "Per-token KL is cheaper to compute", "Sequence-level KL is not mathematically well-defined", "Per-token and sequence-level KL penalties are always identical"],
+      correct: 0,
       explanation: "The sequence-level KL decomposes as $\\text{KL}(\\pi \\| \\pi_{\\text{ref}}) = \\sum_t \\mathbb{E}[\\log \\frac{\\pi(y_t | x, y_{<t})}{\\pi_{\\text{ref}}(y_t | x, y_{<t})}]$, so the per-token formulation is mathematically equivalent. However, placing the KL penalty at each token step is crucial for the RL optimization: it provides dense intermediate rewards, making the value function estimation problem much easier and enabling GAE to assign credit at the token level. Without this, the value function must predict the entire future KL from each state, which is much harder."
     },
     {
       type: "mc",
       question: "Consider a simplified RLHF setup with discrete reward $r \\in \\{0, 1\\}$ and a policy $\\pi_\\theta$ parameterized by a single scalar $\\theta$ controlling the probability of a \"good\" action: $\\pi_\\theta(\\text{good}) = \\sigma(\\theta)$. The REINFORCE gradient estimator is $\\nabla_\\theta J = \\mathbb{E}_{a \\sim \\pi_\\theta}[r(a) \\nabla_\\theta \\log \\pi_\\theta(a)]$. With a single sample $a$ and no baseline, the variance of this estimator is high because:",
-      options: [
-        "The gradient is always zero",
-        "The estimator is biased",
-        "When $r(a) = 0$ (bad action), the gradient is zero regardless of how informative the sample is, and when $r(a) = 1$ (good action), the gradient magnitude depends on $\\pi_\\theta(a)$ — high reward but low probability actions produce large, rare gradient spikes",
-        "REINFORCE cannot be applied to discrete action spaces"
-      ],
-      correct: 2,
+      options: ["The gradient is always zero", "When $r(a) = 0$ (bad action), the gradient is zero regardless of how informative the sample is, and when $r(a) = 1$ (good action), the gradient magnitude depends on $\\pi_\\theta(a)$ — high reward but low probability actions produce large, rare gradient spikes", "The estimator is biased", "REINFORCE cannot be applied to discrete action spaces"],
+      correct: 1,
       explanation: "REINFORCE with $r \\in \\{0, 1\\}$: if the sampled action has $r = 0$, we get $\\nabla = 0$ — no learning signal, even though a bad outcome is informative. If $r = 1$, we get $\\nabla = \\nabla_\\theta \\log \\pi_\\theta(a)$, which is large when $\\pi_\\theta(a)$ is small (rare good actions produce gradient spikes). The variance is $\\text{Var}[r \\nabla \\log \\pi] = \\mathbb{E}[r^2 (\\nabla \\log \\pi)^2] - (\\mathbb{E}[r \\nabla \\log \\pi])^2$, which can be enormous. A baseline $b$ (e.g., $V(s)$) replaces $r$ with $r - b$, drastically reducing variance without introducing bias."
     }
   ]
@@ -418,37 +303,22 @@ export const directAlignmentAssessment = {
     {
       type: "mc",
       question: "DPO's key derivation insight starts from the KL-constrained RLHF objective $\\max_\\pi \\mathbb{E}[r(x,y)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$. The closed-form optimal policy is $\\pi^*(y|x) = \\frac{1}{Z(x)} \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. DPO's crucial next step is to:",
-      options: [
-        "Approximate $Z(x)$ using Monte Carlo sampling",
-        "Rearrange to express the reward as $r(x,y) = \\beta \\log \\frac{\\pi^*(y|x)}{\\pi_{\\text{ref}}(y|x)} + \\beta \\log Z(x)$, then substitute into the Bradley-Terry model — the partition function $Z(x)$ cancels in the preference probability, yielding a loss that depends only on the policy",
-        "Train a separate reward model to approximate $Z(x)$",
-        "Set $Z(x) = 1$ by assumption"
-      ],
-      correct: 1,
+      options: ["Approximate $Z(x)$ using Monte Carlo sampling", "Set $Z(x) = 1$ by assumption", "Train a separate reward model to approximate $Z(x)$", "Rearrange to express the reward as $r(x,y) = \\beta \\log \\frac{\\pi^*(y|x)}{\\pi_{\\text{ref}}(y|x)} + \\beta \\log Z(x)$, then substitute into the Bradley-Terry model — the partition function $Z(x)$ cancels in the preference probability, yielding a loss that depends only on the policy"],
+      correct: 3,
       explanation: "The full derivation: (1) Solve for optimal policy: $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) e^{r/\\beta}$. (2) Invert: $r(x,y) = \\beta \\log \\frac{\\pi^*(y|x)}{\\pi_{\\text{ref}}(y|x)} + \\beta \\log Z(x)$. (3) Substitute into Bradley-Terry: $P(y_w \\succ y_l) = \\sigma(r_w - r_l) = \\sigma\\left(\\beta \\log \\frac{\\pi^*(y_w|x)}{\\pi_{\\text{ref}}(y_w|x)} - \\beta \\log \\frac{\\pi^*(y_l|x)}{\\pi_{\\text{ref}}(y_l|x)}\\right)$. The $\\beta \\log Z(x)$ terms cancel in the difference. (4) Replace $\\pi^*$ with $\\pi_\\theta$ to get the training objective."
     },
     {
       type: "mc",
       question: "The DPO loss is $\\mathcal{L}_{\\text{DPO}} = -\\mathbb{E}\\left[\\log \\sigma\\left(\\beta \\log \\frac{\\pi_\\theta(y_w|x)}{\\pi_{\\text{ref}}(y_w|x)} - \\beta \\log \\frac{\\pi_\\theta(y_l|x)}{\\pi_{\\text{ref}}(y_l|x)}\\right)\\right]$. The gradient with respect to $\\theta$ is proportional to $(1 - \\sigma(\\hat{r}_w - \\hat{r}_l))$ where $\\hat{r}_i = \\beta \\log \\frac{\\pi_\\theta(y_i|x)}{\\pi_{\\text{ref}}(y_i|x)}$. This means the gradient:",
-      options: [
-        "Is constant regardless of how well the model has learned the preference",
-        "Is large when the model's implicit reward difference is wrong ($\\hat{r}_w - \\hat{r}_l \\ll 0$) and vanishes when the model already correctly ranks the pair ($\\hat{r}_w - \\hat{r}_l \\gg 0$) — an adaptive weighting similar to the reward model loss",
-        "Is always zero for correctly ranked pairs",
-        "Only depends on the winning response, not the losing response"
-      ],
-      correct: 1,
+      options: ["Is constant regardless of how well the model has learned the preference", "Is always zero for correctly ranked pairs", "Is large when the model's implicit reward difference is wrong ($\\hat{r}_w - \\hat{r}_l \\ll 0$) and vanishes when the model already correctly ranks the pair ($\\hat{r}_w - \\hat{r}_l \\gg 0$) — an adaptive weighting similar to the reward model loss", "Only depends on the winning response, not the losing response"],
+      correct: 2,
       explanation: "The factor $(1 - \\sigma(\\hat{r}_w - \\hat{r}_l))$ acts as an implicit curriculum: when the model already assigns much higher implicit reward to the preferred response, $\\sigma(\\hat{r}_w - \\hat{r}_l) \\approx 1$ and the gradient vanishes. When the model incorrectly ranks the pair, $\\sigma(\\hat{r}_w - \\hat{r}_l) \\approx 0$ and the gradient is maximal. The gradient simultaneously pushes $\\pi_\\theta(y_w|x)$ up and $\\pi_\\theta(y_l|x)$ down relative to the reference."
     },
     {
       type: "mc",
       question: "A major failure mode of offline DPO is \"distribution shift.\" What specifically causes this?",
-      options: [
-        "The tokenizer changes between pretraining and DPO",
-        "DPO trains on preference pairs $(y_w, y_l)$ generated by a *different* policy (often the SFT model), but optimizes $\\pi_\\theta$ — as $\\pi_\\theta$ diverges from the data-generating policy, the log-probabilities $\\log \\pi_\\theta(y|x)$ become unreliable estimates for out-of-distribution responses",
-        "The reference model is too large",
-        "Distribution shift only affects models with more than 100B parameters"
-      ],
-      correct: 1,
+      options: ["DPO trains on preference pairs $(y_w, y_l)$ generated by a *different* policy (often the SFT model), but optimizes $\\pi_\\theta$ — as $\\pi_\\theta$ diverges from the data-generating policy, the log-probabilities $\\log \\pi_\\theta(y|x)$ become unreliable estimates for out-of-distribution responses", "The tokenizer changes between pretraining and DPO", "The reference model is too large", "Distribution shift only affects models with more than 100B parameters"],
+      correct: 0,
       explanation: "Offline DPO uses a fixed dataset of preference pairs. As $\\pi_\\theta$ evolves during training, it may encounter responses $y$ that are very different from what it would generate — the log-probabilities $\\log \\pi_\\theta(y|x)$ become poorly calibrated for these out-of-distribution sequences. The implicit reward $\\beta \\log \\frac{\\pi_\\theta(y|x)}{\\pi_{\\text{ref}}(y|x)}$ can become meaningless. This is analogous to off-policy RL issues. Online DPO mitigates this by regenerating responses with the current $\\pi_\\theta$."
     },
     {
@@ -466,37 +336,22 @@ export const directAlignmentAssessment = {
     {
       type: "mc",
       question: "KTO (Kahneman-Tversky Optimization) differs from DPO in a fundamental data requirement. What is this difference?",
-      options: [
-        "KTO requires 10x more data than DPO",
-        "KTO works with unpaired binary feedback (each response independently labeled as good/bad) rather than requiring *paired* preferences ($y_w \\succ y_l$ for the same prompt) — this makes data collection much simpler",
-        "KTO requires paired preferences while DPO works with point-wise labels",
-        "KTO only works with numerical reward scores, not binary feedback"
-      ],
-      correct: 1,
+      options: ["KTO requires 10x more data than DPO", "KTO only works with numerical reward scores, not binary feedback", "KTO requires paired preferences while DPO works with point-wise labels", "KTO works with unpaired binary feedback (each response independently labeled as good/bad) rather than requiring *paired* preferences ($y_w \\succ y_l$ for the same prompt) — this makes data collection much simpler"],
+      correct: 3,
       explanation: "DPO requires *pairwise* comparisons: for the same prompt $x$, a preferred $y_w$ and dispreferred $y_l$. KTO only needs independent binary labels: \"this response is good\" or \"this response is bad,\" without pairing. This is inspired by Kahneman-Tversky prospect theory (loss aversion). KTO's loss treats good and bad examples asymmetrically, applying stronger penalties for producing bad outputs than rewards for producing good ones. This dramatically simplifies data collection — binary thumbs up/down is far cheaper than side-by-side comparisons."
     },
     {
       type: "mc",
       question: "Online DPO (also called \"iterative DPO\" or \"online RLHF with DPO loss\") modifies the standard DPO pipeline by:",
-      options: [
-        "Training on a larger static dataset",
-        "Generating new response pairs from the *current* policy $\\pi_\\theta$ at each iteration, scoring them with a reward model, and constructing fresh preference pairs — this keeps the training distribution aligned with the policy and mitigates distribution shift",
-        "Using a different loss function than DPO",
-        "Removing the reference model from the objective"
-      ],
-      correct: 1,
+      options: ["Training on a larger static dataset", "Using a different loss function than DPO", "Generating new response pairs from the *current* policy $\\pi_\\theta$ at each iteration, scoring them with a reward model, and constructing fresh preference pairs — this keeps the training distribution aligned with the policy and mitigates distribution shift", "Removing the reference model from the objective"],
+      correct: 2,
       explanation: "Online DPO closes the distribution shift gap: (1) sample responses from current $\\pi_\\theta$, (2) score with RM to determine preferences, (3) train with DPO loss on these on-policy pairs, (4) repeat. This is conceptually similar to RLHF (generate, score, update) but uses the DPO loss instead of PPO. The result is that $\\log \\pi_\\theta(y|x)$ is always computed for responses the current policy would actually generate, making the implicit reward estimates accurate. Empirically, online DPO significantly outperforms offline DPO."
     },
     {
       type: "mc",
       question: "SimPO (Simple Preference Optimization) makes a key simplification compared to DPO by defining the implicit reward as the *length-normalized* log-probability: $r_{\\text{SimPO}}(x, y) = \\frac{1}{|y|} \\log \\pi_\\theta(y | x)$. What does this eliminate?",
-      options: [
-        "The need for GPU memory",
-        "The reference model $\\pi_{\\text{ref}}$ — SimPO does not need to store or compute log-probabilities under a frozen reference, halving memory requirements and simplifying the pipeline",
-        "The preference data entirely",
-        "The need for gradient computation"
-      ],
-      correct: 1,
+      options: ["The reference model $\\pi_{\\text{ref}}$ — SimPO does not need to store or compute log-probabilities under a frozen reference, halving memory requirements and simplifying the pipeline", "The need for GPU memory", "The preference data entirely", "The need for gradient computation"],
+      correct: 0,
       explanation: "DPO's implicit reward is $\\beta \\log \\frac{\\pi_\\theta(y|x)}{\\pi_{\\text{ref}}(y|x)}$, requiring a frozen $\\pi_{\\text{ref}}$ alongside $\\pi_\\theta$ during training (2x memory). SimPO replaces this with the length-normalized log-probability $\\frac{1}{|y|}\\log \\pi_\\theta(y|x)$, eliminating $\\pi_{\\text{ref}}$ entirely. Length normalization prevents the model from trivially increasing reward by generating shorter sequences. SimPO adds a margin term $\\gamma$ to the loss, similar to IPO's finite target, to prevent overoptimization."
     },
     {
@@ -514,25 +369,15 @@ export const directAlignmentAssessment = {
     {
       type: "mc",
       question: "Constitutional AI (CAI) / RLAIF replaces human preference labels with AI-generated feedback. The \"constitutional\" part refers to:",
-      options: [
-        "A legal framework governing model training",
-        "A set of natural-language principles (the \"constitution\") that the AI uses to evaluate and revise its own outputs — the AI critiques responses based on these principles and generates preference labels for RLHF/DPO training",
-        "The model's architecture being fixed (\"constituted\") during training",
-        "A requirement that training data come from government sources"
-      ],
-      correct: 1,
+      options: ["A legal framework governing model training", "A requirement that training data come from government sources", "The model's architecture being fixed (\"constituted\") during training", "A set of natural-language principles (the \"constitution\") that the AI uses to evaluate and revise its own outputs — the AI critiques responses based on these principles and generates preference labels for RLHF/DPO training"],
+      correct: 3,
       explanation: "CAI (Bai et al., 2022) works in two phases: (1) **Self-critique and revision**: the model generates a response, then is prompted to critique and revise it according to constitutional principles (e.g., \"Choose the response that is most helpful and least harmful\"). (2) **RLAIF**: the AI compares original vs. revised responses to generate preference labels, which train a reward model for RLHF. The constitution is a set of human-written principles that encode values, replacing per-example human annotation with scalable AI-based evaluation."
     },
     {
       type: "mc",
       question: "ORPO (Odds Ratio Preference Optimization) combines SFT and preference optimization into a single loss: $\\mathcal{L}_{\\text{ORPO}} = \\mathcal{L}_{\\text{SFT}}(y_w) + \\lambda \\cdot \\mathcal{L}_{\\text{OR}}$ where $\\mathcal{L}_{\\text{OR}} = -\\log \\sigma\\left(\\log \\frac{\\text{odds}_\\theta(y_w|x)}{\\text{odds}_\\theta(y_l|x)}\\right)$ and $\\text{odds}_\\theta(y|x) = \\frac{P_\\theta(y|x)}{1 - P_\\theta(y|x)}$. What is the key advantage of this unified approach?",
-      options: [
-        "ORPO achieves higher reward scores than all other methods",
-        "It eliminates the need for a separate SFT stage and a reference model — the SFT term teaches the desired format while the odds ratio term simultaneously encodes preferences, reducing the multi-stage pipeline to a single training phase",
-        "ORPO never overfits regardless of training duration",
-        "The odds ratio is always easier to compute than log-probabilities"
-      ],
-      correct: 1,
+      options: ["ORPO achieves higher reward scores than all other methods", "ORPO never overfits regardless of training duration", "It eliminates the need for a separate SFT stage and a reference model — the SFT term teaches the desired format while the odds ratio term simultaneously encodes preferences, reducing the multi-stage pipeline to a single training phase", "The odds ratio is always easier to compute than log-probabilities"],
+      correct: 2,
       explanation: "Standard alignment pipelines require: (1) SFT, (2) freeze as $\\pi_{\\text{ref}}$, (3) DPO/RLHF. ORPO merges steps 1 and 2–3: the SFT loss $\\mathcal{L}_{\\text{SFT}}(y_w)$ on the preferred response teaches format and content, while the odds ratio loss $\\mathcal{L}_{\\text{OR}}$ teaches preferences. No reference model is needed because the odds ratio $\\frac{\\text{odds}(y_w)}{\\text{odds}(y_l)}$ implicitly regularizes — it contrasts the chosen vs. rejected response within the same model. This simplifies the pipeline and reduces computational cost."
     }
   ]
@@ -552,13 +397,8 @@ export const frontierAlignmentAssessment = {
     {
       type: "mc",
       question: "The \"weak-to-strong generalization\" problem (Burns et al., 2023) studies whether a weak model can supervise a stronger one. The key empirical finding was:",
-      options: [
-        "Weak supervisors always fail — the strong model degrades to weak-model performance",
-        "Strong models trained with weak supervision consistently outperform their weak supervisors, recovering a significant fraction of the gap between weak and strong performance — suggesting that strong models can partially \"generalize beyond\" noisy labels",
-        "Weak and strong models always achieve identical performance",
-        "The strong model learns to ignore the weak supervisor entirely"
-      ],
-      correct: 1,
+      options: ["Strong models trained with weak supervision consistently outperform their weak supervisors, recovering a significant fraction of the gap between weak and strong performance — suggesting that strong models can partially \"generalize beyond\" noisy labels", "Weak supervisors always fail — the strong model degrades to weak-model performance", "Weak and strong models always achieve identical performance", "The strong model learns to ignore the weak supervisor entirely"],
+      correct: 0,
       explanation: "Burns et al. found that when a weak model (e.g., GPT-2-level) provides labels for training a strong model (e.g., GPT-4-level), the strong model consistently exceeds the weak supervisor's performance. This is encouraging for scalable oversight: it suggests that superhuman models might partially self-correct even when trained with imperfect human feedback. However, the recovery is incomplete — there is a \"alignment tax\" — and the gap grows on harder tasks, indicating that weak-to-strong generalization alone is insufficient for frontier alignment."
     },
     {
@@ -576,37 +416,22 @@ export const frontierAlignmentAssessment = {
     {
       type: "mc",
       question: "Representation engineering / steering vectors involve finding directions $\\mathbf{v}$ in a model's activation space such that adding $\\alpha \\mathbf{v}$ to intermediate activations controls a specific behavior (e.g., honesty). These vectors are typically found by:",
-      options: [
-        "Random search in the activation space",
-        "Computing the difference in mean activations between contrastive prompt pairs (e.g., honest vs. dishonest responses) across a dataset — the resulting direction captures the \"concept direction\" in representation space",
-        "Training a separate classifier on the model's outputs",
-        "Pruning attention heads until the behavior changes"
-      ],
-      correct: 1,
+      options: ["Random search in the activation space", "Pruning attention heads until the behavior changes", "Training a separate classifier on the model's outputs", "Computing the difference in mean activations between contrastive prompt pairs (e.g., honest vs. dishonest responses) across a dataset — the resulting direction captures the \"concept direction\" in representation space"],
+      correct: 3,
       explanation: "The standard approach: (1) construct contrastive pairs — prompts that elicit opposite behaviors (e.g., truthful vs. deceptive responses). (2) Run both through the model, extract activations at a chosen layer. (3) Compute $\\mathbf{v} = \\mathbb{E}[\\mathbf{h}_{\\text{positive}}] - \\mathbb{E}[\\mathbf{h}_{\\text{negative}}]$. This difference vector captures the linear direction in representation space corresponding to the concept. Adding $\\alpha \\mathbf{v}$ at inference time \"steers\" the model along this direction. More sophisticated methods use PCA or linear probes on the contrastive activations."
     },
     {
       type: "mc",
       question: "OpenAI's o1/o3 models use RL for reasoning, training on chain-of-thought traces. A critical design choice is training the model to produce long \"thinking\" traces before answering. What RL signal structure makes this work?",
-      options: [
-        "Reward is given at every token of the reasoning trace",
-        "Outcome-based reward (correctness of the final answer) combined with process supervision — the RL algorithm must learn to credit intermediate reasoning steps that lead to correct answers despite extremely sparse reward",
-        "The model is only trained with supervised learning on expert traces",
-        "Reward is given only for short responses to encourage efficiency"
-      ],
-      correct: 1,
+      options: ["Reward is given at every token of the reasoning trace", "The model is only trained with supervised learning on expert traces", "Outcome-based reward (correctness of the final answer) combined with process supervision — the RL algorithm must learn to credit intermediate reasoning steps that lead to correct answers despite extremely sparse reward", "Reward is given only for short responses to encourage efficiency"],
+      correct: 2,
       explanation: "The o1/o3 paradigm uses RL with sparse outcome reward (is the final answer correct?) to train extended reasoning. The challenge is credit assignment: a 10,000-token reasoning trace might have one reward signal. Process reward models (PRMs) and process supervision help bridge this by evaluating intermediate steps. The RL training (likely a variant of PPO or GRPO) must learn which reasoning patterns — backtracking, verification, decomposition — lead to correct outcomes. This is \"RL for inference-time compute scaling\" — the model learns to think longer and more carefully."
     },
     {
       type: "mc",
       question: "Process supervision (as in the \"Let's Verify Step by Step\" paper, Lightman et al. 2023) provides feedback on each reasoning step. Compared to outcome supervision, process supervision:",
-      options: [
-        "Always produces worse results but is cheaper to implement",
-        "Provides denser reward signal, enables better credit assignment, and allows the model to be guided away from flawed reasoning even when it accidentally reaches correct answers — but requires significantly more expensive per-step human annotations",
-        "Does not require any human annotations",
-        "Is only applicable to non-mathematical tasks"
-      ],
-      correct: 1,
+      options: ["Provides denser reward signal, enables better credit assignment, and allows the model to be guided away from flawed reasoning even when it accidentally reaches correct answers — but requires significantly more expensive per-step human annotations", "Always produces worse results but is cheaper to implement", "Does not require any human annotations", "Is only applicable to non-mathematical tasks"],
+      correct: 0,
       explanation: "Process supervision labels each step as correct/incorrect, creating a rich training signal. Benefits: (1) **Credit assignment**: identifies exactly where reasoning fails, rather than penalizing the entire trace for a wrong final answer. (2) **Avoiding reward hacking**: a correct final answer via flawed reasoning gets negative process feedback. (3) **Denser signal**: reduces variance in policy gradients. The cost is annotation: labeling each step requires expert annotators who understand the reasoning, which is far more expensive than checking final answers. Lightman et al. showed process supervision substantially outperforms outcome supervision on math reasoning."
     },
     {
@@ -624,37 +449,22 @@ export const frontierAlignmentAssessment = {
     {
       type: "mc",
       question: "A steering vector $\\mathbf{v}$ is applied as $\\mathbf{h}'_l = \\mathbf{h}_l + \\alpha \\mathbf{v}$ at layer $l$. The coefficient $\\alpha$ controls steering strength. A known failure mode is that large $|\\alpha|$ values cause:",
-      options: [
-        "The model to produce higher quality outputs",
-        "Distribution shift in the activations — the modified $\\mathbf{h}'_l$ moves outside the manifold of activations the downstream layers were trained on, causing incoherent or degenerate text even if the desired behavioral shift is achieved",
-        "The model to ignore the steering vector entirely",
-        "Faster inference speed"
-      ],
-      correct: 1,
+      options: ["The model to produce higher quality outputs", "Faster inference speed", "The model to ignore the steering vector entirely", "Distribution shift in the activations — the modified $\\mathbf{h}'_l$ moves outside the manifold of activations the downstream layers were trained on, causing incoherent or degenerate text even if the desired behavioral shift is achieved"],
+      correct: 3,
       explanation: "The model's downstream layers (layers $> l$) are trained on activations from the natural distribution. Adding a large $\\alpha \\mathbf{v}$ pushes activations off-manifold — the downstream layers receive inputs they've never seen during training. This is an out-of-distribution problem: the layers may produce unpredictable outputs. In practice, moderate $\\alpha$ produces interpretable behavioral shifts, but large $\\alpha$ degrades coherence. This is analogous to the \"curse of representation engineering\" — effective steering requires staying within the model's operational distribution."
     },
     {
       type: "mc",
       question: "The concept of \"alignment tax\" refers to:",
-      options: [
-        "Government taxes on AI companies for safety compliance",
-        "The capability cost of alignment training — the observation that safety training (RLHF, refusals, guardrails) can reduce the model's performance on benign tasks, creating a tradeoff between safety and helpfulness",
-        "The computational cost of training larger models",
-        "The salary cost of hiring alignment researchers"
-      ],
-      correct: 1,
+      options: ["Government taxes on AI companies for safety compliance", "The computational cost of training larger models", "The capability cost of alignment training — the observation that safety training (RLHF, refusals, guardrails) can reduce the model's performance on benign tasks, creating a tradeoff between safety and helpfulness", "The salary cost of hiring alignment researchers"],
+      correct: 2,
       explanation: "Alignment tax measures how much capability is lost to make a model safe. An ideal alignment method has zero tax — the model is both maximally capable and perfectly safe. In practice, safety training introduces refusals, hedging, and conservatism that can degrade performance: (1) over-refusal on benign queries, (2) reduced creativity due to conservative generation, (3) loss of calibration from RLHF. Minimizing alignment tax is a key research goal — methods like Constitutional AI and careful reward modeling aim to maintain capabilities while improving safety."
     },
     {
       type: "mc",
       question: "Scalable oversight is the problem of providing reliable training signal for models that exceed human capabilities in some domains. The recursive reward modeling (RRM) approach proposes to:",
-      options: [
-        "Use the same human annotators for all model generations",
-        "Use an AI assistant (itself aligned by human feedback) to help humans evaluate the next-level model's outputs — creating a chain where each model helps align its successor, with humans retaining oversight at each stage",
-        "Remove human oversight entirely and rely on self-play",
-        "Train only on tasks where human performance is superior"
-      ],
-      correct: 1,
+      options: ["Use an AI assistant (itself aligned by human feedback) to help humans evaluate the next-level model's outputs — creating a chain where each model helps align its successor, with humans retaining oversight at each stage", "Use the same human annotators for all model generations", "Remove human oversight entirely and rely on self-play", "Train only on tasks where human performance is superior"],
+      correct: 0,
       explanation: "RRM creates a bootstrap chain: (1) Humans directly evaluate model $M_1$. (2) $M_1$ assists humans in evaluating the more capable $M_2$. (3) $M_2$ assists in evaluating $M_3$, and so on. At each stage, humans make the final judgment but are aided by the previous model. The key assumption is that *evaluating with assistance* is easier than *evaluating alone*, even as models become superhuman. This is related to the debate approach — both leverage asymmetric verification. The risk is that errors compound across the chain."
     },
     {

--- a/src/modules/assess-branch-b.js
+++ b/src/modules/assess-branch-b.js
@@ -15,37 +15,22 @@ export const scalingLawsAssessment = {
     {
       type: "mc",
       question: "The original Kaplan et al. (2020) scaling laws suggested that language model loss scales as a power law in model size $N$, dataset size $D$, and compute $C$. A key (later-revised) recommendation was:",
-      options: [
-        "Train all models for exactly one epoch regardless of size",
-        "Scale model size faster than dataset size — larger models are more sample-efficient, so allocate most additional compute to parameters",
-        "Keep model size fixed and only increase data",
-        "Use a fixed learning rate across all scales"
-      ],
-      correct: 1,
+      options: ["Train all models for exactly one epoch regardless of size", "Use a fixed learning rate across all scales", "Keep model size fixed and only increase data", "Scale model size faster than dataset size — larger models are more sample-efficient, so allocate most additional compute to parameters"],
+      correct: 3,
       explanation: "Kaplan et al. found that loss decreases more steeply with model size than with data. Their recommendation was to scale $N$ faster than $D$ when compute grows — roughly $N \\propto C^{0.73}$ and $D \\propto C^{0.27}$. The Chinchilla paper later overturned this by showing the exponents were closer to equal."
     },
     {
       type: "mc",
       question: "The Chinchilla (Hoffmann et al., 2022) scaling law fundamentally revised Kaplan's recommendations. The compute-optimal prescription is approximately:",
-      options: [
-        "1 token per parameter — keep models large and data small",
-        "20 tokens per parameter — scale model size and data equally with compute",
-        "200 tokens per parameter — use vastly more data than parameters",
-        "The ratio does not matter as long as total FLOPs are fixed"
-      ],
-      correct: 1,
+      options: ["1 token per parameter — keep models large and data small", "200 tokens per parameter — use vastly more data than parameters", "20 tokens per parameter — scale model size and data equally with compute", "The ratio does not matter as long as total FLOPs are fixed"],
+      correct: 2,
       explanation: "Chinchilla showed the compute-optimal ratio is roughly 20 tokens per parameter. A 10B parameter model should train on ~200B tokens. This means Kaplan-era models like the original GPT-3 (175B parameters, 300B tokens, ~1.7 tokens/param) were significantly undertrained relative to their size."
     },
     {
       type: "mc",
       question: "Why did the Kaplan and Chinchilla scaling laws arrive at different compute-optimal allocations between model size $N$ and data $D$?",
-      options: [
-        "They used different model architectures (RNNs vs Transformers)",
-        "Kaplan did not tune the learning rate schedule for smaller token budgets, biasing results toward larger models appearing more efficient",
-        "Chinchilla used a larger vocabulary, making each token more informative",
-        "The two studies measured different loss functions"
-      ],
-      correct: 1,
+      options: ["Kaplan did not tune the learning rate schedule for smaller token budgets, biasing results toward larger models appearing more efficient", "They used different model architectures (RNNs vs Transformers)", "Chinchilla used a larger vocabulary, making each token more informative", "The two studies measured different loss functions"],
+      correct: 0,
       explanation: "A critical methodological issue: Kaplan used a fixed learning rate schedule (cosine decay over a long horizon) even for short runs with less data. This meant small-data runs were undertrained — not because they had too little data, but because their LR schedule was suboptimal. When Chinchilla properly tuned the schedule for each configuration, data turned out to be as valuable as model size."
     },
     {
@@ -63,37 +48,22 @@ export const scalingLawsAssessment = {
     {
       type: "mc",
       question: "Inference-aware scaling laws (e.g., Sardana & Frankle, 2024) modify the Chinchilla-optimal strategy by accounting for deployment costs. Their key recommendation is:",
-      options: [
-        "Use the largest possible model to minimize total training cost",
-        "Train a smaller-than-Chinchilla-optimal model on significantly more data, because inference cost scales with model size, not training data",
-        "Distill large models into small ones after Chinchilla-optimal training",
-        "Use quantization to make the Chinchilla-optimal model cheaper at inference"
-      ],
-      correct: 1,
+      options: ["Use the largest possible model to minimize total training cost", "Use quantization to make the Chinchilla-optimal model cheaper at inference", "Distill large models into small ones after Chinchilla-optimal training", "Train a smaller-than-Chinchilla-optimal model on significantly more data, because inference cost scales with model size, not training data"],
+      correct: 3,
       explanation: "When you account for inference cost (which depends on model size but not training data), the optimal strategy shifts: train a smaller model on more data than Chinchilla prescribes. A model that is \"overtrained\" relative to Chinchilla is slightly worse in loss but much cheaper to serve. This is why Llama models train on far more tokens per parameter than Chinchilla suggests."
     },
     {
       type: "mc",
       question: "Power-law scaling of loss $L(C) = aC^{-\\alpha} + L_\\infty$ implies which of the following about the returns from increasing compute?",
-      options: [
-        "Each doubling of compute yields a constant absolute improvement in loss",
-        "Each doubling of compute yields diminishing absolute improvements — you get a fixed multiplicative reduction in reducible loss $L - L_\\infty$",
-        "There is a critical compute threshold beyond which loss drops suddenly",
-        "Returns are increasing — larger models improve faster per FLOP"
-      ],
-      correct: 1,
+      options: ["Each doubling of compute yields a constant absolute improvement in loss", "There is a critical compute threshold beyond which loss drops suddenly", "Each doubling of compute yields diminishing absolute improvements — you get a fixed multiplicative reduction in reducible loss $L - L_\\infty$", "Returns are increasing — larger models improve faster per FLOP"],
+      correct: 2,
       explanation: "A power law $L - L_\\infty \\propto C^{-\\alpha}$ means doubling compute multiplies the reducible loss by $2^{-\\alpha}$ — a constant fractional reduction. In absolute terms, each doubling gives less improvement because $L - L_\\infty$ is shrinking. There are no sudden thresholds or increasing returns; the curve is smooth and concave on a log-log plot."
     },
     {
       type: "mc",
       question: "Scaling laws predict pretraining loss, but practitioners care about downstream task performance. Research on predicting downstream capabilities from loss has found:",
-      options: [
-        "Downstream task accuracy is a simple linear function of loss",
-        "There is no relationship between pretraining loss and downstream tasks",
-        "Average downstream accuracy often improves smoothly with loss, but individual tasks can show sharp \"emergent\" transitions when measured with nonlinear metrics like exact-match accuracy",
-        "Downstream performance follows the same power law exponent as training loss"
-      ],
-      correct: 2,
+      options: ["Average downstream accuracy often improves smoothly with loss, but individual tasks can show sharp \"emergent\" transitions when measured with nonlinear metrics like exact-match accuracy", "There is no relationship between pretraining loss and downstream tasks", "Downstream task accuracy is a simple linear function of loss", "Downstream performance follows the same power law exponent as training loss"],
+      correct: 0,
       explanation: "The relationship between loss and downstream performance is nuanced. Schaeffer et al. (2023) showed that \"emergence\" often arises from the choice of metric: exact-match accuracy is a nonlinear, threshold-like function of per-token probabilities. When you switch to smoother metrics (like Brier score or token-level probability), performance improves continuously. But some tasks genuinely require a threshold level of capability."
     },
     {
@@ -111,25 +81,15 @@ export const scalingLawsAssessment = {
     {
       type: "mc",
       question: "The irreducible loss $L_\\infty$ in scaling laws $L = aC^{-\\alpha} + L_\\infty$ corresponds to:",
-      options: [
-        "The loss achieved by the largest model ever trained",
-        "The entropy of the data distribution — the theoretical minimum loss achievable by any model, reflecting inherent noise and ambiguity in the data",
-        "The loss of a randomly initialized model",
-        "Zero, since a sufficiently large model can memorize any dataset"
-      ],
-      correct: 1,
+      options: ["The loss achieved by the largest model ever trained", "Zero, since a sufficiently large model can memorize any dataset", "The loss of a randomly initialized model", "The entropy of the data distribution — the theoretical minimum loss achievable by any model, reflecting inherent noise and ambiguity in the data"],
+      correct: 3,
       explanation: "The irreducible loss represents the Bayes-optimal loss: the entropy $H(P)$ of the true data distribution. No model can beat this because the data itself contains inherent randomness (e.g., multiple valid next tokens in natural language). Estimating $L_\\infty$ is important for understanding how much room for improvement remains, but it's difficult to measure precisely in practice."
     },
     {
       type: "mc",
       question: "When using $\\mu$P to transfer hyperparameters from a small proxy model to a large target model, which of the following must change with model width $d$?",
-      options: [
-        "The learning rate — it must decrease as $1/d$",
-        "The initialization scale of weight matrices — input and output layers use different scaling than hidden layers, with specific $1/\\sqrt{d}$ and $1/d$ prescriptions",
-        "The batch size — it must scale linearly with $d$",
-        "Nothing changes — that is the entire point of $\\mu$P"
-      ],
-      correct: 1,
+      options: ["The learning rate — it must decrease as $1/d$", "The batch size — it must scale linearly with $d$", "The initialization scale of weight matrices — input and output layers use different scaling than hidden layers, with specific $1/\\sqrt{d}$ and $1/d$ prescriptions", "Nothing changes — that is the entire point of $\\mu$P"],
+      correct: 2,
       explanation: "In $\\mu$P, the initialization scales and per-layer learning rate multipliers are set so that activations, gradients, and updates remain $\\Theta(1)$ as width varies. Different layer types (input embeddings, hidden layers, output layer) require different scaling rules. The point is not that nothing changes — it is that the *optimal learning rate* stays the same, while the parameterization itself adapts via prescribed initialization and multiplier rules."
     }
   ]
@@ -149,13 +109,8 @@ export const architectureAssessment = {
     {
       type: "mc",
       question: "In a Mixture-of-Experts (MoE) Transformer, the gating network selects a subset of expert FFN layers for each token. The primary computational advantage is:",
-      options: [
-        "The attention layers become cheaper because experts handle most computation",
-        "Total parameters increase but FLOPs per token stay constant — only $k$ of $E$ experts activate per token, decoupling parameter count from compute cost",
-        "Experts share weights, reducing memory requirements",
-        "The vocabulary size can be reduced because experts specialize in different token types"
-      ],
-      correct: 1,
+      options: ["Total parameters increase but FLOPs per token stay constant — only $k$ of $E$ experts activate per token, decoupling parameter count from compute cost", "The attention layers become cheaper because experts handle most computation", "Experts share weights, reducing memory requirements", "The vocabulary size can be reduced because experts specialize in different token types"],
+      correct: 0,
       explanation: "MoE decouples model capacity (total parameters) from per-token compute. A model with $E$ experts but top-$k$ routing uses $k/E$ of the FFN FLOPs per token. For example, Mixtral 8x7B has ~47B total parameters but uses only ~13B per token (top-2 of 8 experts). The attention layers are unchanged."
     },
     {
@@ -173,37 +128,22 @@ export const architectureAssessment = {
     {
       type: "mc",
       question: "Standard self-attention computes $\\text{Softmax}(QK^\\top / \\sqrt{d})V$, which is $O(n^2 d)$ in sequence length $n$. Linear attention replaces this with $\\phi(Q)(\\phi(K)^\\top V)$, achieving $O(nd^2)$. Why does linear attention underperform standard attention on retrieval-intensive tasks?",
-      options: [
-        "Linear attention cannot represent positional information",
-        "The kernel feature map $\\phi$ compresses the key-query interaction into a fixed-size matrix $\\phi(K)^\\top V \\in \\mathbb{R}^{d \\times d}$, which cannot store and retrieve arbitrary token-level associations from a long context",
-        "Linear attention uses fewer parameters than standard attention",
-        "Linear attention cannot be parallelized during training"
-      ],
-      correct: 1,
+      options: ["Linear attention cannot represent positional information", "Linear attention cannot be parallelized during training", "Linear attention uses fewer parameters than standard attention", "The kernel feature map $\\phi$ compresses the key-query interaction into a fixed-size matrix $\\phi(K)^\\top V \\in \\mathbb{R}^{d \\times d}$, which cannot store and retrieve arbitrary token-level associations from a long context"],
+      correct: 3,
       explanation: "By associating right-to-left, linear attention maintains a $d \\times d$ state matrix that accumulates key-value associations. This is a fixed-size bottleneck regardless of sequence length — it cannot perfectly store $n$ distinct key-value pairs when $n > d$. Standard attention computes each query against all keys explicitly, enabling precise retrieval. This is why hybrid architectures pair linear attention (for efficiency) with some standard attention layers (for retrieval)."
     },
     {
       type: "mc",
       question: "Mamba and S4 are examples of state-space models (SSMs) for sequence modeling. Their key structural property, compared to Transformers, is:",
-      options: [
-        "They use convolutions instead of any recurrence, making them purely feedforward",
-        "They model sequences through a latent continuous-time dynamical system $\\dot{h}(t) = Ah(t) + Bx(t)$, discretized for efficiency, enabling linear-time sequence processing with a fixed-size hidden state",
-        "They replace attention with graph neural networks over token dependency trees",
-        "They use external memory modules to store long-range dependencies"
-      ],
-      correct: 1,
+      options: ["They use convolutions instead of any recurrence, making them purely feedforward", "They replace attention with graph neural networks over token dependency trees", "They model sequences through a latent continuous-time dynamical system $\\dot{h}(t) = Ah(t) + Bx(t)$, discretized for efficiency, enabling linear-time sequence processing with a fixed-size hidden state", "They use external memory modules to store long-range dependencies"],
+      correct: 2,
       explanation: "SSMs are grounded in continuous-time state-space equations: $\\dot{h} = Ah + Bx$, $y = Ch + Dx$. After discretization, these become linear recurrences that can be computed as convolutions during training (parallelizable) or step-by-step during inference (efficient autoregressive generation). Mamba adds input-dependent (selective) gating to the $A$, $B$, $C$ matrices, which is crucial for content-based reasoning."
     },
     {
       type: "mc",
       question: "What distinguishes Mamba's \"selective\" state-space mechanism from the original S4 model?",
-      options: [
-        "Mamba uses a larger state dimension",
-        "Mamba makes the SSM parameters ($B$, $C$, and $\\Delta$) input-dependent, allowing the model to selectively filter or retain information based on content rather than using fixed dynamics",
-        "Mamba replaces the HiPPO initialization with random initialization",
-        "Mamba adds self-attention layers between SSM layers"
-      ],
-      correct: 1,
+      options: ["Mamba makes the SSM parameters ($B$, $C$, and $\\Delta$) input-dependent, allowing the model to selectively filter or retain information based on content rather than using fixed dynamics", "Mamba uses a larger state dimension", "Mamba replaces the HiPPO initialization with random initialization", "Mamba adds self-attention layers between SSM layers"],
+      correct: 0,
       explanation: "S4's $A$, $B$, $C$ matrices are fixed (input-independent) — the same dynamics apply to every input. Mamba makes $B$, $C$, and the discretization step $\\Delta$ functions of the input, enabling content-aware filtering. This selectivity is analogous to gating in LSTMs and is essential for tasks that require ignoring irrelevant tokens. The cost is losing the convolution-mode parallelism of S4, which Mamba compensates with a hardware-aware scan algorithm."
     },
     {
@@ -221,37 +161,22 @@ export const architectureAssessment = {
     {
       type: "mc",
       question: "The load-balancing auxiliary loss used in MoE training typically takes the form $\\mathcal{L}_{\\text{aux}} = \\alpha \\cdot E \\cdot \\sum_{i=1}^{E} f_i \\cdot p_i$, where $f_i$ is the fraction of tokens routed to expert $i$ and $p_i$ is the average router probability for expert $i$. Why is this formulation used instead of directly penalizing the variance of $f_i$?",
-      options: [
-        "Variance penalization would be too expensive to compute",
-        "The $f_i \\cdot p_i$ product is differentiable with respect to the router's logits (through $p_i$), whereas $f_i$ alone involves a non-differentiable argmax/top-k selection",
-        "Variance penalization would force all experts to be identical",
-        "The $f_i \\cdot p_i$ formulation also regularizes the expert weights"
-      ],
-      correct: 1,
+      options: ["Variance penalization would be too expensive to compute", "The $f_i \\cdot p_i$ formulation also regularizes the expert weights", "Variance penalization would force all experts to be identical", "The $f_i \\cdot p_i$ product is differentiable with respect to the router's logits (through $p_i$), whereas $f_i$ alone involves a non-differentiable argmax/top-k selection"],
+      correct: 3,
       explanation: "The token-to-expert assignment $f_i$ involves discrete top-$k$ selection, which is not differentiable. But the router probability $p_i$ (the softmax output before the discrete decision) is differentiable. By multiplying $f_i \\cdot p_i$, the gradient flows through $p_i$ to update the router, encouraging it to spread probability mass more evenly. Minimizing $\\sum f_i p_i$ is minimized when both fractions and probabilities are uniform ($1/E$ each)."
     },
     {
       type: "mc",
       question: "Hybrid architectures that combine attention with linear recurrences (e.g., Jamba, Griffin) typically interleave the two layer types. The design rationale is:",
-      options: [
-        "Attention layers are used only in the first few layers for position encoding",
-        "Attention provides precise in-context retrieval for tasks that need it, while recurrent layers provide efficient long-range context compression — the hybrid gets both capabilities at lower total cost than pure attention",
-        "Recurrent layers are only needed during inference for caching",
-        "The combination enables the model to process images and text simultaneously"
-      ],
-      correct: 1,
+      options: ["Attention layers are used only in the first few layers for position encoding", "Recurrent layers are only needed during inference for caching", "Attention provides precise in-context retrieval for tasks that need it, while recurrent layers provide efficient long-range context compression — the hybrid gets both capabilities at lower total cost than pure attention", "The combination enables the model to process images and text simultaneously"],
+      correct: 2,
       explanation: "Pure recurrent models (Mamba, RWKV) struggle with tasks requiring precise recall from long contexts (e.g., \"what was the 3rd item in the list?\") because their fixed-size state compresses information. Pure attention is $O(n^2)$. Hybrids use a few attention layers (often every 4th or 8th layer) to handle retrieval while the recurrent layers efficiently process the majority of the context at $O(n)$ cost."
     },
     {
       type: "mc",
       question: "Early exit strategies in Transformer inference allow the model to produce an output token from an intermediate layer rather than processing through all $L$ layers. A key practical challenge is:",
-      options: [
-        "Early layers do not have enough parameters to make predictions",
-        "The hidden representations at early layers live in a different space than what the final output head expects, requiring either separate output heads per layer or representation alignment techniques that add training complexity",
-        "Early exit requires a different tokenizer for each exit point",
-        "Gradient computation is impossible with early exit during training"
-      ],
-      correct: 1,
+      options: ["The hidden representations at early layers live in a different space than what the final output head expects, requiring either separate output heads per layer or representation alignment techniques that add training complexity", "Early layers do not have enough parameters to make predictions", "Early exit requires a different tokenizer for each exit point", "Gradient computation is impossible with early exit during training"],
+      correct: 0,
       explanation: "The output projection (unembedding) is trained against the final layer's representations. Intermediate representations may not yet encode the information needed for prediction, or may encode it in a different subspace. Solutions include: training separate lightweight classifiers at each potential exit layer, using shared output heads with representation alignment losses, or \"overthinking\" classifiers that decide when additional layers would not change the prediction."
     },
     {
@@ -283,37 +208,22 @@ export const dataCentricAssessment = {
     {
       type: "mc",
       question: "Influence functions estimate how a model's prediction would change if a specific training example were removed (or upweighted). The classic formula involves $\\mathcal{I}(z, z_{\\text{test}}) = -\\nabla_\\theta \\ell(z_{\\text{test}})^\\top H_\\theta^{-1} \\nabla_\\theta \\ell(z)$. Why do influence functions not scale to modern LLMs?",
-      options: [
-        "The loss function of LLMs is not twice-differentiable",
-        "Computing or approximating the inverse Hessian $H_\\theta^{-1}$ is intractable for billions of parameters, and the quadratic approximation breaks down in the non-convex, overparameterized regime where LLMs operate",
-        "Influence functions require the model to be trained to convergence, which LLMs never achieve",
-        "The gradient $\\nabla_\\theta \\ell(z)$ is always zero at the optimum"
-      ],
-      correct: 1,
+      options: ["The loss function of LLMs is not twice-differentiable", "The gradient $\\nabla_\\theta \\ell(z)$ is always zero at the optimum", "Influence functions require the model to be trained to convergence, which LLMs never achieve", "Computing or approximating the inverse Hessian $H_\\theta^{-1}$ is intractable for billions of parameters, and the quadratic approximation breaks down in the non-convex, overparameterized regime where LLMs operate"],
+      correct: 3,
       explanation: "The Hessian $H_\\theta$ is an $N \\times N$ matrix where $N$ is the parameter count — storing it is impossible for LLMs (e.g., $70\\text{B}^2$ entries). Even Hessian-vector product approximations (like LiSSA) are noisy and expensive. Furthermore, influence functions assume a convex loss landscape near the optimum, which does not hold for deep networks. Recent work (TRAK, datamodels) uses random projection-based approximations that trade fidelity for scalability."
     },
     {
       type: "mc",
       question: "Data attribution methods like TRAK (Tracing with Randomly-projected After Kernel) address the scalability limitations of influence functions by:",
-      options: [
-        "Using only the first-order gradient without any Hessian information",
-        "Projecting per-example gradients into a low-dimensional random subspace, then computing attribution scores via a linear model in that projected space — trading exact inverse-Hessian computation for tractable random projections",
-        "Training a separate neural network to predict influence scores",
-        "Computing influence only for the last layer of the model"
-      ],
-      correct: 1,
+      options: ["Using only the first-order gradient without any Hessian information", "Training a separate neural network to predict influence scores", "Projecting per-example gradients into a low-dimensional random subspace, then computing attribution scores via a linear model in that projected space — trading exact inverse-Hessian computation for tractable random projections", "Computing influence only for the last layer of the model"],
+      correct: 2,
       explanation: "TRAK projects the high-dimensional gradient vectors $\\nabla_\\theta \\ell(z) \\in \\mathbb{R}^N$ down to $\\mathbb{R}^k$ (with $k \\ll N$) using random matrices. In this compressed space, it fits a linear model that predicts test loss from training example features. This is motivated by the neural tangent kernel (NTK) perspective: near convergence, the model behaves approximately linearly in the projected gradient space. TRAK is orders of magnitude cheaper than exact influence functions."
     },
     {
       type: "mc",
       question: "DSIR (Data Selection with Importance Resampling) selects pretraining data that resembles a target distribution. The core mechanism is:",
-      options: [
-        "Training a classifier to label data as \"good\" or \"bad\" and keeping only positives",
-        "Computing importance weights $w(x) = p_{\\text{target}}(x) / p_{\\text{source}}(x)$ using n-gram language model ratios, then resampling the source corpus according to these weights",
-        "Clustering the data and selecting clusters closest to the target centroid",
-        "Using perplexity under a target-domain LM as the sole selection criterion"
-      ],
-      correct: 1,
+      options: ["Computing importance weights $w(x) = p_{\\text{target}}(x) / p_{\\text{source}}(x)$ using n-gram language model ratios, then resampling the source corpus according to these weights", "Training a classifier to label data as \"good\" or \"bad\" and keeping only positives", "Clustering the data and selecting clusters closest to the target centroid", "Using perplexity under a target-domain LM as the sole selection criterion"],
+      correct: 0,
       explanation: "DSIR fits lightweight n-gram models to both the target domain and the source corpus, then computes importance weights as the density ratio. Data points that are more likely under the target distribution (relative to the source) get upweighted. Resampling according to these weights yields a subset whose distribution approximates the target. This is much cheaper than training a neural classifier, and importance resampling has well-understood statistical properties."
     },
     {
@@ -331,37 +241,22 @@ export const dataCentricAssessment = {
     {
       type: "mc",
       question: "Catastrophic forgetting in continual pretraining occurs when a model fine-tuned on domain-specific data loses its general capabilities. Which of the following is NOT a standard mitigation strategy?",
-      options: [
-        "Mixing domain-specific data with a fraction of the original pretraining distribution during continued training",
-        "Using elastic weight consolidation (EWC) or similar regularization that penalizes changes to parameters important for previous tasks",
-        "Training on the new domain for exactly one epoch to prevent overfitting",
-        "Replaying a small buffer of original pretraining data alongside the new data"
-      ],
-      correct: 2,
+      options: ["Mixing domain-specific data with a fraction of the original pretraining distribution during continued training", "Using elastic weight consolidation (EWC) or similar regularization that penalizes changes to parameters important for previous tasks", "Replaying a small buffer of original pretraining data alongside the new data", "Training on the new domain for exactly one epoch to prevent overfitting"],
+      correct: 3,
       explanation: "Training for exactly one epoch is not a principled forgetting mitigation — forgetting depends on the degree of distribution shift, not epochs. The other three are well-established approaches: data mixing (most common in practice), EWC-style regularization (penalizes parameter drift weighted by Fisher information), and replay buffers (store and interleave old examples). In practice, simple data mixing (e.g., 90% domain + 10% general) is the most widely used because it is effective and easy to implement."
     },
     {
       type: "mc",
       question: "Learning rate rewarming is a technique used when continuing pretraining on a new data distribution. The practice involves:",
-      options: [
-        "Resetting the learning rate to its initial maximum and repeating the full warmup + decay schedule",
-        "Briefly increasing the learning rate back to a moderate value before decaying again, which helps the model escape the loss basin of the original training distribution and adapt to the new data",
-        "Using a constant learning rate throughout continual pretraining",
-        "Reducing the learning rate to near zero to prevent catastrophic forgetting"
-      ],
-      correct: 1,
+      options: ["Resetting the learning rate to its initial maximum and repeating the full warmup + decay schedule", "Using a constant learning rate throughout continual pretraining", "Briefly increasing the learning rate back to a moderate value before decaying again, which helps the model escape the loss basin of the original training distribution and adapt to the new data", "Reducing the learning rate to near zero to prevent catastrophic forgetting"],
+      correct: 2,
       explanation: "After pretraining, the LR has decayed to a very small value. If you continue training at this low LR on new data, the model adapts very slowly. Rewarming briefly raises the LR (typically not to the original maximum, but to a meaningful fraction) and then decays again. This lets the model move away from its current minimum to better accommodate the new distribution. The Gupta et al. (2023) work on continual pretraining found rewarming essential for efficient adaptation."
     },
     {
       type: "mc",
       question: "When building a domain-specific LLM (e.g., for biomedicine), you can either (A) pretrain from scratch on domain data, or (B) continue pretraining a general-purpose LLM on domain data. Which statement is most accurate?",
-      options: [
-        "From-scratch pretraining always produces superior domain models because the tokenizer is domain-optimized",
-        "Continued pretraining is almost always more compute-efficient: general LLMs have already learned syntax, reasoning, and world knowledge that transfers to the domain, so domain adaptation requires far fewer tokens than learning everything from scratch",
-        "The two approaches yield identical results given the same total compute",
-        "Continued pretraining cannot work because the tokenizer does not have domain-specific tokens"
-      ],
-      correct: 1,
+      options: ["Continued pretraining is almost always more compute-efficient: general LLMs have already learned syntax, reasoning, and world knowledge that transfers to the domain, so domain adaptation requires far fewer tokens than learning everything from scratch", "From-scratch pretraining always produces superior domain models because the tokenizer is domain-optimized", "The two approaches yield identical results given the same total compute", "Continued pretraining cannot work because the tokenizer does not have domain-specific tokens"],
+      correct: 0,
       explanation: "Continued pretraining leverages transfer learning: a 7B model pretrained on 2T tokens has learned language structure, reasoning patterns, and broad knowledge. Adapting it to biomedicine with 50-100B domain tokens is far cheaper than training a biomedical model from scratch on hundreds of billions of tokens. The tokenizer concern is real but secondary — subword tokenizers handle unseen terms by decomposition, and domain terms can be added. Models like BioMedLM, PMC-LLaMA, and SciLLM all use continued pretraining."
     },
     {
@@ -379,13 +274,8 @@ export const dataCentricAssessment = {
     {
       type: "mc",
       question: "In the context of data quality filtering for pretraining, a perplexity-based filter uses a reference language model to score each document. What is a known failure mode of naive perplexity filtering?",
-      options: [
-        "It cannot process documents longer than the reference model's context window",
-        "It systematically biases the pretraining data toward the style and domain of the reference model's training data — e.g., a Wikipedia-trained reference model will favor Wikipedia-like text and discard informal but informative content",
-        "It removes all non-English text regardless of quality",
-        "It is too slow to apply to web-scale corpora"
-      ],
-      correct: 1,
+      options: ["It cannot process documents longer than the reference model's context window", "It is too slow to apply to web-scale corpora", "It removes all non-English text regardless of quality", "It systematically biases the pretraining data toward the style and domain of the reference model's training data — e.g., a Wikipedia-trained reference model will favor Wikipedia-like text and discard informal but informative content"],
+      correct: 3,
       explanation: "A reference LM assigns low perplexity to text similar to its own training distribution. A Wikipedia-trained filter will favor encyclopedic prose and penalize code, dialogue, informal writing, and domain-specific jargon — all of which may be high-quality and valuable for a general-purpose LLM. The C4 dataset used a Wikipedia perplexity filter, which is now recognized as having been too aggressive. Modern pipelines use classifier-based quality scoring with more diverse positive examples."
     },
     {
@@ -417,13 +307,8 @@ export const trainingDynamicsAssessment = {
     {
       type: "mc",
       question: "The \"edge of stability\" phenomenon (Cohen et al., 2021) in gradient descent training describes a regime where:",
-      options: [
-        "Training loss oscillates wildly but validation loss remains stable",
-        "The sharpness (largest eigenvalue of the Hessian) rises until it reaches $\\approx 2/\\eta$ (where $\\eta$ is the learning rate), then oscillates around this threshold while loss continues to decrease non-monotonically",
-        "The model parameters reach a critical point where any perturbation causes divergence",
-        "Batch normalization causes gradient norms to hover at a fixed value"
-      ],
-      correct: 1,
+      options: ["The sharpness (largest eigenvalue of the Hessian) rises until it reaches $\\approx 2/\\eta$ (where $\\eta$ is the learning rate), then oscillates around this threshold while loss continues to decrease non-monotonically", "Training loss oscillates wildly but validation loss remains stable", "The model parameters reach a critical point where any perturbation causes divergence", "Batch normalization causes gradient norms to hover at a fixed value"],
+      correct: 0,
       explanation: "Classical optimization theory predicts divergence when sharpness exceeds $2/\\eta$. Instead, Cohen et al. observed that full-batch GD on neural networks enters a regime where sharpness self-stabilizes at $\\approx 2/\\eta$: when it exceeds this threshold, the loss temporarily increases (the optimizer takes steps that are \"too large\"), which modifies the landscape to reduce sharpness back below the threshold. This is not predicted by convex optimization theory and suggests GD implicitly regularizes toward flatter minima."
     },
     {
@@ -453,37 +338,22 @@ export const trainingDynamicsAssessment = {
     {
       type: "mc",
       question: "The formation of induction heads during training exhibits a phase transition. What does this mean concretely?",
-      options: [
-        "Induction heads form instantly at initialization",
-        "There is a sudden, discrete jump in in-context learning ability at a specific point during training, with the loss on repeated-pattern tasks dropping sharply over a narrow window of training steps rather than improving gradually",
-        "The model alternates between having and not having induction heads as training progresses",
-        "Induction heads form only if the model has more than 12 layers"
-      ],
-      correct: 1,
+      options: ["Induction heads form instantly at initialization", "Induction heads form only if the model has more than 12 layers", "The model alternates between having and not having induction heads as training progresses", "There is a sudden, discrete jump in in-context learning ability at a specific point during training, with the loss on repeated-pattern tasks dropping sharply over a narrow window of training steps rather than improving gradually"],
+      correct: 3,
       explanation: "Olsson et al. observed that in-context learning ability (measured by how much loss decreases from the first to the second occurrence of a pattern) remains near zero for many training steps, then rapidly improves over a narrow window. This coincides with the formation of the induction head circuit. This is a genuine phase transition — a qualitative change in capability emerging suddenly from continuous optimization. It's one of the clearest examples of emergent capability in a controlled setting."
     },
     {
       type: "mc",
       question: "Loss landscape mode connectivity refers to the finding that:",
-      options: [
-        "All local minima have the same loss value",
-        "Different trained models (from different initializations) can often be connected by simple low-loss paths (e.g., linear or piecewise-linear) in weight space, suggesting they lie in the same broad basin or on the same loss-level set",
-        "The loss landscape is convex near any local minimum",
-        "Gradient descent always converges to the global minimum"
-      ],
-      correct: 1,
+      options: ["All local minima have the same loss value", "The loss landscape is convex near any local minimum", "Different trained models (from different initializations) can often be connected by simple low-loss paths (e.g., linear or piecewise-linear) in weight space, suggesting they lie in the same broad basin or on the same loss-level set", "Gradient descent always converges to the global minimum"],
+      correct: 2,
       explanation: "Mode connectivity (Garipov et al., 2018; Draxler et al., 2018) showed that independently trained models often lie in connected low-loss regions. While the straight line between two models in weight space may cross a loss barrier, a slightly curved path (found by optimization) often connects them with negligible loss increase. This suggests the loss landscape of overparameterized networks has a simpler structure than previously thought — most good minima are connected."
     },
     {
       type: "mc",
       question: "Mode connectivity has direct implications for model merging. When we average the weights of two fine-tuned models (linear interpolation $\\theta_{\\text{merged}} = \\alpha \\theta_1 + (1 - \\alpha) \\theta_2$), the merged model performs well only when:",
-      options: [
-        "Both models have the same number of parameters",
-        "The two models share a common pretrained initialization — this ensures they lie in the same basin of the loss landscape, making the linear interpolation path stay in a low-loss region",
-        "Both models were trained on identical data",
-        "The models use different optimizers to ensure diversity"
-      ],
-      correct: 1,
+      options: ["The two models share a common pretrained initialization — this ensures they lie in the same basin of the loss landscape, making the linear interpolation path stay in a low-loss region", "Both models have the same number of parameters", "Both models were trained on identical data", "The models use different optimizers to ensure diversity"],
+      correct: 0,
       explanation: "Models fine-tuned from the same pretrained checkpoint tend to remain in the same loss basin (the pretrained model acts as an \"anchor\"). Linear interpolation between them stays in the low-loss region. Models trained from different random initializations typically do NOT mode-connect linearly — there are loss barriers between their basins. This is why weight averaging works well for merging LoRA adapters or task-specific fine-tunes of the same base model, but fails for independently pretrained models."
     },
     {
@@ -501,37 +371,22 @@ export const trainingDynamicsAssessment = {
     {
       type: "mc",
       question: "In the context of $\\mu$P, what happens to the gradient dynamics of a standard (non-$\\mu$P) Transformer as you increase width $d$ while keeping learning rate fixed?",
-      options: [
-        "Gradients vanish because each weight contributes less to the output",
-        "The model enters the kernel (lazy) regime: weight updates become infinitesimally small relative to the random initialization, so internal representations stop learning meaningful features",
-        "Training speed doubles with each doubling of width",
-        "The model becomes more robust to learning rate choices"
-      ],
-      correct: 1,
+      options: ["Gradients vanish because each weight contributes less to the output", "The model becomes more robust to learning rate choices", "Training speed doubles with each doubling of width", "The model enters the kernel (lazy) regime: weight updates become infinitesimally small relative to the random initialization, so internal representations stop learning meaningful features"],
+      correct: 3,
       explanation: "Under standard parameterization (SP), if you keep the learning rate fixed and increase width, each weight's update contributes less to the output (because activations are averaged over more dimensions). In the infinite-width limit, this gives the Neural Tangent Kernel regime where the network is effectively linear around initialization. $\\mu$P rescales learning rates and initialization so that the contribution of each weight update to the output remains $\\Theta(1)$, preserving feature learning dynamics regardless of width."
     },
     {
       type: "mc",
       question: "The phenomenon of \"grokking\" in neural network training refers to:",
-      options: [
-        "The model failing to learn despite sufficient capacity",
-        "A delayed generalization pattern where the model first memorizes training data (achieving zero training loss with high test loss), then — much later in training — suddenly generalizes (test loss drops sharply), despite no change in training loss",
-        "Rapid learning in the first few steps followed by a plateau",
-        "The model learning multiple tasks simultaneously without interference"
-      ],
-      correct: 1,
+      options: ["The model failing to learn despite sufficient capacity", "Rapid learning in the first few steps followed by a plateau", "A delayed generalization pattern where the model first memorizes training data (achieving zero training loss with high test loss), then — much later in training — suddenly generalizes (test loss drops sharply), despite no change in training loss", "The model learning multiple tasks simultaneously without interference"],
+      correct: 2,
       explanation: "Grokking (Power et al., 2022) is a striking phenomenon where generalization occurs long after memorization. On modular arithmetic tasks, models achieve perfect training accuracy quickly, but test accuracy remains at chance for many more steps before suddenly jumping to near-perfect. This suggests the model transitions from a memorization solution to an algorithmic (generalizing) solution. Weight decay and regularization accelerate grokking, supporting the interpretation that regularization pressure eventually pushes the model toward the simpler, generalizing solution."
     },
     {
       type: "mc",
       question: "When training a large Transformer, practitioners often observe that the effective learning rate must be adjusted for different parts of the model. Which statement about per-layer learning rate dynamics is correct?",
-      options: [
-        "All layers should use exactly the same learning rate for optimal training",
-        "In standard training, earlier layers tend to have smaller gradients (and thus effectively lower learning rates under Adam), while attention logits and embedding layers require special handling (e.g., lower LR or normalization) to prevent instability",
-        "Later layers should always use a smaller learning rate because they are closer to the loss",
-        "Per-layer learning rates are only needed for models with more than 100B parameters"
-      ],
-      correct: 1,
+      options: ["In standard training, earlier layers tend to have smaller gradients (and thus effectively lower learning rates under Adam), while attention logits and embedding layers require special handling (e.g., lower LR or normalization) to prevent instability", "All layers should use exactly the same learning rate for optimal training", "Later layers should always use a smaller learning rate because they are closer to the loss", "Per-layer learning rates are only needed for models with more than 100B parameters"],
+      correct: 0,
       explanation: "The gradient magnitudes vary systematically across a Transformer: embedding layers and attention logits tend to grow disproportionately, contributing to instability. Adam's adaptive rates help but don't fully resolve this. Techniques like QK-LayerNorm (normalizing queries and keys), embedding scaling, and logit capping address specific problematic components. $\\mu$P provides a principled framework by prescribing per-layer multipliers that maintain consistent update scales. In practice, many large-scale training runs use lower learning rates for embeddings."
     }
   ]
@@ -563,37 +418,22 @@ export const novelObjectivesAssessment = {
     {
       type: "mc",
       question: "A key practical advantage of MLM over autoregressive LM during pretraining is:",
-      options: [
-        "MLM can use a smaller vocabulary",
-        "MLM processes all tokens bidirectionally — each masked position attends to both left and right context — which produces richer contextualized representations for downstream tasks that require understanding (e.g., classification, NER), and it achieves this with $T$ prediction tasks per sequence rather than requiring left-to-right factorization",
-        "MLM is faster at inference because it generates all tokens in parallel",
-        "MLM requires less training data because it uses each token more efficiently"
-      ],
-      correct: 1,
+      options: ["MLM can use a smaller vocabulary", "MLM requires less training data because it uses each token more efficiently", "MLM is faster at inference because it generates all tokens in parallel", "MLM processes all tokens bidirectionally — each masked position attends to both left and right context — which produces richer contextualized representations for downstream tasks that require understanding (e.g., classification, NER), and it achieves this with $T$ prediction tasks per sequence rather than requiring left-to-right factorization"],
+      correct: 3,
       explanation: "MLM's bidirectional context is its main strength for representation learning. When predicting a masked token, the model can use information from both sides, producing representations that capture the full context. Autoregressive models only see left context at each position. However, MLM only trains on the ~15% of tokens that are masked (the rest don't contribute to the loss), while autoregressive models get a gradient signal from every token. This makes autoregressive pretraining more compute-efficient per token."
     },
     {
       type: "mc",
       question: "UL2 (Unifying Language Learning Paradigms) proposes training a single model with multiple denoising objectives. Its core insight is:",
-      options: [
-        "Different downstream tasks benefit from different pretraining objectives (short spans for understanding, long spans for generation), so mixing multiple denoising tasks with mode-switching tokens creates a model that handles both regimes",
-        "A single denoising objective is always optimal if tuned properly",
-        "UL2 eliminates the need for fine-tuning by training on all possible task formats",
-        "UL2 uses reinforcement learning instead of maximum likelihood"
-      ],
-      correct: 0,
+      options: ["UL2 eliminates the need for fine-tuning by training on all possible task formats", "A single denoising objective is always optimal if tuned properly", "Different downstream tasks benefit from different pretraining objectives (short spans for understanding, long spans for generation), so mixing multiple denoising tasks with mode-switching tokens creates a model that handles both regimes", "UL2 uses reinforcement learning instead of maximum likelihood"],
+      correct: 2,
       explanation: "UL2 defines three denoising modes: R-denoiser (short spans, like BERT), S-denoiser (sequential/prefix LM), and X-denoiser (extreme/long spans). A special sentinel token tells the model which mode is active. The key insight is that no single denoising objective dominates across all downstream tasks — short-span denoising helps classification and NLU, while long-span and prefix modes help generation. By mixing modes, UL2 produces a single model competitive on both understanding and generation benchmarks."
     },
     {
       type: "mc",
       question: "Diffusion models have been highly successful for continuous data (images, audio). Why is applying diffusion to discrete text fundamentally harder?",
-      options: [
-        "Text sequences are too short for the diffusion process to work",
-        "Discrete data cannot be interpolated smoothly — there is no natural continuous noise process for tokens. Adding Gaussian noise to token embeddings destroys the discrete structure, and discrete corruption processes (e.g., random token replacement) lack the mathematical properties (e.g., known reverse process) that make continuous diffusion tractable",
-        "The vocabulary size is too large for the denoising network",
-        "Diffusion requires 2D spatial structure that text does not have"
-      ],
-      correct: 1,
+      options: ["Discrete data cannot be interpolated smoothly — there is no natural continuous noise process for tokens. Adding Gaussian noise to token embeddings destroys the discrete structure, and discrete corruption processes (e.g., random token replacement) lack the mathematical properties (e.g., known reverse process) that make continuous diffusion tractable", "Text sequences are too short for the diffusion process to work", "The vocabulary size is too large for the denoising network", "Diffusion requires 2D spatial structure that text does not have"],
+      correct: 0,
       explanation: "Continuous diffusion relies on gradually adding Gaussian noise and learning to reverse this process. For discrete tokens, there is no natural analog: you cannot \"slightly noise\" a token. Approaches include: (1) embedding tokens in continuous space and applying continuous diffusion (D3PM, Diffusion-LM), (2) using discrete corruption (token masking/replacement) as forward process (multinomial diffusion), or (3) score-matching on the simplex (MDLM). Each has trade-offs: continuous embeddings disconnect from the discrete structure; discrete corruption requires custom transition matrices."
     },
     {
@@ -611,37 +451,22 @@ export const novelObjectivesAssessment = {
     {
       type: "mc",
       question: "Energy-based models (EBMs) for text define an unnormalized density $p_\\theta(x) \\propto \\exp(-E_\\theta(x))$ over sequences. The central computational challenge of EBMs is:",
-      options: [
-        "The energy function $E_\\theta(x)$ is difficult to parameterize for text",
-        "Computing the normalizing constant $Z_\\theta = \\sum_x \\exp(-E_\\theta(x))$ requires summing over all possible sequences (exponential in length and vocabulary), making exact likelihood evaluation and gradient computation intractable",
-        "EBMs cannot assign different probabilities to different sequences",
-        "The energy function must be non-negative, which limits expressiveness"
-      ],
-      correct: 1,
+      options: ["The energy function $E_\\theta(x)$ is difficult to parameterize for text", "The energy function must be non-negative, which limits expressiveness", "EBMs cannot assign different probabilities to different sequences", "Computing the normalizing constant $Z_\\theta = \\sum_x \\exp(-E_\\theta(x))$ requires summing over all possible sequences (exponential in length and vocabulary), making exact likelihood evaluation and gradient computation intractable"],
+      correct: 3,
       explanation: "The partition function $Z_\\theta$ sums over all possible token sequences — $|V|^T$ terms for vocabulary $V$ and length $T$. This is astronomically intractable. Training EBMs requires approximations: contrastive divergence (MCMC sampling for negative examples), noise contrastive estimation (NCE), or score matching. For text specifically, MCMC sampling is difficult because the discrete space makes gradient-based sampling (Langevin dynamics) inapplicable. These challenges are why EBMs remain niche for text despite their theoretical elegance."
     },
     {
       type: "mc",
       question: "The prefix language modeling objective (used in T5 and UL2) treats part of the input as a bidirectional prefix and the rest as an autoregressive target. Compared to pure causal LM, this means:",
-      options: [
-        "The model has fewer parameters because the prefix encoder shares weights with the decoder",
-        "Tokens in the prefix attend to each other bidirectionally (full self-attention), while target tokens attend causally — this unifies the benefits of bidirectional encoding for the input context with autoregressive generation for the output",
-        "The prefix must always be exactly half the sequence length",
-        "Prefix LM cannot perform zero-shot generation"
-      ],
-      correct: 1,
+      options: ["The model has fewer parameters because the prefix encoder shares weights with the decoder", "The prefix must always be exactly half the sequence length", "Tokens in the prefix attend to each other bidirectionally (full self-attention), while target tokens attend causally — this unifies the benefits of bidirectional encoding for the input context with autoregressive generation for the output", "Prefix LM cannot perform zero-shot generation"],
+      correct: 2,
       explanation: "Prefix LM uses a single Transformer with a hybrid attention mask: prefix tokens see each other fully (bidirectional), target tokens see all prefix tokens plus previous target tokens (causal). This is strictly more expressive than causal LM for the prefix portion (which benefits from bidirectional context) while maintaining valid autoregressive generation for the target. It is a natural fit for conditional generation tasks (question$\\rightarrow$answer, document$\\rightarrow$summary) where the input benefits from bidirectional encoding."
     },
     {
       type: "mc",
       question: "Noise contrastive estimation (NCE) has been proposed as an alternative to maximum likelihood for training language models. NCE trains the model to distinguish real data from noise samples. Why has NCE not replaced cross-entropy for large-scale LM pretraining?",
-      options: [
-        "NCE produces a discriminator, not a generator, so it cannot be used for text generation",
-        "NCE requires the noise distribution to be close to the data distribution for efficient learning, but designing such a noise distribution for natural language is itself a hard problem — and NCE's statistical efficiency degrades with vocabulary size, requiring many noise samples per data point",
-        "NCE cannot be combined with Transformer architectures",
-        "NCE requires labeled data"
-      ],
-      correct: 1,
+      options: ["NCE requires the noise distribution to be close to the data distribution for efficient learning, but designing such a noise distribution for natural language is itself a hard problem — and NCE's statistical efficiency degrades with vocabulary size, requiring many noise samples per data point", "NCE produces a discriminator, not a generator, so it cannot be used for text generation", "NCE cannot be combined with Transformer architectures", "NCE requires labeled data"],
+      correct: 0,
       explanation: "NCE converts density estimation into binary classification: real vs. noise. The quality of the noise distribution matters enormously — if noise is too different from data, the classification is trivial and uninformative; if too similar, training is slow. For LLMs with vocabulary sizes of 30K-100K, NCE needs $k$ noise samples per real token (where $k$ should ideally grow with $|V|$), making it less efficient than the softmax cross-entropy loss which processes the entire vocabulary in one shot via the log-sum-exp. Modern hardware makes full-vocabulary softmax feasible."
     },
     {
@@ -659,13 +484,8 @@ export const novelObjectivesAssessment = {
     {
       type: "mc",
       question: "The \"exposure bias\" problem in autoregressive language models refers to the discrepancy between training and inference. Specifically:",
-      options: [
-        "The model is exposed to too much data during training",
-        "During training the model conditions on ground-truth previous tokens (teacher forcing), but during inference it conditions on its own predictions — errors compound because the model never learns to recover from its own mistakes",
-        "The model is biased toward frequent tokens in the training data",
-        "Longer sequences receive more gradient updates, biasing the model toward verbose outputs"
-      ],
-      correct: 1,
+      options: ["The model is exposed to too much data during training", "Longer sequences receive more gradient updates, biasing the model toward verbose outputs", "The model is biased toward frequent tokens in the training data", "During training the model conditions on ground-truth previous tokens (teacher forcing), but during inference it conditions on its own predictions — errors compound because the model never learns to recover from its own mistakes"],
+      correct: 3,
       explanation: "Teacher forcing provides ground-truth context during training: $P(x_t \\mid x_1^*, \\dots, x_{t-1}^*)$. At inference, the model generates $P(x_t \\mid \\hat{x}_1, \\dots, \\hat{x}_{t-1})$ where $\\hat{x}$ are its own (potentially erroneous) predictions. The distribution of contexts at inference differs from training, causing errors to accumulate. Scheduled sampling (mixing ground-truth and model predictions during training) partially addresses this, and it is one motivation for non-autoregressive and diffusion-based alternatives. In practice, exposure bias is less damaging for very large LLMs because their per-token error rate is low."
     }
   ]

--- a/src/modules/assess-branch-cd.js
+++ b/src/modules/assess-branch-cd.js
@@ -17,73 +17,43 @@ export const quantizationAssessment = {
     {
       type: "mc",
       question: "In post-training quantization (PTQ), weights are quantized **after** training is complete. Quantization-aware training (QAT) instead:",
-      options: [
-        "Trains a separate smaller model from scratch",
-        "Simulates quantization effects during training via straight-through estimators so the model learns to be robust to reduced precision",
-        "Quantizes only the optimizer states, not the model weights",
-        "Uses lower learning rates to compensate for precision loss"
-      ],
-      correct: 1,
+      options: ["Trains a separate smaller model from scratch", "Quantizes only the optimizer states, not the model weights", "Simulates quantization effects during training via straight-through estimators so the model learns to be robust to reduced precision", "Uses lower learning rates to compensate for precision loss"],
+      correct: 2,
       explanation: "QAT inserts fake-quantization nodes during training that round weights/activations to the target precision in the forward pass but pass gradients through unmodified (straight-through estimator). The model thus learns weight configurations that are robust to quantization noise. QAT typically recovers 0.5-1.0 perplexity points over PTQ but requires a full training run, making it far more expensive."
     },
     {
       type: "mc",
       question: "Activation quantization is generally harder than weight quantization because:",
-      options: [
-        "Activations use more memory than weights",
-        "Activations exhibit **outlier features** — a small number of hidden dimensions have magnitudes 10-100x larger than the rest, making uniform quantization waste most of its range on a few extreme values",
-        "Activations are always stored in float64",
-        "The backward pass requires full-precision activations"
-      ],
-      correct: 1,
+      options: ["Activations use more memory than weights", "The backward pass requires full-precision activations", "Activations are always stored in float64", "Activations exhibit **outlier features** — a small number of hidden dimensions have magnitudes 10-100x larger than the rest, making uniform quantization waste most of its range on a few extreme values"],
+      correct: 3,
       explanation: "Research (e.g., LLM.int8(), SmoothQuant) showed that transformer activations contain persistent outlier dimensions with magnitudes far exceeding the typical range. A uniform INT8 grid spanning $[-100, 100]$ to accommodate outliers wastes precision for the majority of values clustered near $[-1, 1]$. SmoothQuant addresses this by mathematically migrating the quantization difficulty from activations to weights via per-channel scaling: $Y = (X \\cdot \\text{diag}(s)^{-1}) \\cdot (\\text{diag}(s) \\cdot W)$."
     },
     {
       type: "mc",
       question: "GPTQ is a popular weight quantization method. Its core strategy is:",
-      options: [
-        "Training from scratch with quantized weights",
-        "Quantizing all weights simultaneously with k-means clustering",
-        "Quantizing weights **column by column**, using the inverse Hessian to optimally adjust remaining weights to compensate for each column's quantization error",
-        "Pruning weights below a threshold, then quantizing the rest"
-      ],
-      correct: 2,
+      options: ["Training from scratch with quantized weights", "Quantizing weights **column by column**, using the inverse Hessian to optimally adjust remaining weights to compensate for each column's quantization error", "Quantizing all weights simultaneously with k-means clustering", "Pruning weights below a threshold, then quantizing the rest"],
+      correct: 1,
       explanation: "GPTQ extends the Optimal Brain Quantization framework. It processes weight columns sequentially: after quantizing one column, it uses the inverse Hessian $H^{-1}$ of the layer's reconstruction loss to compute the optimal update to all not-yet-quantized columns, minimizing $\\|WX - \\hat{W}X\\|^2$. This Hessian-guided error compensation is what makes GPTQ achieve much better quality than naive round-to-nearest at 4-bit and below."
     },
     {
       type: "mc",
       question: "AWQ (Activation-Aware Weight Quantization) differs from GPTQ by focusing on:",
-      options: [
-        "Quantizing activations instead of weights",
-        "Identifying the small fraction of **salient weight channels** (those corresponding to large activation magnitudes) and protecting them with per-channel scaling before quantization, rather than using Hessian-based error compensation",
-        "Using 8-bit instead of 4-bit quantization",
-        "Training a separate quantization network"
-      ],
-      correct: 1,
+      options: ["Identifying the small fraction of **salient weight channels** (those corresponding to large activation magnitudes) and protecting them with per-channel scaling before quantization, rather than using Hessian-based error compensation", "Quantizing activations instead of weights", "Using 8-bit instead of 4-bit quantization", "Training a separate quantization network"],
+      correct: 0,
       explanation: "AWQ observes that only ~1% of weight channels are critical — those connected to activation outlier features. Rather than expensive Hessian computation, AWQ finds per-channel scaling factors $s$ that protect salient channels: it scales weights by $s$ and inversely scales activations, shifting the quantization difficulty away from important channels. This is simpler than GPTQ and often matches or exceeds its quality with faster quantization time."
     },
     {
       type: "mc",
       question: "A model uses mixed-precision quantization: some layers at 4-bit, others at 8-bit. The decision of which layers get higher precision is typically based on:",
-      options: [
-        "Layer index — earlier layers always need more precision",
-        "**Per-layer sensitivity analysis** — layers where quantization causes larger increases in output error or perplexity are assigned higher precision, often measured via Hessian trace, Fisher information, or direct calibration loss",
-        "Parameter count — larger layers get lower precision",
-        "Random assignment with a fixed ratio"
-      ],
-      correct: 1,
+      options: ["Layer index — earlier layers always need more precision", "Parameter count — larger layers get lower precision", "**Per-layer sensitivity analysis** — layers where quantization causes larger increases in output error or perplexity are assigned higher precision, often measured via Hessian trace, Fisher information, or direct calibration loss", "Random assignment with a fixed ratio"],
+      correct: 2,
       explanation: "Mixed-precision strategies measure each layer's sensitivity to quantization error, typically by quantizing one layer at a time and measuring the impact on calibration loss. Layers with high Hessian trace ($\\text{tr}(H)$) or large Fisher information are more sensitive. Empirically, attention projection layers and the first/last layers tend to be more sensitive. This yields a constrained optimization: minimize total quality loss subject to a target average bit-width."
     },
     {
       type: "mc",
       question: "SqueezeLLM achieves high-quality ultra-low-bit quantization by combining:",
-      options: [
-        "Knowledge distillation with pruning",
-        "Dense-and-sparse decomposition: a low-bit dense representation for the bulk of weights plus a **sparse matrix** storing outlier weights at full precision, keeping the sensitive values exact",
-        "Layer fusion and operator merging",
-        "Dynamic quantization at inference time"
-      ],
-      correct: 1,
+      options: ["Knowledge distillation with pruning", "Dynamic quantization at inference time", "Layer fusion and operator merging", "Dense-and-sparse decomposition: a low-bit dense representation for the bulk of weights plus a **sparse matrix** storing outlier weights at full precision, keeping the sensitive values exact"],
+      correct: 3,
       explanation: "SqueezeLLM decomposes each weight matrix into a dense low-bit component plus a sparse full-precision component for outlier weights. The key insight is that weight sensitivity follows a heavy-tailed distribution — a small number of weights disproportionately affect output quality. By storing these in a sparse matrix (which adds minimal memory overhead due to sparsity), the dense component can be aggressively quantized to 3 or even 2 bits with minimal degradation."
     },
     {
@@ -101,25 +71,15 @@ export const quantizationAssessment = {
     {
       type: "mc",
       question: "A 7B parameter model with float16 weights occupies 14 GB. After GPTQ 4-bit quantization with group size 128, the model size is approximately:",
-      options: [
-        "1.75 GB — exactly $14 \\times (4/16)$",
-        "~3.9 GB — each group of 128 weights shares a float16 scale and zero-point, adding overhead: $14 \\times \\frac{4}{16} + \\frac{7 \\times 10^9}{128} \\times 4\\text{ bytes} \\approx 3.5 + 0.22$ GB",
-        "7 GB — quantization only affects compute, not storage",
-        "14 GB — the quantized model includes a full-precision copy"
-      ],
-      correct: 1,
+      options: ["~3.9 GB — each group of 128 weights shares a float16 scale and zero-point, adding overhead: $14 \\times \\frac{4}{16} + \\frac{7 \\times 10^9}{128} \\times 4\\text{ bytes} \\approx 3.5 + 0.22$ GB", "1.75 GB — exactly $14 \\times (4/16)$", "7 GB — quantization only affects compute, not storage", "14 GB — the quantized model includes a full-precision copy"],
+      correct: 0,
       explanation: "4-bit quantization reduces the weight payload to $14 \\times (4/16) = 3.5$ GB. However, each group of 128 weights requires a float16 scale and zero-point (4 bytes per group). With $\\frac{7 \\times 10^9}{128} \\approx 54.7\\text{M}$ groups, that adds $\\sim$219 MB of overhead. Total $\\approx 3.7$-$3.9$ GB depending on metadata. Smaller group sizes improve quality but increase overhead; group size 128 is the standard trade-off."
     },
     {
       type: "mc",
       question: "When quantizing a weight value $w$ to a $b$-bit unsigned integer grid $[0, 2^b - 1]$, the standard affine quantization formula is:",
-      options: [
-        "$q = \\text{round}(w \\times 2^b)$",
-        "$q = \\text{clamp}\\left(\\text{round}\\left(\\frac{w - z}{s}\\right), 0, 2^b - 1\\right)$ where $s = \\frac{w_{\\max} - w_{\\min}}{2^b - 1}$ is the scale and $z = w_{\\min}$ is the zero-point",
-        "$q = \\text{sign}(w) \\times \\lfloor |w| \\rfloor$",
-        "$q = \\text{round}(w)$ clipped to $b$ bits"
-      ],
-      correct: 1,
+      options: ["$q = \\text{round}(w \\times 2^b)$", "$q = \\text{sign}(w) \\times \\lfloor |w| \\rfloor$", "$q = \\text{clamp}\\left(\\text{round}\\left(\\frac{w - z}{s}\\right), 0, 2^b - 1\\right)$ where $s = \\frac{w_{\\max} - w_{\\min}}{2^b - 1}$ is the scale and $z = w_{\\min}$ is the zero-point", "$q = \\text{round}(w)$ clipped to $b$ bits"],
+      correct: 2,
       explanation: "Affine (asymmetric) quantization maps the floating-point range $[w_{\\min}, w_{\\max}]$ to the integer range $[0, 2^b - 1]$. The scale $s = \\frac{w_{\\max} - w_{\\min}}{2^b - 1}$ determines the step size, and the zero-point $z$ handles asymmetric distributions. Dequantization recovers $\\hat{w} = s \\cdot q + z$. The quantization error per weight is bounded by $s/2$, so fewer bits means larger steps and more error."
     },
     {
@@ -163,13 +123,8 @@ export const decodingAssessment = {
     {
       type: "mc",
       question: "For a 70B parameter model (80 layers, 64 heads, $d_h = 128$) serving a single request at 128K context in float16, the KV-cache alone requires approximately:",
-      options: [
-        "~1.3 GB",
-        "~5 GB",
-        "~20 GB — computed as $2 \\times 80 \\times 64 \\times 128 \\times 128000 \\times 2$ bytes $\\approx 20.97$ GB",
-        "~80 GB"
-      ],
-      correct: 2,
+      options: ["~20 GB — computed as $2 \\times 80 \\times 64 \\times 128 \\times 128000 \\times 2$ bytes $\\approx 20.97$ GB", "~5 GB", "~1.3 GB", "~80 GB"],
+      correct: 0,
       explanation: "KV-cache $= 2 \\times 80 \\times 64 \\times 128 \\times 128000 \\times 2 = 2 \\times 80 \\times 8192 \\times 128000 \\times 2$ bytes. Breaking it down: $80 \\times 8192 = 655360$ (per-layer KV dim), $\\times 128000 \\times 2 \\times 2 = 335,544,320,000$ bytes $\\approx 20.97$ GB. This means a single 128K-context request on a 70B model needs ~21 GB just for the KV-cache, in addition to the ~140 GB for model weights. This is why KV-cache optimization is critical."
     },
     {
@@ -187,13 +142,8 @@ export const decodingAssessment = {
     {
       type: "mc",
       question: "Speculative decoding uses a small **draft model** to generate $K$ candidate tokens, then the large **target model** verifies them in a single forward pass. A key theoretical guarantee is:",
-      options: [
-        "The output quality matches the draft model",
-        "The output distribution is **mathematically identical** to sampling from the target model alone — the draft model only affects speed, not the distribution of generated text",
-        "The method only works with greedy decoding",
-        "The draft model must share the same vocabulary as the target model but not vice versa"
-      ],
-      correct: 1,
+      options: ["The output quality matches the draft model", "The draft model must share the same vocabulary as the target model but not vice versa", "The method only works with greedy decoding", "The output distribution is **mathematically identical** to sampling from the target model alone — the draft model only affects speed, not the distribution of generated text"],
+      correct: 3,
       explanation: "Speculative decoding uses a rejection sampling scheme: each draft token is accepted with probability $\\min(1, \\frac{p_{\\text{target}}(x)}{p_{\\text{draft}}(x)})$. If rejected, a corrected token is sampled from a modified distribution. This guarantees the final output follows the exact target model distribution. The speedup comes from the fact that the target model can verify $K$ tokens in parallel (one forward pass), while generating them autoregressively would require $K$ passes. Typical speedups are 2-3x."
     },
     {
@@ -211,37 +161,22 @@ export const decodingAssessment = {
     {
       type: "mc",
       question: "Continuous batching (also called iteration-level or in-flight batching) differs from static batching by:",
-      options: [
-        "Using larger batch sizes",
-        "Allowing new requests to **join the batch as soon as any request finishes**, rather than waiting for all requests in the batch to complete — this eliminates idle GPU cycles from padding shorter sequences",
-        "Processing requests one at a time for lower latency",
-        "Batching only the prefill phase, not decoding"
-      ],
-      correct: 1,
+      options: ["Allowing new requests to **join the batch as soon as any request finishes**, rather than waiting for all requests in the batch to complete — this eliminates idle GPU cycles from padding shorter sequences", "Using larger batch sizes", "Processing requests one at a time for lower latency", "Batching only the prefill phase, not decoding"],
+      correct: 0,
       explanation: "In static batching, all requests in a batch must complete before new ones are admitted. Since requests have variable output lengths, short-output requests finish early and their GPU resources sit idle. Continuous batching inserts new requests at each iteration, maintaining high GPU utilization. This can improve throughput by 2-5x over static batching. vLLM, TensorRT-LLM, and SGLang all implement continuous batching as a core feature."
     },
     {
       type: "mc",
       question: "Prefix caching (also called prompt caching) accelerates serving by:",
-      options: [
-        "Caching the final output tokens for common prompts",
-        "Storing the **computed KV-cache for shared prompt prefixes** (e.g., system prompts) so that multiple requests sharing the same prefix skip the redundant prefill computation",
-        "Caching the model weights for faster loading",
-        "Pre-computing all possible outputs for short prompts"
-      ],
-      correct: 1,
+      options: ["Caching the final output tokens for common prompts", "Caching the model weights for faster loading", "Storing the **computed KV-cache for shared prompt prefixes** (e.g., system prompts) so that multiple requests sharing the same prefix skip the redundant prefill computation", "Pre-computing all possible outputs for short prompts"],
+      correct: 2,
       explanation: "Many serving scenarios involve repeated prefixes: system prompts in chat APIs, few-shot examples, or shared document contexts. Prefix caching computes the KV-cache for the shared prefix once and reuses it across requests. For a 2K system prompt with a 70B model, this saves ~2K tokens of prefill computation per request. RadixAttention (SGLang) extends this with a radix tree to efficiently share arbitrary prefix subtrees across concurrent requests."
     },
     {
       type: "mc",
       question: "Multi-Query Attention (MQA) and Grouped-Query Attention (GQA) reduce the KV-cache size by:",
-      options: [
-        "Using fewer transformer layers",
-        "Reducing the number of distinct K and V heads — MQA uses a **single** KV head shared across all query heads, while GQA uses $G$ KV head groups (where $1 < G < H$), reducing cache by a factor of $H/G$",
-        "Quantizing the KV-cache to 4-bit",
-        "Only caching every other layer"
-      ],
-      correct: 1,
+      options: ["Using fewer transformer layers", "Only caching every other layer", "Quantizing the KV-cache to 4-bit", "Reducing the number of distinct K and V heads — MQA uses a **single** KV head shared across all query heads, while GQA uses $G$ KV head groups (where $1 < G < H$), reducing cache by a factor of $H/G$"],
+      correct: 3,
       explanation: "Standard multi-head attention has $H$ distinct K,V projections. MQA collapses these to 1 shared K,V head (cache reduced by $H\\times$). GQA uses $G$ groups, each serving $H/G$ query heads (cache reduced by $H/G\\times$). For example, LLaMA-2 70B uses GQA with 8 KV heads for 64 query heads, reducing KV-cache by $8\\times$. This is critical for long-context serving: the 128K KV-cache drops from ~21 GB to ~2.6 GB."
     },
     {
@@ -259,13 +194,8 @@ export const decodingAssessment = {
     {
       type: "mc",
       question: "A serving system processes a batch of 32 sequences, each generating one token per step. Compared to serving a single sequence, the token generation throughput (tokens/second across all sequences) approximately:",
-      options: [
-        "Stays the same — the GPU can only generate one token at a time",
-        "Increases by ~32x because matrix-vector products become matrix-matrix products, better utilizing compute; per-sequence latency stays roughly constant until compute saturation",
-        "Increases by exactly 32x with 32x higher latency",
-        "Decreases due to memory contention"
-      ],
-      correct: 1,
+      options: ["Increases by ~32x because matrix-vector products become matrix-matrix products, better utilizing compute; per-sequence latency stays roughly constant until compute saturation", "Stays the same — the GPU can only generate one token at a time", "Increases by exactly 32x with 32x higher latency", "Decreases due to memory contention"],
+      correct: 0,
       explanation: "Batching converts $Wx$ (matrix-vector, bandwidth-bound) into $WX$ (matrix-matrix, compute-bound), increasing arithmetic intensity from ~2 to $\\sim 2B$ FLOPs/byte where $B$ is batch size. Since decode steps are bandwidth-bound, adding sequences is nearly free until the GPU's compute becomes the bottleneck. A batch of 32 thus achieves ~32x throughput with minimal per-sequence latency increase. The crossover to compute-bound depends on model size and GPU specs — typically around batch size 64-256."
     }
   ]
@@ -285,25 +215,15 @@ export const servingAssessment = {
     {
       type: "mc",
       question: "The prefill phase (processing the input prompt) and the decode phase (generating output tokens) have fundamentally different computational profiles:",
-      options: [
-        "Both phases are memory-bandwidth-bound",
-        "Prefill is **compute-bound** (large matrix-matrix multiplications over all prompt tokens in parallel) while decode is **memory-bandwidth-bound** (matrix-vector products generating one token at a time)",
-        "Prefill is memory-bound while decode is compute-bound",
-        "Both phases are compute-bound but decode uses more FLOPs"
-      ],
-      correct: 1,
+      options: ["Both phases are memory-bandwidth-bound", "Prefill is memory-bound while decode is compute-bound", "Prefill is **compute-bound** (large matrix-matrix multiplications over all prompt tokens in parallel) while decode is **memory-bandwidth-bound** (matrix-vector products generating one token at a time)", "Both phases are compute-bound but decode uses more FLOPs"],
+      correct: 2,
       explanation: "Prefill processes all $N$ prompt tokens simultaneously: the main operations are matrix-matrix multiplies $Y = XW$ where $X \\in \\mathbb{R}^{N \\times d}$. This has high arithmetic intensity ($\\sim 2N$ FLOPs/byte) and saturates GPU compute. Decode generates one token at a time: matrix-vector multiplies $y = Wx$ with arithmetic intensity $\\sim 2$ FLOPs/byte, bottlenecked by weight-loading bandwidth. This asymmetry is the key insight driving disaggregated inference architectures."
     },
     {
       type: "mc",
       question: "Disaggregated inference (as in systems like Splitwise or DistServe) separates prefill and decode into different GPU pools because:",
-      options: [
-        "Prefill and decode require different model architectures",
-        "Co-locating them causes **interference** — long prefills block decode steps (increasing time-to-first-token), and decode's low utilization wastes compute-optimized GPUs; separating them allows hardware-specific optimization for each phase",
-        "Decode requires more GPU memory than prefill",
-        "It simplifies the codebase"
-      ],
-      correct: 1,
+      options: ["Prefill and decode require different model architectures", "It simplifies the codebase", "Decode requires more GPU memory than prefill", "Co-locating them causes **interference** — long prefills block decode steps (increasing time-to-first-token), and decode's low utilization wastes compute-optimized GPUs; separating them allows hardware-specific optimization for each phase"],
+      correct: 3,
       explanation: "When prefill and decode share GPUs, a long prefill (e.g., 100K context) stalls all concurrent decode iterations, creating latency spikes. Disaggregation assigns prefill to compute-optimized GPUs (maximizing FLOPs) and decode to bandwidth-optimized or cheaper GPUs (where memory bandwidth is the bottleneck). The KV-cache is transferred between pools after prefill. This can reduce P99 time-to-first-token by 2-5x while improving overall throughput."
     },
     {
@@ -321,37 +241,22 @@ export const servingAssessment = {
     {
       type: "mc",
       question: "The NVIDIA H100 SXM offers ~3.35 TB/s HBM3 bandwidth vs the A100 SXM's ~2.0 TB/s HBM2e. For **decode-phase** serving (memory-bandwidth-bound), switching from A100 to H100 provides approximately:",
-      options: [
-        "~4x speedup due to the H100's higher FP16 FLOPS (990 TFLOPS vs 312 TFLOPS)",
-        "~1.67x speedup — decode is bandwidth-bound, so the improvement tracks the bandwidth ratio $3.35/2.0 \\approx 1.67$, not the compute ratio",
-        "No improvement — the models are identical",
-        "~10x speedup from the Transformer Engine"
-      ],
-      correct: 1,
+      options: ["~1.67x speedup — decode is bandwidth-bound, so the improvement tracks the bandwidth ratio $3.35/2.0 \\approx 1.67$, not the compute ratio", "~4x speedup due to the H100's higher FP16 FLOPS (990 TFLOPS vs 312 TFLOPS)", "No improvement — the models are identical", "~10x speedup from the Transformer Engine"],
+      correct: 0,
       explanation: "Since decode is bottlenecked by memory bandwidth (loading model weights for matrix-vector products), the speedup is determined by the HBM bandwidth ratio, not the FLOPS ratio. The H100's ~3.35 TB/s vs A100's ~2.0 TB/s gives ~1.67x decode throughput. The H100's massive compute advantage (3.2x in FP16, even more with FP8) primarily benefits the compute-bound prefill phase. This is why hardware selection for inference depends critically on the workload mix."
     },
     {
       type: "mc",
       question: "vLLM, TensorRT-LLM, and SGLang represent three major open-source serving frameworks. A distinguishing feature of SGLang is:",
-      options: [
-        "It was the first to implement continuous batching",
-        "**RadixAttention** — a radix tree-based KV-cache sharing mechanism that enables efficient prefix caching across requests with arbitrary shared prefixes, plus a frontend language for programming complex LLM pipelines",
-        "It only supports NVIDIA GPUs",
-        "It uses a proprietary model format"
-      ],
-      correct: 1,
+      options: ["It was the first to implement continuous batching", "It only supports NVIDIA GPUs", "**RadixAttention** — a radix tree-based KV-cache sharing mechanism that enables efficient prefix caching across requests with arbitrary shared prefixes, plus a frontend language for programming complex LLM pipelines", "It uses a proprietary model format"],
+      correct: 2,
       explanation: "SGLang introduced RadixAttention, which organizes the KV-cache as a radix tree indexed by token sequences. This allows automatic, fine-grained cache sharing: if requests share any prefix (not just a pre-defined system prompt), the common KV-cache entries are reused. Combined with SGLang's frontend DSL for expressing multi-call LLM programs (e.g., tree-of-thought, multi-turn), this enables cache-aware scheduling that can reduce redundant prefill computation by 5-10x in structured generation workloads."
     },
     {
       type: "mc",
       question: "A model with 70B float16 parameters requires 140 GB of weight storage. To serve this on hardware with 80 GB GPUs, the minimum number of GPUs needed using tensor parallelism is:",
-      options: [
-        "1 GPU — with offloading to CPU memory",
-        "2 GPUs — the weights are split across GPUs, with each GPU holding approximately 70 GB of weights plus KV-cache and activation memory",
-        "4 GPUs — you need significant headroom beyond the raw weight size",
-        "8 GPUs — tensor parallelism has 8x overhead"
-      ],
-      correct: 1,
+      options: ["1 GPU — with offloading to CPU memory", "8 GPUs — tensor parallelism has 8x overhead", "4 GPUs — you need significant headroom beyond the raw weight size", "2 GPUs — the weights are split across GPUs, with each GPU holding approximately 70 GB of weights plus KV-cache and activation memory"],
+      correct: 3,
       explanation: "140 GB of weights requires at least 2 GPUs with 80 GB each (160 GB total). Each GPU holds ~70 GB of weights, leaving ~10 GB for KV-cache, activations, and framework overhead. In practice, 2 GPUs may be tight for long contexts (KV-cache grows with sequence length), so production deployments often use 4 GPUs for the headroom. Tensor parallelism splits each layer's matrices across GPUs with all-reduce communication between them — communication overhead is typically 5-15% of total latency."
     },
     {
@@ -369,37 +274,22 @@ export const servingAssessment = {
     {
       type: "mc",
       question: "FP8 inference (available on H100 and later GPUs) provides a benefit over FP16 primarily by:",
-      options: [
-        "Reducing model accuracy to save power",
-        "**Doubling the effective memory bandwidth** (8-bit values are half the size of 16-bit, so 2x more values loaded per second) and doubling the compute throughput (2x more FP8 ops per cycle), benefiting both prefill and decode phases",
-        "Enabling larger vocabulary sizes",
-        "Reducing the number of required transformer layers"
-      ],
-      correct: 1,
+      options: ["**Doubling the effective memory bandwidth** (8-bit values are half the size of 16-bit, so 2x more values loaded per second) and doubling the compute throughput (2x more FP8 ops per cycle), benefiting both prefill and decode phases", "Reducing model accuracy to save power", "Enabling larger vocabulary sizes", "Reducing the number of required transformer layers"],
+      correct: 0,
       explanation: "FP8 halves the bytes per parameter: a 70B model occupies ~70 GB instead of ~140 GB, and the effective bandwidth for weight loading doubles. The H100's Transformer Engine provides 1979 TFLOPS in FP8 vs 990 in FP16. For decode (bandwidth-bound), FP8 nearly doubles throughput. For prefill (compute-bound), FP8 doubles peak FLOPS. Combined, FP8 can provide 1.5-1.9x end-to-end throughput improvement with minimal quality loss when properly calibrated."
     },
     {
       type: "mc",
       question: "Chunked prefill is an optimization that breaks the prefill phase of a long prompt into smaller chunks. The main benefit is:",
-      options: [
-        "Reducing the total compute for prefill",
-        "Preventing a single long prefill from **monopolizing the GPU** for hundreds of milliseconds — by interleaving prefill chunks with decode steps from other requests, it reduces latency spikes and improves TPOT consistency for concurrent requests",
-        "Enabling longer context lengths than the model supports",
-        "Reducing KV-cache memory usage"
-      ],
-      correct: 1,
+      options: ["Reducing the total compute for prefill", "Enabling longer context lengths than the model supports", "Preventing a single long prefill from **monopolizing the GPU** for hundreds of milliseconds — by interleaving prefill chunks with decode steps from other requests, it reduces latency spikes and improves TPOT consistency for concurrent requests", "Reducing KV-cache memory usage"],
+      correct: 2,
       explanation: "A 100K-token prefill on a 70B model can take several seconds, during which no decode steps execute for other requests. Chunked prefill splits this into e.g., 512-token chunks, interleaving decode iterations between chunks. This caps the maximum time any decode step is delayed to the time for one prefill chunk. The total prefill time increases slightly (due to repeated kernel launches), but the P99 TPOT for concurrent requests improves dramatically — essential for meeting SLA targets."
     },
     {
       type: "mc",
       question: "When evaluating serving frameworks, the metric \"requests per second per dollar\" accounts for:",
-      options: [
-        "Only the GPU cost",
-        "The **total cost efficiency** — including GPU cost, utilization, batching efficiency, and framework overhead; a framework achieving 100 req/s on a \\$2/hr GPU ($180K/yr$) beats one achieving 150 req/s on a \\$6/hr GPU, despite lower raw throughput",
-        "The number of parameters in the model",
-        "The accuracy of the model's outputs"
-      ],
-      correct: 1,
+      options: ["Only the GPU cost", "The accuracy of the model's outputs", "The number of parameters in the model", "The **total cost efficiency** — including GPU cost, utilization, batching efficiency, and framework overhead; a framework achieving 100 req/s on a \\$2/hr GPU ($180K/yr$) beats one achieving 150 req/s on a \\$6/hr GPU, despite lower raw throughput"],
+      correct: 3,
       explanation: "Raw throughput (req/s) is insufficient for cost comparison. Framework A serving 100 req/s on an A100 (\\$2/hr) achieves 50 req/s/\\$ vs. Framework B serving 150 req/s on 2x H100s (\\$8/hr) at 18.75 req/s/\\$. Real cost analysis also considers: GPU utilization under varying load, the latency-throughput trade-off at SLA boundaries, CPU/memory/networking costs, and operational complexity. This is why serving benchmarks should report cost-normalized throughput at a specified latency target."
     }
   ]
@@ -431,37 +321,22 @@ export const compressionAssessment = {
     {
       type: "mc",
       question: "Logit matching distillation minimizes $\\text{KL}(p_{\\text{teacher}} \\| p_{\\text{student}})$ over the output distribution. Feature matching distillation instead:",
-      options: [
-        "Matches only the final prediction",
-        "Aligns **intermediate layer representations** between teacher and student — e.g., minimizing $\\|f_{\\text{teacher}}^{(l)} - g(f_{\\text{student}}^{(k)})\\|^2$ where $g$ is a learned projection to handle dimension mismatches",
-        "Uses reinforcement learning to train the student",
-        "Matches the gradient norms of teacher and student"
-      ],
-      correct: 1,
+      options: ["Aligns **intermediate layer representations** between teacher and student — e.g., minimizing $\\|f_{\\text{teacher}}^{(l)} - g(f_{\\text{student}}^{(k)})\\|^2$ where $g$ is a learned projection to handle dimension mismatches", "Matches only the final prediction", "Uses reinforcement learning to train the student", "Matches the gradient norms of teacher and student"],
+      correct: 0,
       explanation: "Feature matching (FitNets, PKD) adds losses that align intermediate representations. Since teacher and student may have different hidden dimensions, a learned linear projection $g$ maps student features to teacher feature space. This provides richer supervision than output-only matching: the student learns not just what to predict but how to represent. For LLM distillation, this can include matching attention patterns, hidden states at specific layers, or the output of feed-forward blocks."
     },
     {
       type: "mc",
       question: "On-policy distillation (used in models like Gemma and some LLaMA variants) differs from standard offline distillation by:",
-      options: [
-        "Using a smaller teacher model",
-        "Having the **student generate its own outputs**, then using the teacher to score/correct them — this avoids the train-test distribution mismatch where the student is trained on teacher-generated text but must generate its own text at inference",
-        "Training without any teacher signal",
-        "Using only hard labels from the teacher"
-      ],
-      correct: 1,
+      options: ["Using a smaller teacher model", "Training without any teacher signal", "Having the **student generate its own outputs**, then using the teacher to score/correct them — this avoids the train-test distribution mismatch where the student is trained on teacher-generated text but must generate its own text at inference", "Using only hard labels from the teacher"],
+      correct: 2,
       explanation: "In offline distillation, the student trains on teacher-generated sequences. At inference, the student generates from its own distribution, creating exposure bias — errors compound because the student never learned to recover from its own mistakes. On-policy distillation lets the student generate sequences, then uses the teacher's per-token probabilities as training signal. This is analogous to DAgger in imitation learning. The GKD (Generalized Knowledge Distillation) framework formalizes the spectrum between on-policy and off-policy distillation."
     },
     {
       type: "mc",
       question: "Structured pruning removes entire **structures** (attention heads, neurons, layers), while unstructured pruning removes individual weights. The practical advantage of structured pruning is:",
-      options: [
-        "It achieves higher sparsity levels",
-        "The resulting model has **regular, dense tensor shapes** that run efficiently on standard hardware (GPUs/TPUs) without specialized sparse kernels — unstructured pruning creates irregular sparsity patterns that standard hardware cannot accelerate",
-        "It preserves more model quality at the same sparsity",
-        "It can be applied during training at no cost"
-      ],
-      correct: 1,
+      options: ["It achieves higher sparsity levels", "It can be applied during training at no cost", "It preserves more model quality at the same sparsity", "The resulting model has **regular, dense tensor shapes** that run efficiently on standard hardware (GPUs/TPUs) without specialized sparse kernels — unstructured pruning creates irregular sparsity patterns that standard hardware cannot accelerate"],
+      correct: 3,
       explanation: "Removing 50% of individual weights (unstructured) leaves an irregular sparse matrix requiring specialized sparse GEMM kernels to achieve speedup — and these kernels often underperform dense GEMMs until >90% sparsity on GPUs. Removing 50% of neurons (structured) simply halves the matrix dimension, yielding dense smaller matrices that run at full hardware efficiency. The trade-off: unstructured pruning preserves more quality at the same compression ratio, but structured pruning gives predictable, hardware-friendly speedups."
     },
     {
@@ -479,37 +354,22 @@ export const compressionAssessment = {
     {
       type: "mc",
       question: "A teacher model has 70B parameters and a student has 7B. After distillation, the student achieves 95% of the teacher's accuracy on benchmarks. The student's inference cost is approximately:",
-      options: [
-        "95% of the teacher's cost",
-        "~10% of the teacher's cost — inference cost scales roughly linearly with parameter count (dominated by weight-loading for decode), so a 10x smaller model is ~10x cheaper regardless of how well it was trained",
-        "50% of the teacher's cost due to shared architecture",
-        "The same as the teacher's cost because it was trained by the teacher"
-      ],
-      correct: 1,
+      options: ["~10% of the teacher's cost — inference cost scales roughly linearly with parameter count (dominated by weight-loading for decode), so a 10x smaller model is ~10x cheaper regardless of how well it was trained", "95% of the teacher's cost", "50% of the teacher's cost due to shared architecture", "The same as the teacher's cost because it was trained by the teacher"],
+      correct: 0,
       explanation: "Inference compute and memory scale with parameter count, not training method. The 7B student needs ~10x fewer FLOPs per forward pass, ~10x less memory for weights, and ~10x less KV-cache memory (assuming proportionally smaller hidden dimensions). Distillation improves the student's quality for its size class but doesn't change its computational cost. This is precisely the value proposition of distillation: getting a model that punches above its weight class computationally."
     },
     {
       type: "mc",
       question: "Neural Architecture Search (NAS) for LLMs differs from NAS for vision models primarily because:",
-      options: [
-        "LLMs don't have hyperparameters to search",
-        "The **training cost of each candidate architecture** is enormous (millions of dollars for a full pre-training run), making exhaustive search infeasible — NAS for LLMs typically relies on proxy metrics, scaling law predictions, or searching only within constrained subspaces like depth/width ratios",
-        "LLM architectures are already optimal",
-        "NAS requires supervised labels which LLMs don't use"
-      ],
-      correct: 1,
+      options: ["LLMs don't have hyperparameters to search", "LLM architectures are already optimal", "The **training cost of each candidate architecture** is enormous (millions of dollars for a full pre-training run), making exhaustive search infeasible — NAS for LLMs typically relies on proxy metrics, scaling law predictions, or searching only within constrained subspaces like depth/width ratios", "NAS requires supervised labels which LLMs don't use"],
+      correct: 2,
       explanation: "Vision NAS can evaluate a candidate architecture by training it to convergence in hours on a single GPU. LLM NAS cannot — training a 7B model costs ~\\$100K, making brute-force search over architecture variants prohibitive. Practical LLM NAS uses: (1) scaling law extrapolation from small proxy models, (2) zero-shot proxies based on gradient statistics, (3) constrained search over specific dimensions (depth, width, FFN ratio, head count) with other choices fixed. Results like the Chinchilla scaling laws are a form of two-variable NAS over model size and data quantity."
     },
     {
       type: "mc",
       question: "Layer pruning (removing entire transformer layers) from a 32-layer model shows an interesting pattern: removing layers from the **middle** of the network causes less degradation than removing early or late layers. This suggests:",
-      options: [
-        "Middle layers are redundant and should always be removed",
-        "Middle layers exhibit more **representational redundancy** — adjacent middle layers compute similar transformations (high cosine similarity between layer inputs and outputs), while early layers build critical low-level features and late layers perform task-specific computation that is hard to compensate for",
-        "The model was trained incorrectly",
-        "Layer ordering doesn't matter in transformers"
-      ],
-      correct: 1,
+      options: ["Middle layers are redundant and should always be removed", "Layer ordering doesn't matter in transformers", "The model was trained incorrectly", "Middle layers exhibit more **representational redundancy** — adjacent middle layers compute similar transformations (high cosine similarity between layer inputs and outputs), while early layers build critical low-level features and late layers perform task-specific computation that is hard to compensate for"],
+      correct: 3,
       explanation: "Empirical studies (e.g., ShortGPT, LaCo) show that the cosine similarity between a middle layer's input and output is often >0.99, meaning the layer makes only a small residual update. Early layers show lower similarity (larger transformations building representations), and final layers show specialized computation for the output distribution. This pattern motivates depth pruning strategies that remove middle layers and connects to the broader observation that over-parameterized networks have redundant capacity concentrated in particular regions."
     },
     {
@@ -527,13 +387,8 @@ export const compressionAssessment = {
     {
       type: "mc",
       question: "Pruning at initialization (before training) versus pruning after training represents a fundamental debate. The **lottery ticket hypothesis** states:",
-      options: [
-        "All neural network architectures are equally expressive",
-        "Dense randomly-initialized networks contain **sparse subnetworks** (winning tickets) that, when trained in isolation from their original initialization, match the full dense network's accuracy — suggesting that most parameters exist to help find these subnetworks during training",
-        "Pruned networks always outperform dense networks",
-        "Random pruning is as effective as informed pruning"
-      ],
-      correct: 1,
+      options: ["Dense randomly-initialized networks contain **sparse subnetworks** (winning tickets) that, when trained in isolation from their original initialization, match the full dense network's accuracy — suggesting that most parameters exist to help find these subnetworks during training", "All neural network architectures are equally expressive", "Pruned networks always outperform dense networks", "Random pruning is as effective as informed pruning"],
+      correct: 0,
       explanation: "Frankle & Carlin (2019) showed that within a randomly initialized dense network, there exist sparse subnetworks that can be trained from their original initialization to match the dense network's performance. Finding these \"winning tickets\" requires train-prune-reset cycles. For LLMs, directly finding winning tickets is computationally prohibitive, but the hypothesis motivates the intuition behind successful post-training pruning: well-trained networks contain many low-importance parameters whose removal minimally impacts function. Subsequent work (especially on supermasks) has refined these findings significantly."
     }
   ]
@@ -553,25 +408,15 @@ export const cotAssessment = {
     {
       type: "mc",
       question: "The **scratchpad hypothesis** for why chain-of-thought (CoT) improves LLM reasoning posits that:",
-      options: [
-        "CoT activates special reasoning circuits in the transformer",
-        "The intermediate tokens serve as **external working memory** — they allow the model to decompose multi-step problems into sequential single-step computations, each conditioned on the previous result, effectively extending the model's bounded computational depth per token",
-        "CoT prompts contain the answer implicitly",
-        "Writing more tokens gives the model more time to think in wall-clock time"
-      ],
-      correct: 1,
+      options: ["CoT activates special reasoning circuits in the transformer", "CoT prompts contain the answer implicitly", "The intermediate tokens serve as **external working memory** — they allow the model to decompose multi-step problems into sequential single-step computations, each conditioned on the previous result, effectively extending the model's bounded computational depth per token", "Writing more tokens gives the model more time to think in wall-clock time"],
+      correct: 2,
       explanation: "A transformer's forward pass has fixed computational depth (number of layers). For problems requiring more sequential computation steps than layers, the model cannot solve them in a single pass. CoT externalizes intermediate computations into generated tokens, which are then fed back as input. Each token generation step adds another forward pass worth of computation, conditioned on previous results. This effectively gives the model $O(T \\times L)$ sequential computation for $T$ output tokens and $L$ layers, rather than just $O(L)$."
     },
     {
       type: "mc",
       question: "Self-consistency (Wang et al., 2022) improves CoT reasoning by:",
-      options: [
-        "Training the model to be internally consistent",
-        "Sampling **multiple independent reasoning chains** (with temperature > 0), extracting the final answer from each, and returning the answer with the highest frequency — a majority voting scheme that marginalizes over diverse reasoning paths",
-        "Asking the model to check its own work",
-        "Using a verifier model to score reasoning chains"
-      ],
-      correct: 1,
+      options: ["Training the model to be internally consistent", "Using a verifier model to score reasoning chains", "Asking the model to check its own work", "Sampling **multiple independent reasoning chains** (with temperature > 0), extracting the final answer from each, and returning the answer with the highest frequency — a majority voting scheme that marginalizes over diverse reasoning paths"],
+      correct: 3,
       explanation: "Self-consistency samples $N$ reasoning chains (e.g., $N = 40$) with temperature sampling, then takes a majority vote on the final answers. The intuition: correct answers tend to be reachable via multiple valid reasoning paths, while incorrect answers typically result from specific errors that vary across samples. Formally, it approximates $\\arg\\max_a P(a \\mid \\text{question})$ by marginalizing over reasoning paths. This is a simple but powerful technique — it improved GSM8K accuracy from 56% (single CoT) to 74% on PaLM 540B."
     },
     {
@@ -589,37 +434,22 @@ export const cotAssessment = {
     {
       type: "mc",
       question: "Process reward models (PRMs) provide feedback on each **step** of a reasoning chain, as opposed to outcome reward models (ORMs) that only score the final answer. The advantage of PRMs for math reasoning is:",
-      options: [
-        "PRMs are cheaper to train",
-        "PRMs provide **dense, step-level credit assignment** — they can identify exactly where a reasoning chain went wrong, enabling more efficient search over reasoning paths and better training signal for the policy model, rather than assigning a single reward to an entire multi-step derivation",
-        "PRMs always produce more accurate final answers",
-        "PRMs don't require human annotations"
-      ],
-      correct: 1,
+      options: ["PRMs provide **dense, step-level credit assignment** — they can identify exactly where a reasoning chain went wrong, enabling more efficient search over reasoning paths and better training signal for the policy model, rather than assigning a single reward to an entire multi-step derivation", "PRMs are cheaper to train", "PRMs always produce more accurate final answers", "PRMs don't require human annotations"],
+      correct: 0,
       explanation: "ORMs suffer from the sparse reward problem: a 10-step derivation gets a single correct/incorrect label, giving no signal about which step caused a failure. PRMs score each step (e.g., step 3 introduced an algebraic error), enabling: (1) best-first search that prunes reasoning chains at the first erroneous step, (2) more efficient training since each step provides a supervision signal, and (3) interpretable failure analysis. Let's Verify Step by Step (Lightman et al., 2023) showed PRMs substantially outperform ORMs for math reasoning on MATH benchmark."
     },
     {
       type: "mc",
       question: "When does chain-of-thought reasoning **hurt** performance compared to direct answering?",
-      options: [
-        "Never — CoT always helps",
-        "On tasks requiring **fast pattern matching or factual recall** — CoT can introduce errors by overthinking simple retrievals, and the reasoning steps can lead the model astray on questions where the direct answer is already highly confident. CoT overhead also hurts latency-sensitive applications",
-        "Only on mathematical problems",
-        "When the model is very large"
-      ],
-      correct: 1,
+      options: ["Never — CoT always helps", "Only on mathematical problems", "On tasks requiring **fast pattern matching or factual recall** — CoT can introduce errors by overthinking simple retrievals, and the reasoning steps can lead the model astray on questions where the direct answer is already highly confident. CoT overhead also hurts latency-sensitive applications", "When the model is very large"],
+      correct: 2,
       explanation: "CoT helps most on multi-step reasoning tasks (math, logic, multi-hop QA) where the problem genuinely requires sequential computation. It hurts on: (1) simple factual recall (\"What is the capital of France?\") where reasoning steps are unnecessary noise, (2) tasks where the model's first instinct is correct but overthinking introduces doubt, (3) pattern-matching tasks like sentiment analysis where reasoning can rationalize wrong answers. Empirically, CoT provides little benefit or even degrades performance for models below ~100B parameters on many tasks."
     },
     {
       type: "mc",
       question: "The debate over whether LLMs are \"truly reasoning\" versus \"pattern matching\" centers on:",
-      options: [
-        "Whether LLMs use symbolic or subsymbolic representations",
-        "Whether LLMs exhibit **systematic generalization** — solving novel problem compositions they haven't seen in training — or merely interpolate between training examples. Key evidence includes failure on problems with superficially similar structure but different solutions, and sensitivity to irrelevant surface features",
-        "Whether LLMs use more parameters than the human brain",
-        "Whether LLMs were trained on reasoning data"
-      ],
-      correct: 1,
+      options: ["Whether LLMs use symbolic or subsymbolic representations", "Whether LLMs were trained on reasoning data", "Whether LLMs use more parameters than the human brain", "Whether LLMs exhibit **systematic generalization** — solving novel problem compositions they haven't seen in training — or merely interpolate between training examples. Key evidence includes failure on problems with superficially similar structure but different solutions, and sensitivity to irrelevant surface features"],
+      correct: 3,
       explanation: "The critical test is out-of-distribution generalization: can models solve problems requiring novel combinations of learned operations? Evidence for pattern matching: performance degrades on math problems with unusual number ranges, models are fooled by irrelevant information that shouldn't affect logical reasoning, and models struggle with problems structurally identical to training examples but with different surface forms. Evidence for reasoning: models can solve some novel compositions, show consistent performance on well-structured problems, and benefit from CoT in ways consistent with genuine computation. The truth likely involves both capabilities in different proportions."
     },
     {
@@ -637,37 +467,22 @@ export const cotAssessment = {
     {
       type: "mc",
       question: "Few-shot CoT prompting provides exemplar reasoning chains in the prompt. Zero-shot CoT instead uses a trigger phrase like \"Let's think step by step.\" The fact that zero-shot CoT works at all suggests:",
-      options: [
-        "The model doesn't actually need examples",
-        "Instruction-tuned models have **internalized a general reasoning mode** that can be activated by trigger phrases — this mode was learned from the many step-by-step explanations in training data and RLHF, making the model predisposed to produce structured reasoning when prompted appropriately",
-        "Zero-shot CoT works only on easy problems",
-        "The trigger phrase is mathematically optimal"
-      ],
-      correct: 1,
+      options: ["Instruction-tuned models have **internalized a general reasoning mode** that can be activated by trigger phrases — this mode was learned from the many step-by-step explanations in training data and RLHF, making the model predisposed to produce structured reasoning when prompted appropriately", "The model doesn't actually need examples", "Zero-shot CoT works only on easy problems", "The trigger phrase is mathematically optimal"],
+      correct: 0,
       explanation: "Zero-shot CoT (Kojima et al., 2022) showed that \"Let's think step by step\" improves accuracy across diverse reasoning tasks without any exemplars. This works because: (1) pre-training on web data includes millions of step-by-step explanations, (2) instruction tuning explicitly rewards detailed reasoning, (3) RLHF preferences favor thorough explanations. The trigger phrase shifts the model's generation distribution toward the \"explanation\" mode it learned during training. This is evidence that reasoning capabilities are latent in the model and can be elicited by appropriate prompting."
     },
     {
       type: "mc",
       question: "When using self-consistency with $N = 40$ samples, the computational cost is 40x a single generation. Which statement about the cost-accuracy trade-off is correct?",
-      options: [
-        "Accuracy scales linearly with $N$ — 80 samples would be twice as good as 40",
-        "Accuracy improvements follow **diminishing returns** — the marginal gain from each additional sample decreases logarithmically; gains from $N=1$ to $N=5$ are much larger than from $N=20$ to $N=40$, and the optimal $N$ depends on the difficulty distribution of the task",
-        "All $N$ samples must use the same temperature",
-        "Self-consistency with $N=2$ is always worse than single CoT"
-      ],
-      correct: 1,
+      options: ["Accuracy scales linearly with $N$ — 80 samples would be twice as good as 40", "All $N$ samples must use the same temperature", "Accuracy improvements follow **diminishing returns** — the marginal gain from each additional sample decreases logarithmically; gains from $N=1$ to $N=5$ are much larger than from $N=20$ to $N=40$, and the optimal $N$ depends on the difficulty distribution of the task", "Self-consistency with $N=2$ is always worse than single CoT"],
+      correct: 2,
       explanation: "Majority voting accuracy follows a law of diminishing returns. For an easy problem where the model gets the right answer 80% of the time, even $N=5$ gives >95% accuracy (binomial probability). For a hard problem where the correct rate is 30%, even $N=100$ won't produce a majority-correct result. The marginal improvement from each additional sample decreases because the majority vote converges. The compute-optimal strategy is to allocate more samples to harder problems (adaptive compute) rather than using a fixed $N$ across all inputs."
     },
     {
       type: "mc",
       question: "A model answers a math problem correctly with CoT, but when the same problem is rephrased with a misleading \"common sense\" cue (e.g., adding irrelevant context suggesting a different answer), the model changes its answer. This demonstrates:",
-      options: [
-        "The model needs more training data",
-        "**Reasoning fragility** — the model's chain-of-thought is influenced by surface-level features and social priors rather than following a purely logical computation; genuine reasoning should be invariant to irrelevant perturbations, but the model's reasoning is entangled with pattern-matching heuristics",
-        "The rephrased problem was actually harder",
-        "CoT doesn't work for math problems"
-      ],
-      correct: 1,
+      options: ["The model needs more training data", "CoT doesn't work for math problems", "The rephrased problem was actually harder", "**Reasoning fragility** — the model's chain-of-thought is influenced by surface-level features and social priors rather than following a purely logical computation; genuine reasoning should be invariant to irrelevant perturbations, but the model's reasoning is entangled with pattern-matching heuristics"],
+      correct: 3,
       explanation: "This is a key piece of evidence in the reasoning-vs-pattern-matching debate. Studies show that adding irrelevant information (e.g., \"Alice has 5 apples\" in a problem that doesn't involve Alice) or framing a problem to suggest a common-but-wrong answer can cause models to produce incorrect reasoning chains that rationalize the wrong answer. True compositional reasoning should be invariant to such perturbations. This suggests the model's \"reasoning\" is partly a post-hoc rationalization process guided by distributional cues rather than a faithful logical computation."
     }
   ]
@@ -699,37 +514,22 @@ export const testTimeComputeAssessment = {
     {
       type: "mc",
       question: "Best-of-N sampling generates $N$ complete responses and selects the best one using a reward model or verifier. Compared to self-consistency (majority voting), best-of-N:",
-      options: [
-        "Always produces better results because it uses a reward model",
-        "Can select based on **response quality rather than just answer frequency** — it can prefer a well-reasoned minority answer over a frequently-repeated shallow answer, but its effectiveness is bounded by the verifier's accuracy and the coverage of $N$ samples",
-        "Uses less compute since it only generates one response",
-        "Is identical to self-consistency"
-      ],
-      correct: 1,
+      options: ["Can select based on **response quality rather than just answer frequency** — it can prefer a well-reasoned minority answer over a frequently-repeated shallow answer, but its effectiveness is bounded by the verifier's accuracy and the coverage of $N$ samples", "Always produces better results because it uses a reward model", "Uses less compute since it only generates one response", "Is identical to self-consistency"],
+      correct: 0,
       explanation: "Self-consistency selects by answer frequency, implicitly assuming that correct reasoning paths outnumber incorrect ones. Best-of-N uses a learned verifier to evaluate response quality, which can capture reasoning quality beyond just the final answer. However, best-of-N is limited by: (1) verifier accuracy — a miscalibrated verifier may prefer confident-sounding wrong answers, (2) sample coverage — $N$ samples may not include a correct response for very hard problems, and (3) reward hacking if the verifier has exploitable biases."
     },
     {
       type: "mc",
       question: "Applying Monte Carlo Tree Search (MCTS) to LLM reasoning faces a fundamental challenge that doesn't exist in game-playing (e.g., AlphaGo):",
-      options: [
-        "LLMs can't play games",
-        "The **branching factor is enormous** — at each token (or reasoning step), there are thousands of possible continuations, making exhaustive tree search intractable; games like Go have ~250 legal moves per position, while an LLM's vocabulary is 32K-128K tokens, and even at the reasoning-step level, the space of possible next thoughts is vast",
-        "MCTS requires a board representation",
-        "LLMs are too slow for real-time search"
-      ],
-      correct: 1,
+      options: ["LLMs can't play games", "MCTS requires a board representation", "The **branching factor is enormous** — at each token (or reasoning step), there are thousands of possible continuations, making exhaustive tree search intractable; games like Go have ~250 legal moves per position, while an LLM's vocabulary is 32K-128K tokens, and even at the reasoning-step level, the space of possible next thoughts is vast", "LLMs are too slow for real-time search"],
+      correct: 2,
       explanation: "MCTS succeeds in Go because: (1) the branching factor (~250) is manageable, (2) a value network provides reliable position evaluations, and (3) the game has a clear terminal reward. For LLM reasoning: (1) the branching factor at the token level is ~32K-128K, requiring either very aggressive pruning or operating at the \"reasoning step\" level, (2) evaluating partial reasoning chains is much harder than evaluating board positions, and (3) defining what constitutes a \"move\" in reasoning is ambiguous. Approaches like LATS and RAP address these by chunking reasoning into coarse steps and using the LLM itself as a value function."
     },
     {
       type: "mc",
       question: "Compute-optimal inference allocation suggests that the optimal amount of test-time compute should depend on:",
-      options: [
-        "Only the model size — larger models should always think longer",
-        "The **difficulty of the specific input** — easy questions should use minimal test-time compute (direct answering), while hard questions benefit from extended reasoning, search, or multiple samples; spending equal compute on all inputs is wasteful",
-        "The user's subscription tier",
-        "The time of day"
-      ],
-      correct: 1,
+      options: ["Only the model size — larger models should always think longer", "The time of day", "The user's subscription tier", "The **difficulty of the specific input** — easy questions should use minimal test-time compute (direct answering), while hard questions benefit from extended reasoning, search, or multiple samples; spending equal compute on all inputs is wasteful"],
+      correct: 3,
       explanation: "Inference scaling research shows that the value of additional test-time compute follows a difficulty-dependent curve. For easy problems, the model's first answer is usually correct — additional compute is wasted. For hard problems, extended thinking, multiple samples, or search can dramatically improve accuracy. The optimal strategy adaptively allocates compute: a difficulty classifier or confidence estimator decides how much inference-time computation to invest per query. This mirrors the human intuition of \"thinking harder\" about harder problems."
     },
     {
@@ -747,37 +547,22 @@ export const testTimeComputeAssessment = {
     {
       type: "mc",
       question: "A system uses best-of-N with a reward model to solve math problems. With $N = 1$, accuracy is 40%. With $N = 100$, accuracy reaches 75%. Doubling to $N = 200$ would most likely yield:",
-      options: [
-        "~100% accuracy — double the samples, double the improvement",
-        "~78-80% — improvements follow **logarithmic scaling** with $N$; each doubling of $N$ provides diminishing marginal gains because the probability of covering the correct solution approaches a ceiling set by the model's coverage distribution",
-        "~75% — no improvement beyond 100 samples",
-        "~50% — more samples confuse the reward model"
-      ],
-      correct: 1,
+      options: ["~78-80% — improvements follow **logarithmic scaling** with $N$; each doubling of $N$ provides diminishing marginal gains because the probability of covering the correct solution approaches a ceiling set by the model's coverage distribution", "~100% accuracy — double the samples, double the improvement", "~75% — no improvement beyond 100 samples", "~50% — more samples confuse the reward model"],
+      correct: 0,
       explanation: "Best-of-N accuracy scales as $1 - (1 - p)^N$ where $p$ is the per-sample probability of a correct-and-top-ranked response. For large $N$, this saturates. If the model has a 1% chance of producing the correct answer per sample, $N=100$ gives $\\sim 63\\%$ coverage, and $N=200$ gives $\\sim 87\\%$. But with a reward model selector, the binding constraint is often the reward model's ability to distinguish correct from incorrect solutions, not just coverage. Empirically, accuracy scales roughly as $a + b \\log(N)$ in the relevant range."
     },
     {
       type: "mc",
       question: "Process reward models (PRMs) can be used for step-level beam search during test-time reasoning. In this approach, the search:",
-      options: [
-        "Generates all tokens simultaneously",
-        "Maintains a beam of $B$ partial reasoning chains, scoring each at every reasoning step using the PRM and pruning low-scoring branches — this focuses compute on the most promising reasoning paths rather than committing to a single chain or running independent samples",
-        "Only evaluates the final answer",
-        "Uses the PRM to generate tokens directly"
-      ],
-      correct: 1,
+      options: ["Generates all tokens simultaneously", "Only evaluates the final answer", "Maintains a beam of $B$ partial reasoning chains, scoring each at every reasoning step using the PRM and pruning low-scoring branches — this focuses compute on the most promising reasoning paths rather than committing to a single chain or running independent samples", "Uses the PRM to generate tokens directly"],
+      correct: 2,
       explanation: "Step-level beam search with PRMs is a structured test-time compute strategy: at each reasoning step, $B$ candidate continuations are generated, the PRM scores each partial chain, and only the top-$B$ survive. This is more efficient than best-of-N (which runs $N$ independent chains to completion) because compute is concentrated on promising paths early. The PRM acts as a value function estimating the probability of reaching a correct answer from each partial state. This is the approach advocated by Let's Verify Step by Step and subsequent work on verifier-guided search."
     },
     {
       type: "mc",
       question: "A key distinction between o1-style extended thinking and standard chain-of-thought prompting is:",
-      options: [
-        "Extended thinking uses a different model architecture",
-        "Extended thinking models are trained with **RL to optimize the reasoning process itself** — the model learns when to explore alternatives, backtrack from dead ends, and verify results, rather than producing a single linear chain; standard CoT relies on the model's pre-trained generation distribution without explicit optimization of the reasoning strategy",
-        "Standard CoT produces longer reasoning traces",
-        "Extended thinking only works in English"
-      ],
-      correct: 1,
+      options: ["Extended thinking uses a different model architecture", "Extended thinking only works in English", "Standard CoT produces longer reasoning traces", "Extended thinking models are trained with **RL to optimize the reasoning process itself** — the model learns when to explore alternatives, backtrack from dead ends, and verify results, rather than producing a single linear chain; standard CoT relies on the model's pre-trained generation distribution without explicit optimization of the reasoning strategy"],
+      correct: 3,
       explanation: "Standard CoT relies on the model's pre-trained distribution over explanation-like text — it produces plausible-looking reasoning but has no explicit incentive to reason correctly or to self-correct. o1-style models are trained with RL where the reward signal is answer correctness, so the model learns to use its reasoning trace strategically: trying multiple approaches, identifying and recovering from errors, and allocating reasoning effort proportional to problem difficulty. The RL training fundamentally changes the model's relationship to its own reasoning output from \"generating plausible text\" to \"using text as a computational medium.\""
     },
     {
@@ -795,13 +580,8 @@ export const testTimeComputeAssessment = {
     {
       type: "mc",
       question: "A company deploys a reasoning model and observes that 80% of user queries are simple (answered correctly with 1 inference step) while 20% are hard (requiring 50 inference steps). If they allocate the same 50-step budget to all queries, the wasted compute fraction is approximately:",
-      options: [
-        "0% — more compute never hurts",
-        "About 72% — the 80% of easy queries waste 49 of their 50 allocated steps, so $\\frac{0.8 \\times 49}{0.8 \\times 50 + 0.2 \\times 50} = \\frac{39.2}{50} \\approx 78\\%$ of total compute is wasted on unnecessary reasoning for easy queries",
-        "About 20% — only the hard queries waste compute",
-        "About 50%"
-      ],
-      correct: 1,
+      options: ["About 72% — the 80% of easy queries waste 49 of their 50 allocated steps, so $\\frac{0.8 \\times 49}{0.8 \\times 50 + 0.2 \\times 50} = \\frac{39.2}{50} \\approx 78\\%$ of total compute is wasted on unnecessary reasoning for easy queries", "0% — more compute never hurts", "About 20% — only the hard queries waste compute", "About 50%"],
+      correct: 0,
       explanation: "With uniform 50-step allocation: easy queries use 1 useful step + 49 wasted = 0.8 * 49 = 39.2 wasted step-equivalents. Hard queries use all 50 steps productively. Total compute = 50 steps * 100% of queries = 50 units. Wasted = 39.2 units. Waste fraction = 39.2/50 = 78.4%. Adaptive allocation (1 step for easy, 50 for hard) uses 0.8*1 + 0.2*50 = 10.8 units — a 4.6x compute reduction. This illustrates why difficulty-adaptive inference allocation is crucial for cost-effective deployment of reasoning models."
     }
   ]
@@ -821,25 +601,15 @@ export const toolUseAssessment = {
     {
       type: "mc",
       question: "Function calling in LLMs is typically trained by:",
-      options: [
-        "Hard-coding specific API calls into the model's architecture",
-        "Fine-tuning on datasets of (user query, function call, function result, final response) sequences — the model learns to emit **structured function call tokens** in a special format, which are intercepted by the serving system, executed, and the results injected back into the context",
-        "Giving the model direct access to execute code during training",
-        "Training a separate classifier that maps queries to functions"
-      ],
-      correct: 1,
+      options: ["Hard-coding specific API calls into the model's architecture", "Giving the model direct access to execute code during training", "Fine-tuning on datasets of (user query, function call, function result, final response) sequences — the model learns to emit **structured function call tokens** in a special format, which are intercepted by the serving system, executed, and the results injected back into the context", "Training a separate classifier that maps queries to functions"],
+      correct: 2,
       explanation: "Function calling training involves: (1) curating datasets where the correct response involves calling specific functions with appropriate arguments, (2) defining a structured output format (often JSON) that the model generates inline, (3) teaching the model when to call functions vs. answer directly. The serving system parses these structured outputs, executes the function, and appends the result to the context for the model to incorporate. This is how models like GPT-4 and Claude handle tool use — the function call is part of the model's text generation, not a separate system."
     },
     {
       type: "mc",
       question: "In a RAG (Retrieval-Augmented Generation) system, the chunking strategy — how documents are split into retrievable units — critically affects quality. Which statement is correct?",
-      options: [
-        "Larger chunks are always better because they provide more context",
-        "Chunk size involves a **precision-recall trade-off**: smaller chunks (128-256 tokens) yield precise retrieval but may miss surrounding context, while larger chunks (512-1024 tokens) capture more context but may dilute relevance with irrelevant text; overlapping chunks and hierarchical strategies can mitigate this",
-        "Chunking doesn't matter if the embedding model is good enough",
-        "All documents should be stored as single chunks"
-      ],
-      correct: 1,
+      options: ["Larger chunks are always better because they provide more context", "All documents should be stored as single chunks", "Chunking doesn't matter if the embedding model is good enough", "Chunk size involves a **precision-recall trade-off**: smaller chunks (128-256 tokens) yield precise retrieval but may miss surrounding context, while larger chunks (512-1024 tokens) capture more context but may dilute relevance with irrelevant text; overlapping chunks and hierarchical strategies can mitigate this"],
+      correct: 3,
       explanation: "Too-small chunks: high retrieval precision (the chunk matches the query well) but insufficient context for the LLM to synthesize an answer. Too-large chunks: the relevant passage is buried in irrelevant text, diluting the embedding representation and the LLM's ability to extract the answer. Strategies to mitigate: (1) overlapping windows (e.g., 512 tokens with 128 overlap), (2) hierarchical chunking (retrieve small chunks but expand to parent chunks for context), (3) semantic chunking (split at topic boundaries rather than fixed token counts). The optimal strategy is domain-dependent."
     },
     {
@@ -857,37 +627,22 @@ export const toolUseAssessment = {
     {
       type: "mc",
       question: "Multi-step retrieval (also called iterative or multi-hop RAG) is needed when:",
-      options: [
-        "The document collection is very large",
-        "The answer requires **synthesizing information from multiple documents** or requires a chain of lookups — e.g., \"What is the GDP of the country where the inventor of the transformer architecture was born?\" requires first retrieving who invented transformers, then their birthplace, then that country's GDP",
-        "The embedding model has limited context length",
-        "The user asks multiple questions in one turn"
-      ],
-      correct: 1,
+      options: ["The answer requires **synthesizing information from multiple documents** or requires a chain of lookups — e.g., \"What is the GDP of the country where the inventor of the transformer architecture was born?\" requires first retrieving who invented transformers, then their birthplace, then that country's GDP", "The document collection is very large", "The embedding model has limited context length", "The user asks multiple questions in one turn"],
+      correct: 0,
       explanation: "Single-shot retrieval fails on multi-hop questions because the initial query doesn't contain the intermediate information needed to formulate the final retrieval. Multi-step RAG decomposes the question: (1) retrieve \"transformer architecture inventor\" -> Vaswani et al., (2) retrieve birthplace information -> identify country, (3) retrieve GDP data. Each retrieval step uses information from prior steps to formulate the next query. Architectures like IRCoT (Interleaving Retrieval with CoT) and Self-RAG automate this decomposition."
     },
     {
       type: "mc",
       question: "When an LLM generates a function call that fails (e.g., API returns an error), the ideal error recovery behavior is:",
-      options: [
-        "Immediately returning the error message to the user",
-        "Analyzing the error, **reformulating the function call** (e.g., correcting parameter types, trying alternative APIs, or decomposing into simpler sub-calls), and retrying — this error recovery loop should be bounded to prevent infinite retries, with graceful degradation when recovery fails",
-        "Ignoring the error and generating an answer without the tool result",
-        "Calling the same function again with identical parameters"
-      ],
-      correct: 1,
+      options: ["Immediately returning the error message to the user", "Ignoring the error and generating an answer without the tool result", "Analyzing the error, **reformulating the function call** (e.g., correcting parameter types, trying alternative APIs, or decomposing into simpler sub-calls), and retrying — this error recovery loop should be bounded to prevent infinite retries, with graceful degradation when recovery fails", "Calling the same function again with identical parameters"],
+      correct: 2,
       explanation: "Robust tool use requires error handling as a core capability, not an afterthought. The model should: (1) parse the error message to diagnose the failure (auth error? malformed input? rate limit?), (2) determine if the call can be retried with corrections or if an alternative approach is needed, (3) attempt recovery with a bounded retry count, (4) gracefully inform the user if recovery fails, explaining what was attempted. Training for error recovery involves including error scenarios in the fine-tuning data — models that only see successful tool calls perform poorly when tools fail."
     },
     {
       type: "mc",
       question: "Code generation can be viewed as a form of tool use where the \"tool\" is a code interpreter. The key advantage of code execution over pure text reasoning for tasks like data analysis is:",
-      options: [
-        "Code is always shorter than natural language",
-        "Code execution provides **exact computation and verification** — the model generates a hypothesis as code, the interpreter executes it on real data and returns exact results, eliminating hallucinated computations; natural language arithmetic and data manipulation are unreliable at scale",
-        "Code runs faster than the LLM can think",
-        "Code generation doesn't require pre-training"
-      ],
-      correct: 1,
+      options: ["Code is always shorter than natural language", "Code generation doesn't require pre-training", "Code runs faster than the LLM can think", "Code execution provides **exact computation and verification** — the model generates a hypothesis as code, the interpreter executes it on real data and returns exact results, eliminating hallucinated computations; natural language arithmetic and data manipulation are unreliable at scale"],
+      correct: 3,
       explanation: "When asked \"What is the mean of these 1000 data points?\", an LLM reasoning in natural language will hallucinate a plausible-sounding number. Code generation + execution computes the exact answer. This is the core insight behind tools like Code Interpreter and open-source equivalents: the LLM's strength is understanding the user's intent and translating it to code; the interpreter's strength is exact, verifiable computation. The model can also inspect intermediate results, detect errors, and iterate — forming a generate-execute-debug loop."
     },
     {
@@ -905,37 +660,22 @@ export const toolUseAssessment = {
     {
       type: "mc",
       question: "A naive RAG system retrieves the top-5 most similar passages and concatenates them into the LLM's context. A more sophisticated approach uses the **lost-in-the-middle** finding to:",
-      options: [
-        "Only retrieve 1 passage to avoid confusion",
-        "Place the most relevant passages at the **beginning and end** of the context rather than ranked order — LLMs attend more strongly to the start and end of long contexts, so relevant information in the middle of concatenated passages is more likely to be ignored",
-        "Randomize the passage order",
-        "Retrieve from the middle of documents only"
-      ],
-      correct: 1,
+      options: ["Place the most relevant passages at the **beginning and end** of the context rather than ranked order — LLMs attend more strongly to the start and end of long contexts, so relevant information in the middle of concatenated passages is more likely to be ignored", "Only retrieve 1 passage to avoid confusion", "Randomize the passage order", "Retrieve from the middle of documents only"],
+      correct: 0,
       explanation: "Liu et al. (2023) showed that LLMs' ability to use information from retrieved passages follows a U-shaped curve: performance is highest when the relevant passage is at the beginning or end of the context, and lowest when it's in the middle. This means naive \"rank by relevance\" ordering (most relevant first, then decreasing) places important passages in the problematic middle positions. Solutions include: reordering passages to place the most relevant at the boundaries, using reciprocal rank fusion, or citing specific passages by reference to force the model's attention."
     },
     {
       type: "mc",
       question: "When deciding whether to call a tool or answer directly, the model must assess its own **epistemic uncertainty**. Which approach to this calibration challenge is most effective?",
-      options: [
-        "Always calling tools to be safe",
-        "Training on data that explicitly includes both tool-calling and direct-answering examples for similar queries, with the decision boundary based on **whether the model's knowledge is sufficient and current** — the model learns to recognize queries where its parametric knowledge may be outdated, incomplete, or unreliable",
-        "Using a hardcoded keyword list to trigger tool calls",
-        "Letting the user decide when to use tools"
-      ],
-      correct: 1,
+      options: ["Always calling tools to be safe", "Using a hardcoded keyword list to trigger tool calls", "Training on data that explicitly includes both tool-calling and direct-answering examples for similar queries, with the decision boundary based on **whether the model's knowledge is sufficient and current** — the model learns to recognize queries where its parametric knowledge may be outdated, incomplete, or unreliable", "Letting the user decide when to use tools"],
+      correct: 2,
       explanation: "Effective tool-use routing requires the model to know what it doesn't know. Training strategies include: (1) self-knowledge probing — including examples where the model should say \"I need to look this up\" for recent events or precise numbers, (2) confidence calibration — training the model to express appropriate uncertainty, (3) curriculum with both tool-assisted and direct answers for similar queries, so the model learns the decision boundary. Models like Toolformer automate this by learning to insert API calls only when they improve prediction quality, using a self-supervised filtering criterion."
     },
     {
       type: "mc",
       question: "A RAG system's retrieval component returns passages with relevance scores. At what point does adding more retrieved passages to the LLM context typically **hurt** performance?",
-      options: [
-        "Never — more context is always better",
-        "When additional passages have **low relevance scores** — they introduce noise and irrelevant information that can distract the LLM, cause hallucinated synthesis of contradictory sources, or push relevant information into the less-attended middle of the context window. Optimal passage count depends on query type and model capability",
-        "After exactly 3 passages",
-        "Only when the context window is exceeded"
-      ],
-      correct: 1,
+      options: ["Never — more context is always better", "Only when the context window is exceeded", "After exactly 3 passages", "When additional passages have **low relevance scores** — they introduce noise and irrelevant information that can distract the LLM, cause hallucinated synthesis of contradictory sources, or push relevant information into the less-attended middle of the context window. Optimal passage count depends on query type and model capability"],
+      correct: 3,
       explanation: "Adding passages with relevance scores below a task-specific threshold introduces noise. The LLM may: (1) hallucinate a synthesis of contradictory information from relevant and irrelevant passages, (2) get distracted by plausible-sounding but incorrect passages (especially problematic for factual QA), (3) suffer from the lost-in-the-middle effect as the context grows. Empirically, accuracy often peaks at 3-5 highly relevant passages and degrades with more. Adaptive retrieval strategies set a relevance threshold or use the LLM's own confidence to decide when enough context has been retrieved."
     }
   ]
@@ -967,37 +707,22 @@ export const agenticAssessment = {
     {
       type: "mc",
       question: "If an agent makes correct decisions with 95% accuracy at each step, its probability of completing a 10-step task correctly (assuming independent steps) is approximately:",
-      options: [
-        "95% — the per-step accuracy",
-        "~60% — computed as $0.95^{10} \\approx 0.599$; this **compounding error problem** means even highly reliable per-step performance degrades rapidly over multi-step tasks",
-        "~90% — nearly as good as per-step accuracy",
-        "50% — it's essentially random over 10 steps"
-      ],
-      correct: 1,
+      options: ["~60% — computed as $0.95^{10} \\approx 0.599$; this **compounding error problem** means even highly reliable per-step performance degrades rapidly over multi-step tasks", "95% — the per-step accuracy", "~90% — nearly as good as per-step accuracy", "50% — it's essentially random over 10 steps"],
+      correct: 0,
       explanation: "$0.95^{10} = 0.5987$. This is the compounding error problem: each step's small error probability multiplies. At 20 steps: $0.95^{20} = 0.358$. At 50 steps: $0.95^{50} = 0.077$. This has profound implications for agent design: (1) error recovery mechanisms are essential — agents must detect and recover from mistakes, not just avoid them, (2) reducing task horizon (fewer steps) is as valuable as improving per-step accuracy, (3) verification at intermediate checkpoints can reset the error accumulation by catching and correcting mistakes before they compound."
     },
     {
       type: "mc",
       question: "To achieve 90% task success rate on a 10-step task, the required per-step accuracy is:",
-      options: [
-        "90%",
-        "~99% — since $x^{10} = 0.9$ gives $x = 0.9^{1/10} \\approx 0.9895$; this illustrates why agentic systems need near-perfect per-step reliability for multi-step tasks",
-        "95%",
-        "99.9%"
-      ],
-      correct: 1,
+      options: ["90%", "95%", "~99% — since $x^{10} = 0.9$ gives $x = 0.9^{1/10} \\approx 0.9895$; this illustrates why agentic systems need near-perfect per-step reliability for multi-step tasks", "99.9%"],
+      correct: 2,
       explanation: "Solving $x^{10} = 0.9$: $x = 0.9^{0.1} = e^{0.1 \\ln(0.9)} = e^{-0.01053} \\approx 0.9895$. So you need ~98.95% per-step accuracy for 90% task completion. For a 20-step task: $x = 0.9^{0.05} \\approx 0.9947$ (99.47% per step). This quantifies why long-horizon agentic tasks are so challenging: the reliability requirement per step grows exponentially with task length. It also explains why current agents work best on short, well-defined tasks and struggle with open-ended, multi-step workflows."
     },
     {
       type: "mc",
       question: "Agent memory architectures typically distinguish between short-term and long-term memory. In LLM-based agents, these correspond to:",
-      options: [
-        "GPU memory vs CPU memory",
-        "The **context window** (short-term: recent observations, current plan, working state) and **external storage** (long-term: vector databases of past experiences, summarized episode histories, learned procedures) — the context window is limited and ephemeral, while external storage persists across sessions",
-        "Training data vs inference data",
-        "Attention keys vs attention values"
-      ],
-      correct: 1,
+      options: ["GPU memory vs CPU memory", "Attention keys vs attention values", "Training data vs inference data", "The **context window** (short-term: recent observations, current plan, working state) and **external storage** (long-term: vector databases of past experiences, summarized episode histories, learned procedures) — the context window is limited and ephemeral, while external storage persists across sessions"],
+      correct: 3,
       explanation: "Short-term memory is the context window: it contains the current task description, recent Thought-Action-Observation steps, and immediate working state. It's limited by the model's context length and is lost between sessions. Long-term memory uses external storage: (1) episodic memory — past task executions stored as retrievable summaries, (2) semantic memory — facts and procedures in a vector database, (3) procedural memory — learned tool-use patterns. The retrieval system selectively loads relevant long-term memories into the context window, analogous to human memory retrieval."
     },
     {
@@ -1015,37 +740,22 @@ export const agenticAssessment = {
     {
       type: "mc",
       question: "Evaluating agentic systems is fundamentally harder than evaluating standard LLM outputs because:",
-      options: [
-        "Agents produce longer outputs",
-        "Agent evaluation requires assessing **multi-step trajectories** in environments with stochastic outcomes — the same agent may take different valid paths to the same goal, intermediate states are hard to evaluate, success criteria can be ambiguous, and the environment may change between evaluation runs",
-        "Agents only work in production, not in benchmarks",
-        "Agent outputs cannot be compared to ground truth"
-      ],
-      correct: 1,
+      options: ["Agent evaluation requires assessing **multi-step trajectories** in environments with stochastic outcomes — the same agent may take different valid paths to the same goal, intermediate states are hard to evaluate, success criteria can be ambiguous, and the environment may change between evaluation runs", "Agents produce longer outputs", "Agents only work in production, not in benchmarks", "Agent outputs cannot be compared to ground truth"],
+      correct: 0,
       explanation: "Standard LLM evaluation compares a single output to a reference. Agent evaluation must handle: (1) multiple valid solution paths (did the agent take a suboptimal but correct path?), (2) partial credit for partially completed tasks, (3) environment stochasticity (web pages change, APIs have different latencies), (4) difficulty of attributing failure to specific steps vs. the overall strategy, (5) cost of evaluation (each agent run may take minutes and cost dollars in API calls). Benchmarks like SWE-bench, WebArena, and GAIA attempt standardized agent evaluation but each captures only a narrow slice of real-world agent capabilities."
     },
     {
       type: "mc",
       question: "An agent attempts to book a flight: it searches for flights (step 1), selects one (step 2), fills in passenger details (step 3), but enters the wrong date (step 4), and proceeds to payment (step 5). The most robust agent architecture would:",
-      options: [
-        "Complete the booking and hope the date is correct",
-        "Include a **verification step before irreversible actions** — after filling in details (step 3-4), verify the entered information against the original request before proceeding to payment; irreversible actions like payment should always be preceded by explicit confirmation steps that check for accumulated errors",
-        "Start over from step 1 after every step",
-        "Use a separate model for each step"
-      ],
-      correct: 1,
+      options: ["Complete the booking and hope the date is correct", "Start over from step 1 after every step", "Include a **verification step before irreversible actions** — after filling in details (step 3-4), verify the entered information against the original request before proceeding to payment; irreversible actions like payment should always be preceded by explicit confirmation steps that check for accumulated errors", "Use a separate model for each step"],
+      correct: 2,
       explanation: "Robust agent design distinguishes between reversible and irreversible actions. Browsing and form-filling are reversible (can go back and correct). Payment is irreversible. The agent should: (1) maintain an explicit plan with checkpoints, (2) verify accumulated state against the original goal before irreversible actions, (3) use self-reflection (\"Does this match what the user asked for?\") at critical junctions. This verification overhead reduces throughput but dramatically reduces costly errors. The principle mirrors software engineering: validate inputs before committing transactions."
     },
     {
       type: "mc",
       question: "The \"inner monologue\" approach to agent reasoning, where the agent maintains an explicit running commentary of its state and plans, helps primarily by:",
-      options: [
-        "Making the agent's responses more verbose for users",
-        "Keeping the agent's **goals, current state, and plan in the active context window** — without explicit tracking, the agent can lose track of what it's doing over long trajectories as earlier context scrolls out of the attention window; the inner monologue acts as a self-maintained working memory",
-        "Improving the agent's language fluency",
-        "Reducing the number of API calls"
-      ],
-      correct: 1,
+      options: ["Making the agent's responses more verbose for users", "Reducing the number of API calls", "Improving the agent's language fluency", "Keeping the agent's **goals, current state, and plan in the active context window** — without explicit tracking, the agent can lose track of what it's doing over long trajectories as earlier context scrolls out of the attention window; the inner monologue acts as a self-maintained working memory"],
+      correct: 3,
       explanation: "Over a 50-step trajectory, the early steps (including the original task description) may be hundreds of tokens back in the context, receiving diminished attention. Inner monologue explicitly restates: \"My goal is X. I have completed A, B, C. Current state is Y. Next I need to do Z.\" This keeps critical information in the recent context window where the model attends most strongly. It also serves as a form of self-verification — stating the current plan explicitly can reveal inconsistencies. The cost is additional token generation, but this is usually worthwhile for complex tasks."
     },
     {
@@ -1063,13 +773,8 @@ export const agenticAssessment = {
     {
       type: "mc",
       question: "An agent system decomposes a complex task into subtasks handled by specialized sub-agents (e.g., a \"researcher\" agent, a \"coder\" agent, a \"reviewer\" agent). The orchestration challenge is:",
-      options: [
-        "Sub-agents are more expensive than a single agent",
-        "Ensuring correct **information flow and task dependency management** — the orchestrator must track which sub-tasks are complete, pass the right context to each sub-agent (avoiding both information overload and critical omissions), handle sub-agent failures gracefully, and merge potentially conflicting outputs from parallel sub-tasks",
-        "Sub-agents can't communicate with each other",
-        "Each sub-agent needs a separate GPU"
-      ],
-      correct: 1,
+      options: ["Ensuring correct **information flow and task dependency management** — the orchestrator must track which sub-tasks are complete, pass the right context to each sub-agent (avoiding both information overload and critical omissions), handle sub-agent failures gracefully, and merge potentially conflicting outputs from parallel sub-tasks", "Sub-agents are more expensive than a single agent", "Sub-agents can't communicate with each other", "Each sub-agent needs a separate GPU"],
+      correct: 0,
       explanation: "Multi-agent orchestration is essentially a workflow management problem with LLM-specific challenges: (1) context management — each sub-agent needs enough context to do its job but not so much that it's distracted, (2) dependency tracking — the coder agent can't start until the researcher agent provides specifications, (3) failure handling — if the researcher returns low-quality results, the orchestrator must detect this and retry or adjust, (4) output merging — when the reviewer critiques the coder's output, the orchestrator must route the feedback and manage the revision loop. Frameworks like LangGraph and AutoGen provide abstractions for this but the fundamental complexity remains."
     }
   ]

--- a/src/modules/assess-branch-e.js
+++ b/src/modules/assess-branch-e.js
@@ -28,37 +28,22 @@ export const vlmAssessment = {
     {
       type: "mc",
       question: "CLIP (Contrastive Language-Image Pretraining) trains paired image and text encoders using a contrastive objective. Given a batch of $N$ image-text pairs, what does the training loss optimize?",
-      options: [
-        "Reconstruct the image pixels from the text embedding via a decoder",
-        "Maximize cosine similarity between matching image-text pairs and minimize it between all $N^2 - N$ non-matching pairs in the batch, using a symmetric cross-entropy loss over the similarity matrix",
-        "Predict masked patches in the image conditioned on the text",
-        "Classify each image into one of $N$ predefined categories using the text as labels"
-      ],
-      correct: 1,
+      options: ["Reconstruct the image pixels from the text embedding via a decoder", "Classify each image into one of $N$ predefined categories using the text as labels", "Predict masked patches in the image conditioned on the text", "Maximize cosine similarity between matching image-text pairs and minimize it between all $N^2 - N$ non-matching pairs in the batch, using a symmetric cross-entropy loss over the similarity matrix"],
+      correct: 3,
       explanation: "CLIP computes an $N \\times N$ similarity matrix of cosine similarities between all image and text embeddings in a batch. The diagonal entries are the positive pairs. Two cross-entropy losses are computed: one treating each row as a classification problem (which text matches this image?) and one treating each column similarly (which image matches this text?). The final loss is their average. This requires large batch sizes (CLIP used 32,768) to provide enough hard negatives."
     },
     {
       type: "mc",
       question: "SigLIP replaces CLIP's softmax-based contrastive loss with a sigmoid loss applied independently to each pair in the similarity matrix. What practical advantage does this provide?",
-      options: [
-        "It produces higher-quality image embeddings on all benchmarks",
-        "It eliminates the need for an all-gather across devices to compute the full $N \\times N$ similarity matrix, enabling better scaling to very large batch sizes without cross-device communication",
-        "It allows training without any text data",
-        "It reduces the image encoder size by half"
-      ],
-      correct: 1,
+      options: ["It eliminates the need for an all-gather across devices to compute the full $N \\times N$ similarity matrix, enabling better scaling to very large batch sizes without cross-device communication", "It produces higher-quality image embeddings on all benchmarks", "It allows training without any text data", "It reduces the image encoder size by half"],
+      correct: 0,
       explanation: "CLIP's softmax normalization requires the full $N \\times N$ matrix to compute the partition function, demanding an all-gather across all GPUs. SigLIP treats each of the $N^2$ pairs independently with a binary sigmoid cross-entropy: $-\\log \\sigma(z_{ij} \\cdot (2y_{ij} - 1))$, where $z_{ij}$ is the scaled similarity and $y_{ij}$ indicates if the pair matches. Each device can compute its local portion without global synchronization. This is critical at scale: SigLIP trains with batch sizes up to 1M."
     },
     {
       type: "mc",
       question: "LLaVA-style vision-language models connect a frozen visual encoder to a frozen LLM via a learned projection layer. What is the primary role of this projection?",
-      options: [
-        "It compresses the image into a single token to save context length",
-        "It maps visual encoder embeddings from the vision embedding space into the LLM's token embedding space so visual tokens can be processed by the LLM alongside text tokens",
-        "It fine-tunes the visual encoder to produce text-like outputs",
-        "It replaces the LLM's self-attention with cross-attention over image features"
-      ],
-      correct: 1,
+      options: ["It compresses the image into a single token to save context length", "It fine-tunes the visual encoder to produce text-like outputs", "It maps visual encoder embeddings from the vision embedding space into the LLM's token embedding space so visual tokens can be processed by the LLM alongside text tokens", "It replaces the LLM's self-attention with cross-attention over image features"],
+      correct: 2,
       explanation: "The visual encoder (e.g., CLIP ViT) and the LLM operate in different embedding spaces with potentially different dimensionalities. The projection layer (often a simple MLP or linear layer) learns a mapping $f: \\mathbb{R}^{d_{\\text{vision}}} \\to \\mathbb{R}^{d_{\\text{LLM}}}$ so that projected visual tokens are \"in-distribution\" for the LLM. This is the core insight of the LLaVA architecture: rather than complex cross-attention, a lightweight projection suffices when combined with visual instruction tuning."
     },
     {
@@ -76,37 +61,22 @@ export const vlmAssessment = {
     {
       type: "mc",
       question: "Visual instruction tuning (as introduced in LLaVA) involves fine-tuning on data that pairs images with multi-turn conversations. Why is this stage critical for VLM capability?",
-      options: [
-        "It trains the visual encoder to recognize objects for the first time",
-        "Without it, the model can embed visual tokens but has not learned to reason about, describe, or follow instructions involving visual content -- the projection layer alone provides spatial alignment but not task competence",
-        "It replaces the contrastive pretraining of CLIP entirely",
-        "It is only needed for models that lack a cross-attention mechanism"
-      ],
-      correct: 1,
+      options: ["It trains the visual encoder to recognize objects for the first time", "It is only needed for models that lack a cross-attention mechanism", "It replaces the contrastive pretraining of CLIP entirely", "Without it, the model can embed visual tokens but has not learned to reason about, describe, or follow instructions involving visual content -- the projection layer alone provides spatial alignment but not task competence"],
+      correct: 3,
       explanation: "After pretraining the projection layer on image-caption pairs, the model can roughly align vision and language spaces. But image captioning is a narrow task. Visual instruction tuning exposes the model to diverse tasks -- VQA, spatial reasoning, OCR, visual dialogue -- teaching it to *follow instructions* that reference visual content. This mirrors how text-only SFT unlocks a pretrained LLM's latent abilities: the knowledge is in the encoders, but instruction tuning teaches the model how to deploy it on demand."
     },
     {
       type: "mc",
       question: "Increasing the input image resolution from $224 \\times 224$ to $448 \\times 448$ with a patch size of $14 \\times 14$ changes the number of visual tokens from 256 to 1024. What is the computational consequence for self-attention over these tokens?",
-      options: [
-        "Attention cost doubles (linear scaling with token count)",
-        "Attention cost quadruples -- self-attention has $O(n^2)$ complexity in sequence length, and the visual token count itself scales quadratically with resolution, so doubling resolution yields a $4\\times$ token increase and $16\\times$ attention cost relative to the original",
-        "Attention cost remains the same because patch size is unchanged",
-        "Attention cost increases by $8\\times$"
-      ],
-      correct: 1,
+      options: ["Attention cost quadruples -- self-attention has $O(n^2)$ complexity in sequence length, and the visual token count itself scales quadratically with resolution, so doubling resolution yields a $4\\times$ token increase and $16\\times$ attention cost relative to the original", "Attention cost doubles (linear scaling with token count)", "Attention cost remains the same because patch size is unchanged", "Attention cost increases by $8\\times$"],
+      correct: 0,
       explanation: "At $224 \\times 224$ with patch size $14$: $(224/14)^2 = 256$ tokens. At $448 \\times 448$: $(448/14)^2 = 1024$ tokens, a $4\\times$ increase. Self-attention over $n$ tokens costs $O(n^2)$, so attention FLOPs go from $O(256^2)$ to $O(1024^2)$ -- a $16\\times$ increase. This quadratic-in-resolution scaling is why high-resolution VLMs require tiling strategies, visual token compression, or efficient attention to remain tractable."
     },
     {
       type: "mc",
       question: "Tiling strategies (used in models like LLaVA-NeXT and Monkey) handle high-resolution images by dividing them into crops. A $1344 \\times 1344$ image tiled into $6$ crops of $448 \\times 448$ each (plus a downsampled global view) presents what challenge?",
-      options: [
-        "Each crop loses all global context, making scene understanding impossible",
-        "The total visual token count becomes very large (e.g., $6 \\times 1024 + 256 \\approx 6400$ tokens), consuming a significant fraction of the LLM's context window and proportionally increasing inference cost",
-        "Tiling requires retraining the visual encoder from scratch",
-        "The crops overlap, creating redundant tokens that confuse the model"
-      ],
-      correct: 1,
+      options: ["Each crop loses all global context, making scene understanding impossible", "Tiling requires retraining the visual encoder from scratch", "The total visual token count becomes very large (e.g., $6 \\times 1024 + 256 \\approx 6400$ tokens), consuming a significant fraction of the LLM's context window and proportionally increasing inference cost", "The crops overlap, creating redundant tokens that confuse the model"],
+      correct: 2,
       explanation: "With 6 high-res crops at 1024 tokens each plus a 256-token global view, the model processes ~6400 visual tokens. For an LLM with an 8K context window, this leaves only ~1600 tokens for the text conversation. Each generated text token must also attend to all 6400 visual tokens, dominating prefill cost. This is why visual token compression (e.g., pooling, resampler modules like Perceiver) is important: reduce the 6400 tokens to a few hundred while retaining spatial detail."
     },
     {
@@ -124,13 +94,8 @@ export const vlmAssessment = {
     {
       type: "mc",
       question: "A VLM trained on images at $336 \\times 336$ resolution is evaluated on a document understanding task requiring reading 10pt text. The model fails despite high performance on natural image VQA. What is the most likely root cause?",
-      options: [
-        "The language model lacks knowledge about documents",
-        "The visual encoder cannot encode text characters at all",
-        "At $336 \\times 336$ with $14 \\times 14$ patches, each patch covers roughly $14 \\times 14$ pixels of the original image -- too coarse to resolve individual glyphs of small text, so the textual information is lost before it even reaches the LLM",
-        "Document understanding requires a separate OCR module that cannot be learned end-to-end"
-      ],
-      correct: 2,
+      options: ["The language model lacks knowledge about documents", "The visual encoder cannot encode text characters at all", "Document understanding requires a separate OCR module that cannot be learned end-to-end", "At $336 \\times 336$ with $14 \\times 14$ patches, each patch covers roughly $14 \\times 14$ pixels of the original image -- too coarse to resolve individual glyphs of small text, so the textual information is lost before it even reaches the LLM"],
+      correct: 3,
       explanation: "At $336 \\times 336$, a document image that was originally $2000 \\times 2000$ is downsampled by roughly $6\\times$. After ViT patching at $14 \\times 14$, each patch corresponds to roughly $84 \\times 84$ pixels in the original image. For 10pt text (~13 pixels tall at 96 DPI), multiple characters are collapsed into a single patch where they become indistinguishable. This is a resolution bottleneck, not a capability bottleneck. Higher resolution or tiling strategies (LLaVA-NeXT, InternVL) directly address this by preserving fine-grained pixel detail."
     }
   ]
@@ -150,13 +115,8 @@ export const imageGenAssessment = {
     {
       type: "mc",
       question: "In the forward (diffusion) process of a denoising diffusion probabilistic model (DDPM), noise is added to the data according to a fixed schedule $q(x_t | x_{t-1}) = \\mathcal{N}(x_t; \\sqrt{1-\\beta_t}\\, x_{t-1},\\, \\beta_t I)$. A key property is that $x_t$ can be sampled directly from $x_0$ without iterating through intermediate steps. What enables this?",
-      options: [
-        "The noise at each step is correlated, enabling recursive cancellation",
-        "The composition of Gaussian transitions is itself Gaussian: $q(x_t | x_0) = \\mathcal{N}(x_t; \\sqrt{\\bar{\\alpha}_t}\\, x_0,\\, (1-\\bar{\\alpha}_t)I)$ where $\\bar{\\alpha}_t = \\prod_{s=1}^{t}(1-\\beta_s)$, so any timestep can be sampled in closed form",
-        "The forward process uses a deterministic ODE rather than an SDE",
-        "Each step adds the same amount of noise, making the sum trivial"
-      ],
-      correct: 1,
+      options: ["The composition of Gaussian transitions is itself Gaussian: $q(x_t | x_0) = \\mathcal{N}(x_t; \\sqrt{\\bar{\\alpha}_t}\\, x_0,\\, (1-\\bar{\\alpha}_t)I)$ where $\\bar{\\alpha}_t = \\prod_{s=1}^{t}(1-\\beta_s)$, so any timestep can be sampled in closed form", "The noise at each step is correlated, enabling recursive cancellation", "The forward process uses a deterministic ODE rather than an SDE", "Each step adds the same amount of noise, making the sum trivial"],
+      correct: 0,
       explanation: "Since each forward step is a linear Gaussian transformation of $x_{t-1}$ and Gaussians are closed under linear combinations, the marginal $q(x_t | x_0)$ has an analytical form. Defining $\\alpha_t = 1 - \\beta_t$ and $\\bar{\\alpha}_t = \\prod_{s=1}^t \\alpha_s$, we get $x_t = \\sqrt{\\bar{\\alpha}_t}\\, x_0 + \\sqrt{1-\\bar{\\alpha}_t}\\, \\epsilon$ where $\\epsilon \\sim \\mathcal{N}(0, I)$. This reparameterization is essential for efficient training: we sample a random $t$, compute $x_t$ directly from $x_0$, and train the network to predict $\\epsilon$."
     },
     {
@@ -174,13 +134,8 @@ export const imageGenAssessment = {
     {
       type: "mc",
       question: "Classifier-free guidance (CFG) generates images using $\\tilde{\\epsilon}_\\theta(x_t, t, c) = (1 + w)\\,\\epsilon_\\theta(x_t, t, c) - w\\,\\epsilon_\\theta(x_t, t, \\varnothing)$, where $c$ is the conditioning signal and $w$ is the guidance scale. What tradeoff does increasing $w$ control?",
-      options: [
-        "Training speed vs. convergence stability",
-        "Higher $w$ pushes samples toward modes of the conditional distribution, increasing text-image alignment and perceived quality at the cost of reduced diversity -- extreme $w$ produces saturated, over-sharpened images",
-        "Higher $w$ increases image resolution while reducing color depth",
-        "Higher $w$ reduces the number of denoising steps required"
-      ],
-      correct: 1,
+      options: ["Training speed vs. convergence stability", "Higher $w$ increases image resolution while reducing color depth", "Higher $w$ pushes samples toward modes of the conditional distribution, increasing text-image alignment and perceived quality at the cost of reduced diversity -- extreme $w$ produces saturated, over-sharpened images", "Higher $w$ reduces the number of denoising steps required"],
+      correct: 2,
       explanation: "CFG extrapolates in the direction away from the unconditional prediction toward the conditional prediction. Geometrically, it amplifies the \"signal\" that the conditioning provides. At $w=0$, output equals the conditional model. At moderate $w$ (typically 5--15), samples become sharper and more aligned with the prompt. At very high $w$, the model over-commits to the most likely mode: colors saturate, details become exaggerated, and diversity collapses. This is the quality-diversity tradeoff -- analogous to temperature in language models but operating in score-function space."
     },
     {
@@ -198,25 +153,15 @@ export const imageGenAssessment = {
     {
       type: "mc",
       question: "Latent Diffusion Models (LDMs), as used in Stable Diffusion, perform the diffusion process in a compressed latent space rather than pixel space. What is the primary motivation for this?",
-      options: [
-        "Latent spaces produce higher-fidelity images than pixel space diffusion",
-        "Diffusion in pixel space is computationally prohibitive at high resolutions -- a $512 \\times 512 \\times 3$ image has 786K dimensions, but a pretrained autoencoder compresses this to e.g. $64 \\times 64 \\times 4$ (16K dimensions), reducing the U-Net's compute by orders of magnitude while the autoencoder handles perceptual detail",
-        "Pixel-space diffusion cannot be conditioned on text",
-        "Working in latent space eliminates the need for classifier-free guidance"
-      ],
-      correct: 1,
+      options: ["Latent spaces produce higher-fidelity images than pixel space diffusion", "Working in latent space eliminates the need for classifier-free guidance", "Pixel-space diffusion cannot be conditioned on text", "Diffusion in pixel space is computationally prohibitive at high resolutions -- a $512 \\times 512 \\times 3$ image has 786K dimensions, but a pretrained autoencoder compresses this to e.g. $64 \\times 64 \\times 4$ (16K dimensions), reducing the U-Net's compute by orders of magnitude while the autoencoder handles perceptual detail"],
+      correct: 3,
       explanation: "The key insight of Rombach et al. (2022) is separating perceptual compression (handled by a pretrained autoencoder) from semantic generation (handled by the diffusion model). The autoencoder compresses images with a large spatial downsampling factor (typically $8\\times$), learning a compact latent representation that captures perceptually important features. The diffusion U-Net then operates on this much smaller tensor, making training and inference tractable at high resolutions. The decoder converts the denoised latent back to pixel space."
     },
     {
       type: "mc",
       question: "The autoencoder in Stable Diffusion is trained with a combination of reconstruction loss, perceptual loss, and a KL or VQ regularization term on the latent space. Why is regularization of the latent space critical?",
-      options: [
-        "Without regularization the autoencoder produces blurry images",
-        "Without regularization the latent space can have arbitrary scale and structure -- the diffusion model assumes latents are well-behaved (approximately unit Gaussian after noising), so an unregularized latent space causes the diffusion model to fail to learn a consistent denoising process",
-        "Regularization is only needed for text conditioning",
-        "It prevents the decoder from memorizing training images"
-      ],
-      correct: 1,
+      options: ["Without regularization the latent space can have arbitrary scale and structure -- the diffusion model assumes latents are well-behaved (approximately unit Gaussian after noising), so an unregularized latent space causes the diffusion model to fail to learn a consistent denoising process", "Without regularization the autoencoder produces blurry images", "Regularization is only needed for text conditioning", "It prevents the decoder from memorizing training images"],
+      correct: 0,
       explanation: "An unregularized autoencoder can learn latent spaces with widely varying scales, dead dimensions, or complex multi-modal structure. The diffusion forward process adds Gaussian noise and assumes $x_T \\approx \\mathcal{N}(0, I)$. If latent values span $[-100, 100]$ in some dimensions and $[-0.01, 0.01]$ in others, the fixed noise schedule $\\beta_t$ is miscalibrated. KL regularization (toward $\\mathcal{N}(0,1)$) or VQ regularization ensures latents are compact and well-scaled. In practice, a small KL weight produces the best balance between reconstruction quality and latent regularity."
     },
     {
@@ -246,25 +191,15 @@ export const imageGenAssessment = {
     {
       type: "mc",
       question: "DDIM (Denoising Diffusion Implicit Models) accelerates sampling by allowing larger step sizes in the reverse process. It achieves this by:",
-      options: [
-        "Training a faster neural network to replace the U-Net",
-        "Redefining the reverse process as a non-Markovian deterministic mapping that shares the same marginals $q(x_t|x_0)$ as DDPM but allows skipping timesteps, producing a deterministic ODE trajectory from noise to image",
-        "Using a GAN discriminator to skip denoising steps that are \"good enough\"",
-        "Reducing the image resolution during intermediate denoising steps"
-      ],
-      correct: 1,
+      options: ["Training a faster neural network to replace the U-Net", "Reducing the image resolution during intermediate denoising steps", "Using a GAN discriminator to skip denoising steps that are \"good enough\"", "Redefining the reverse process as a non-Markovian deterministic mapping that shares the same marginals $q(x_t|x_0)$ as DDPM but allows skipping timesteps, producing a deterministic ODE trajectory from noise to image"],
+      correct: 3,
       explanation: "Song et al. (2020) showed that the DDPM forward marginals $q(x_t|x_0)$ can be shared by a family of non-Markovian reverse processes with tunable stochasticity $\\eta$. At $\\eta = 0$, the reverse process becomes a deterministic ODE: given $x_t$, $x_{t-1}$ is uniquely determined. This determinism means the trajectory is smooth, allowing large step sizes (e.g., 50 steps instead of 1000) with minimal quality loss. It also enables latent interpolation: two noise vectors $x_T$ produce meaningfully interpolable images."
     },
     {
       type: "mc",
       question: "Flow matching (Lipman et al., 2023) and rectified flows provide an alternative to the DDPM noise schedule by learning a velocity field $v_\\theta(x_t, t)$ that transports a noise distribution to the data distribution along straight paths. What advantage does the straight-path formulation offer?",
-      options: [
-        "It eliminates the need for a neural network entirely",
-        "Straight paths minimize transport cost and enable high-quality generation in very few steps (sometimes 1--4), because the learned ODE trajectories have low curvature and the Euler discretization error is small",
-        "It only works for images smaller than $256 \\times 256$",
-        "It replaces the U-Net with a linear transformation"
-      ],
-      correct: 1,
+      options: ["Straight paths minimize transport cost and enable high-quality generation in very few steps (sometimes 1--4), because the learned ODE trajectories have low curvature and the Euler discretization error is small", "It eliminates the need for a neural network entirely", "It only works for images smaller than $256 \\times 256$", "It replaces the U-Net with a linear transformation"],
+      correct: 0,
       explanation: "DDPM reverse trajectories are curved in data space because the noise schedule creates non-linear paths. Curved trajectories require many small Euler steps to follow accurately. Rectified flows / flow matching learn to transport along straight lines: $x_t = (1-t)\\epsilon + t\\, x_0$, and the model predicts the constant velocity $v = x_0 - \\epsilon$. Since straight-line ODE trajectories have zero curvature, even a single Euler step can produce reasonable results. This is the core principle behind models like Stable Diffusion 3 and FLUX, which use flow matching for efficient few-step generation."
     }
   ]
@@ -284,13 +219,8 @@ export const audioAssessment = {
     {
       type: "mc",
       question: "Encodec (Meta) and SpeechTokenizer convert continuous audio waveforms into discrete token sequences using residual vector quantization (RVQ). In RVQ with $Q$ codebooks, the first codebook captures:",
-      options: [
-        "The highest-frequency components of the audio",
-        "The coarsest approximation of the signal, with each subsequent codebook encoding the residual error from previous quantization stages, progressively refining the reconstruction",
-        "Only the silence/non-silence boundaries",
-        "Randomly selected frequency bands"
-      ],
-      correct: 1,
+      options: ["The highest-frequency components of the audio", "Only the silence/non-silence boundaries", "The coarsest approximation of the signal, with each subsequent codebook encoding the residual error from previous quantization stages, progressively refining the reconstruction", "Randomly selected frequency bands"],
+      correct: 2,
       explanation: "RVQ works hierarchically: codebook 1 quantizes the original embedding to its nearest codeword, producing a coarse approximation. Codebook 2 then quantizes the *residual* (the difference between the original and the codebook-1 approximation). Codebook 3 quantizes the residual of the residual, and so on. Each layer captures progressively finer details. For speech, the first codebook typically captures phonemic/semantic content, while later codebooks encode prosodic detail, speaker timbre, and acoustic texture."
     },
     {
@@ -308,25 +238,15 @@ export const audioAssessment = {
     {
       type: "mc",
       question: "Whisper (OpenAI) is trained on 680,000 hours of weakly supervised audio-transcript pairs scraped from the internet. What does \"weakly supervised\" mean in this context, and why is it significant?",
-      options: [
-        "The model is trained without any labels using contrastive learning",
-        "The transcripts are not manually verified -- they come from existing subtitles, captions, and ASR outputs of varying quality, but the sheer scale and diversity of this noisy supervision produces a model that generalizes far better than prior systems trained on smaller, cleaner datasets",
-        "The model only learns to transcribe English",
-        "\"Weakly supervised\" means the model is fine-tuned with reinforcement learning"
-      ],
-      correct: 1,
+      options: ["The model is trained without any labels using contrastive learning", "\"Weakly supervised\" means the model is fine-tuned with reinforcement learning", "The model only learns to transcribe English", "The transcripts are not manually verified -- they come from existing subtitles, captions, and ASR outputs of varying quality, but the sheer scale and diversity of this noisy supervision produces a model that generalizes far better than prior systems trained on smaller, cleaner datasets"],
+      correct: 3,
       explanation: "Prior ASR systems trained on carefully transcribed corpora (e.g., LibriSpeech, 960 hours) achieved high accuracy on matched domains but degraded on out-of-distribution audio. Whisper trades label precision for scale and diversity: internet subtitles are noisy (mistimed, paraphrased, or machine-generated), but covering 680K hours across 96+ languages and countless acoustic conditions teaches the model robust generalization. This mirrors the pretraining philosophy of LLMs: massive, noisy, diverse data outperforms small, curated data."
     },
     {
       type: "mc",
       question: "AudioLM (Google) generates audio by first predicting semantic tokens (from w2v-BERT), then using those to condition the generation of acoustic tokens (from SoundStream). Why is this two-stage coarse-to-fine approach necessary?",
-      options: [
-        "It reduces the total model size",
-        "Jointly modeling semantic and acoustic tokens in a single flat sequence would require the model to simultaneously maintain long-range linguistic coherence and fine-grained acoustic detail across thousands of tokens per second -- the hierarchical approach lets each stage focus on its respective timescale and level of abstraction",
-        "The two stages use different programming languages",
-        "Semantic tokens are only needed for non-English languages"
-      ],
-      correct: 1,
+      options: ["Jointly modeling semantic and acoustic tokens in a single flat sequence would require the model to simultaneously maintain long-range linguistic coherence and fine-grained acoustic detail across thousands of tokens per second -- the hierarchical approach lets each stage focus on its respective timescale and level of abstraction", "It reduces the total model size", "The two stages use different programming languages", "Semantic tokens are only needed for non-English languages"],
+      correct: 0,
       explanation: "At 24 kHz with Encodec-style tokenization, one second of audio can produce 75+ tokens per RVQ level across 8 levels = 600+ tokens/second. A flat autoregressive model over all tokens would need to maintain coherence over thousands of tokens for a few seconds of speech. AudioLM's hierarchy solves this: the semantic stage models linguistic structure (what words/sounds to produce) at a compressed timescale, then the acoustic stage fills in the fine-grained details conditioned on those semantic decisions. Each stage's context length is manageable."
     },
     {
@@ -356,37 +276,22 @@ export const audioAssessment = {
     {
       type: "mc",
       question: "Prosody (intonation, stress, rhythm) carries significant meaning in speech. The sentence \"You're going?\" vs. \"You're going.\" differs only in pitch contour. Why is preserving prosody particularly challenging in discrete speech tokenization?",
-      options: [
-        "Prosody only exists in tonal languages like Mandarin",
-        "Discrete codebooks with limited size force prosodic variation into a finite set of categories, quantizing continuous $F_0$ (fundamental frequency) contours and energy envelopes into coarse bins -- subtle distinctions like sarcasm, hesitation, or emphasis that depend on fine-grained pitch and timing modulation may fall within the same quantization bucket",
-        "Modern tokenizers perfectly capture all prosodic features",
-        "Prosody is fully determined by the text content and does not need to be encoded"
-      ],
-      correct: 1,
+      options: ["Prosody only exists in tonal languages like Mandarin", "Prosody is fully determined by the text content and does not need to be encoded", "Modern tokenizers perfectly capture all prosodic features", "Discrete codebooks with limited size force prosodic variation into a finite set of categories, quantizing continuous $F_0$ (fundamental frequency) contours and energy envelopes into coarse bins -- subtle distinctions like sarcasm, hesitation, or emphasis that depend on fine-grained pitch and timing modulation may fall within the same quantization bucket"],
+      correct: 3,
       explanation: "Pitch ($F_0$) is a continuous signal varying from roughly 80-400 Hz in speech. A codebook entry must represent a region of this space. If the quantization is too coarse, the difference between a rising intonation (question) and a falling one (statement) may be captured, but subtler cues -- the slight pitch rise indicating sarcasm, the micro-pauses signaling hesitation, the emphasis pattern conveying focus (\"I didn't say HE stole it\" vs. \"I didn't say he STOLE it\") -- get collapsed. This is why multi-level RVQ helps: coarse levels capture broad contour, fine levels capture nuance."
     },
     {
       type: "mc",
       question: "Continuous speech representations (e.g., from wav2vec 2.0 or HuBERT encoder outputs before quantization) vs. discrete speech tokens offer different tradeoffs. Which statement best characterizes the advantage of continuous representations?",
-      options: [
-        "Continuous representations are always smaller in memory than discrete tokens",
-        "They preserve the full information density of the encoder output without quantization loss, enabling higher reconstruction fidelity and smoother interpolation -- but they cannot be directly consumed by standard autoregressive language models, which require categorical distributions over a finite vocabulary",
-        "Continuous representations do not require a neural network to produce",
-        "They are faster to generate autoregressively"
-      ],
-      correct: 1,
+      options: ["They preserve the full information density of the encoder output without quantization loss, enabling higher reconstruction fidelity and smoother interpolation -- but they cannot be directly consumed by standard autoregressive language models, which require categorical distributions over a finite vocabulary", "Continuous representations are always smaller in memory than discrete tokens", "Continuous representations do not require a neural network to produce", "They are faster to generate autoregressively"],
+      correct: 0,
       explanation: "Continuous representations retain all information from the encoder -- no codebook bottleneck. This matters for high-fidelity applications (music generation, emotional speech synthesis). However, the standard LLM next-token prediction framework uses softmax over a discrete vocabulary. To use continuous representations, you need either: (1) diffusion-based decoders that operate on continuous vectors, (2) flow-matching that maps between distributions, or (3) regression heads with continuous loss functions. Each adds architectural complexity compared to the simplicity of predicting discrete token IDs."
     },
     {
       type: "mc",
       question: "Emotion and affect in speech are conveyed through a combination of pitch variation, speaking rate, energy dynamics, and voice quality (breathiness, tenseness). A speech tokenizer trained primarily on ASR-oriented objectives (e.g., CTC loss for transcription) tends to:",
-      options: [
-        "Perfectly preserve all emotional cues since they are essential for transcription",
-        "Discard emotional information because ASR objectives reward tokens that are invariant to speaker affect -- the same phoneme should map to the same token whether spoken angrily or sadly, so the encoder actively learns to suppress paralinguistic variation that does not aid transcription",
-        "Only capture emotion in the first RVQ level",
-        "Produce emotional representations that are more accurate than human perception"
-      ],
-      correct: 1,
+      options: ["Perfectly preserve all emotional cues since they are essential for transcription", "Only capture emotion in the first RVQ level", "Discard emotional information because ASR objectives reward tokens that are invariant to speaker affect -- the same phoneme should map to the same token whether spoken angrily or sadly, so the encoder actively learns to suppress paralinguistic variation that does not aid transcription", "Produce emotional representations that are more accurate than human perception"],
+      correct: 2,
       explanation: "ASR-oriented objectives define success as correct word sequence output regardless of how the words are spoken. The ideal ASR representation is one where \"hello\" maps to the same latent whether whispered, shouted, or spoken sarcastically. This means the encoder learns to become invariant to exactly the paralinguistic features that carry emotion. Conversely, speech synthesis models need to preserve these features. This tension drives the design of disentangled representations where semantic (ASR-friendly) and paralinguistic (synthesis-friendly) information are explicitly separated."
     },
     {
@@ -418,37 +323,22 @@ export const videoAssessment = {
     {
       type: "mc",
       question: "Temporal consistency is a central challenge in video generation. A diffusion model generates each frame conditioned on a text prompt, but without explicit temporal modeling, frames exhibit flickering and identity drift. What is the primary architectural approach to enforcing consistency?",
-      options: [
-        "Generating each frame independently at very high resolution",
-        "Extending the 2D spatial attention of image diffusion models with temporal attention layers that attend across frames at corresponding spatial positions, allowing the model to enforce coherence of objects, lighting, and motion across the time dimension",
-        "Using a separate post-processing neural network to smooth out inconsistencies",
-        "Limiting generation to very short clips (under 0.5 seconds)"
-      ],
-      correct: 1,
+      options: ["Generating each frame independently at very high resolution", "Limiting generation to very short clips (under 0.5 seconds)", "Using a separate post-processing neural network to smooth out inconsistencies", "Extending the 2D spatial attention of image diffusion models with temporal attention layers that attend across frames at corresponding spatial positions, allowing the model to enforce coherence of objects, lighting, and motion across the time dimension"],
+      correct: 3,
       explanation: "Models like Video Diffusion Models, AnimateDiff, and Sora insert temporal attention blocks (or 3D convolutions) between the existing spatial attention layers. In temporal attention, a token at spatial position $(h, w)$ attends to tokens at the same position across all frames, learning that an object should maintain consistent appearance and that motion should be smooth. Some architectures use full 3D self-attention (each token attends across both space and time), trading higher compute for stronger consistency. The key insight: temporal coherence is not a post-processing problem but must be baked into the generation process."
     },
     {
       type: "mc",
       question: "A 10-second video at 24 FPS and $256 \\times 256$ resolution, tokenized with a spatial patch size of $16 \\times 16$ and temporal patch size of 1 (every frame), produces how many tokens?",
-      options: [
-        "$240 \\times 256 = 61,440$ tokens",
-        "$240 \\times (16 \\times 16) = 61,440$ tokens",
-        "$240 \\times 256 = 61,440$ tokens where 256 is the number of spatial patches per frame",
-        "$(10 \\times 24) \\times (256/16)^2 = 240 \\times 256 = 61,440$ tokens"
-      ],
-      correct: 3,
+      options: ["$(10 \\times 24) \\times (256/16)^2 = 240 \\times 256 = 61,440$ tokens", "$240 \\times (16 \\times 16) = 61,440$ tokens", "$240 \\times 256 = 61,440$ tokens where 256 is the number of spatial patches per frame", "$240 \\times 256 = 61,440$ tokens"],
+      correct: 0,
       explanation: "The calculation: 10 seconds $\\times$ 24 FPS = 240 frames. Each frame has $(256/16) \\times (256/16) = 16 \\times 16 = 256$ spatial patches. Total tokens: $240 \\times 256 = 61{,}440$. With self-attention at $O(n^2)$, this means $\\sim 3.8 \\times 10^9$ attention entries -- already straining memory at this modest resolution. At $1024 \\times 1024$ resolution, the same video would produce $240 \\times 4096 = 983{,}040$ tokens. This token explosion is the fundamental computational bottleneck of video generation."
     },
     {
       type: "mc",
       question: "Temporal patch size (the number of consecutive frames compressed into a single token) directly trades off temporal resolution against token count. Increasing temporal patch size from 1 to 4 (compressing 4 frames per token) reduces the token count by $4\\times$, but introduces what limitation?",
-      options: [
-        "The model can no longer generate video, only images",
-        "It reduces the model's ability to represent fast motion and rapid scene changes -- events shorter than 4 frames are blurred within a single token's representation, and the model cannot generate frame-level variations within a temporal patch",
-        "Color accuracy decreases proportionally",
-        "The spatial resolution is also reduced by $4\\times$"
-      ],
-      correct: 1,
+      options: ["The model can no longer generate video, only images", "Color accuracy decreases proportionally", "It reduces the model's ability to represent fast motion and rapid scene changes -- events shorter than 4 frames are blurred within a single token's representation, and the model cannot generate frame-level variations within a temporal patch", "The spatial resolution is also reduced by $4\\times$"],
+      correct: 2,
       explanation: "With a temporal patch size of 4 at 24 FPS, each token spans $4/24 \\approx 167$ ms. Any motion or change occurring within that window is compressed into a single latent vector. Fast hand gestures, eye blinks, or rapid scene transitions (~100ms events) get averaged or blurred. The model also cannot specify per-frame details within a temporal patch -- it generates a \"summary\" that the decoder must expand to 4 frames. This is directly analogous to spatial patching: larger patches reduce cost but lose fine detail."
     },
     {
@@ -466,37 +356,22 @@ export const videoAssessment = {
     {
       type: "mc",
       question: "Omni-modal models (e.g., GPT-4o, Gemini) aim to process and generate across text, image, audio, and video within a single model. What is the fundamental alignment challenge when integrating modalities that were pretrained separately?",
-      options: [
-        "Different modalities require different GPU types",
-        "Each modality's encoder was trained with different objectives (contrastive, reconstructive, predictive) and maps data to embedding spaces with different geometric structures, scales, and semantic granularities -- forcing these into a shared representation space risks either destroying modality-specific information or creating a space where cross-modal reasoning is superficial",
-        "Omni-modal models always require more training data than single-modality models",
-        "The tokenizers for different modalities must have identical vocabulary sizes"
-      ],
-      correct: 1,
+      options: ["Different modalities require different GPU types", "The tokenizers for different modalities must have identical vocabulary sizes", "Omni-modal models always require more training data than single-modality models", "Each modality's encoder was trained with different objectives (contrastive, reconstructive, predictive) and maps data to embedding spaces with different geometric structures, scales, and semantic granularities -- forcing these into a shared representation space risks either destroying modality-specific information or creating a space where cross-modal reasoning is superficial"],
+      correct: 3,
       explanation: "A CLIP vision encoder learns a space optimized for image-text retrieval (contrastive, normalized embeddings on a hypersphere). A speech encoder like HuBERT learns representations optimized for phonemic discrimination. A video encoder might use reconstruction objectives. These spaces have fundamentally different geometries: contrastive spaces are hyperspherical, reconstruction spaces may be approximately Gaussian, predictive spaces may have complex manifold structure. Naively projecting all into a shared space either requires the projections to be extremely expressive (adding parameters) or accepts lossy alignment. Successful omni-modal models typically use extensive joint training to co-adapt representations."
     },
     {
       type: "mc",
       question: "A 30-second video at 720p (1280$\\times$720), 30 FPS, with spatial patch size 16 and temporal patch size 2 produces tokens for an LLM backbone. Approximately how many visual tokens result, and how does this compare to a typical LLM context window?",
-      options: [
-        "~2,000 tokens, fitting easily in any context window",
-        "~101,250 tokens (450 temporal slots $\\times$ 225 spatial tokens per frame pair), which exceeds the 32K--128K context windows of most LLMs, requiring either aggressive compression, sparse attention, or hierarchical processing",
-        "~1,000,000 tokens, requiring a completely new architecture",
-        "~10,000 tokens, manageable with standard attention"
-      ],
-      correct: 1,
+      options: ["~101,250 tokens (450 temporal slots $\\times$ 225 spatial tokens per frame pair), which exceeds the 32K--128K context windows of most LLMs, requiring either aggressive compression, sparse attention, or hierarchical processing", "~2,000 tokens, fitting easily in any context window", "~1,000,000 tokens, requiring a completely new architecture", "~10,000 tokens, manageable with standard attention"],
+      correct: 0,
       explanation: "Frames: $30 \\times 30 = 900$. With temporal patch size 2: $900/2 = 450$ temporal slots. Spatial tokens per frame pair: $(1280/16) \\times (720/16) = 80 \\times 45 = 3600$. Total: $450 \\times 3600 = 1{,}620{,}000$ -- actually even larger than option C. Even with aggressive spatial compression to, say, 225 tokens (via a Perceiver or $4\\times$ spatial downsampling to 320$\\times$180 effective), you get $450 \\times 225 \\approx 101{,}250$ tokens. This far exceeds standard context windows, illustrating why video models must use aggressive spatial-temporal compression, memory-efficient attention, or streaming approaches."
     },
     {
       type: "mc",
       question: "Video generation models often use a cascaded approach: generate at low resolution (e.g., $64 \\times 64$), then apply spatial and temporal super-resolution models. Compared to directly generating at high resolution, what tradeoff does cascading introduce?",
-      options: [
-        "Cascading always produces better results with no downsides",
-        "Each cascade stage can introduce its own artifacts and inconsistencies -- spatial upsampling may hallucinate fine details that are temporally inconsistent, temporal interpolation may create ghosting between keyframes, and errors accumulate across stages, but the approach is far more computationally tractable than direct high-resolution generation",
-        "Cascading requires exactly 3 stages to work",
-        "The low-resolution base model does not need temporal attention"
-      ],
-      correct: 1,
+      options: ["Cascading always produces better results with no downsides", "Cascading requires exactly 3 stages to work", "Each cascade stage can introduce its own artifacts and inconsistencies -- spatial upsampling may hallucinate fine details that are temporally inconsistent, temporal interpolation may create ghosting between keyframes, and errors accumulate across stages, but the approach is far more computationally tractable than direct high-resolution generation", "The low-resolution base model does not need temporal attention"],
+      correct: 2,
       explanation: "At $64 \\times 64$, the base model has a manageable $16$ spatial tokens per frame (with patch size 16) or $64$ tokens (patch size 8). Spatial super-resolution $64 \\to 256 \\to 1024$ adds details but must invent fine-grained textures that are consistent across frames. Temporal super-resolution (generating intermediate frames) must produce smooth motion but may create ghosting when objects move non-linearly between keyframes. Each stage is independently trained and may have different error modes. Despite these challenges, cascading is the dominant approach because direct $1024 \\times 1024 \\times 30\\text{fps}$ generation remains prohibitively expensive."
     },
     {
@@ -514,25 +389,15 @@ export const videoAssessment = {
     {
       type: "mc",
       question: "Sora (OpenAI) generates videos using a diffusion transformer (DiT) operating on spacetime patches. The use of a transformer (rather than U-Net) architecture for video diffusion offers which key advantage?",
-      options: [
-        "Transformers are always faster than U-Nets for image generation",
-        "Transformers treat spatial and temporal dimensions uniformly as a sequence of tokens, enabling flexible attention patterns (spatial-only, temporal-only, or full spacetime attention), seamless scaling via standard transformer scaling laws, and natural handling of variable resolutions and durations without architectural changes",
-        "U-Nets cannot process video data at all",
-        "Transformers eliminate the need for a noise schedule"
-      ],
-      correct: 1,
+      options: ["Transformers are always faster than U-Nets for image generation", "Transformers eliminate the need for a noise schedule", "U-Nets cannot process video data at all", "Transformers treat spatial and temporal dimensions uniformly as a sequence of tokens, enabling flexible attention patterns (spatial-only, temporal-only, or full spacetime attention), seamless scaling via standard transformer scaling laws, and natural handling of variable resolutions and durations without architectural changes"],
+      correct: 3,
       explanation: "U-Nets have a fixed hierarchical structure with hard-coded spatial downsampling/upsampling stages. Adapting them for video requires inserting temporal layers at each scale, creating architectural complexity. DiTs flatten everything into a 1D sequence of spacetime patch tokens, then apply standard transformer blocks. This offers: (1) uniform treatment of space and time -- attention can be spatial, temporal, or full 3D based on compute budget; (2) known scaling laws from LLMs transfer to guide capacity planning; (3) variable-length sequences handle different resolutions and durations naturally; (4) infrastructure optimizations (FlashAttention, tensor parallelism) apply directly."
     },
     {
       type: "mc",
       question: "A researcher wants to build a model that understands and generates across text, images, audio, and video. They consider two architectures: (A) separate specialized encoders/decoders per modality connected via a shared latent space, vs. (B) a single tokenizer that maps all modalities to a shared discrete vocabulary and a single autoregressive transformer. What is the core tradeoff?",
-      options: [
-        "Architecture A is always better because specialized components outperform general ones",
-        "Architecture B is always better because a single model is simpler to train",
-        "Architecture A preserves modality-specific representations and allows each component to be optimized independently, but requires complex routing and loses the emergent cross-modal reasoning that may arise from joint training; Architecture B offers elegant simplicity and enables cross-modal in-context learning, but suffers from the vocabulary and tokenization-rate mismatches discussed earlier, and the shared capacity must serve all modalities",
-        "There is no meaningful tradeoff; both architectures produce identical results"
-      ],
-      correct: 2,
+      options: ["Architecture A preserves modality-specific representations and allows each component to be optimized independently, but requires complex routing and loses the emergent cross-modal reasoning that may arise from joint training; Architecture B offers elegant simplicity and enables cross-modal in-context learning, but suffers from the vocabulary and tokenization-rate mismatches discussed earlier, and the shared capacity must serve all modalities", "Architecture B is always better because a single model is simpler to train", "Architecture A is always better because specialized components outperform general ones", "There is no meaningful tradeoff; both architectures produce identical results"],
+      correct: 0,
       explanation: "This is one of the defining architectural debates in multimodal AI. Architecture A (modular, e.g., Flamingo, LLaVA) benefits from plug-and-play components: upgrade the vision encoder without retraining the LLM. But the integration points (projection layers, cross-attention) may be information bottlenecks. Architecture B (monolithic, e.g., Chameleon, Gemini-style) treats everything as tokens in one sequence, potentially enabling emergent behaviors like \"reasoning about what an image would sound like.\" But it faces tokenization-rate mismatches (video dominates the sequence), codebook design challenges (one vocabulary for all modalities?), and requires enormous training data covering all modality combinations. Current frontier models increasingly lean toward hybrid approaches."
     }
   ]

--- a/src/modules/assess-branch-f.js
+++ b/src/modules/assess-branch-f.js
@@ -17,37 +17,22 @@ export const probingAssessment = {
     {
       type: "mc",
       question: "A linear probe trained on a frozen LLM's hidden representations achieves 92% accuracy at classifying part-of-speech tags. What can we validly conclude from this result?",
-      options: [
-        "The model actively uses POS information during its forward pass to make predictions",
-        "The hidden representations contain linearly accessible information about POS, but this does not prove the model uses that information for downstream tasks",
-        "The model has explicitly learned a POS tagging algorithm during pretraining",
-        "POS information is stored in a specific attention head that we have now identified"
-      ],
-      correct: 1,
+      options: ["The model actively uses POS information during its forward pass to make predictions", "The model has explicitly learned a POS tagging algorithm during pretraining", "The hidden representations contain linearly accessible information about POS, but this does not prove the model uses that information for downstream tasks", "POS information is stored in a specific attention head that we have now identified"],
+      correct: 2,
       explanation: "A linear probe demonstrates that the information is linearly decodable from the representation, not that the model causally uses it. This is a fundamental limitation: representations are high-dimensional, and a probe might extract information that is a byproduct of encoding other features. The model may encode POS-correlated structure without ever \"reading\" it. Causal methods like activation patching are needed to establish whether information is actually used."
     },
     {
       type: "mc",
       question: "Activation patching (also called causal tracing) works by running a model on a clean input and a corrupted input, then selectively restoring activations from the clean run into the corrupted run at specific positions and layers. If restoring the residual stream at layer $l$, position $t$ recovers the model's original output, what does this demonstrate?",
-      options: [
-        "Layer $l$ is the only layer that matters for this prediction",
-        "The residual stream at $(l, t)$ carries information that is causally necessary for the model to produce its output on this input, because restoring it suffices to recover the clean behavior in the otherwise-corrupted computation",
-        "The attention heads at layer $l$ have memorized the answer",
-        "Position $t$ always contains the most important information regardless of the input"
-      ],
-      correct: 1,
+      options: ["Layer $l$ is the only layer that matters for this prediction", "Position $t$ always contains the most important information regardless of the input", "The attention heads at layer $l$ have memorized the answer", "The residual stream at $(l, t)$ carries information that is causally necessary for the model to produce its output on this input, because restoring it suffices to recover the clean behavior in the otherwise-corrupted computation"],
+      correct: 3,
       explanation: "Activation patching establishes a causal claim: the information flowing through the residual stream at that specific (layer, position) is sufficient to restore clean behavior when the rest of the computation uses corrupted activations. This is stronger than probing because it demonstrates causal relevance, not just information presence. The original causal tracing work by Meng et al. used this to localize factual associations to mid-layer MLPs at the last subject token position."
     },
     {
       type: "mc",
       question: "ROME (Rank-One Model Editing) edits factual knowledge in a transformer by modifying a single MLP weight matrix. Specifically, it targets the second MLP matrix $W_{\\text{out}}$ at a critical layer identified via causal tracing. What mathematical operation does ROME perform?",
-      options: [
-        "It fine-tunes the entire MLP layer with gradient descent on a corrective loss",
-        "It applies a rank-one update $W_{\\text{out}} \\leftarrow W_{\\text{out}} + \\Delta$ where $\\Delta = \\frac{(v_* - W_{\\text{out}} k_*) k_*^T}{k_*^T k_*}$ is chosen so the MLP maps the subject's key vector $k_*$ to a new value vector $v_*$ encoding the desired fact",
-        "It deletes the attention head responsible for the old fact and retrains a new one",
-        "It adds a new neuron to the MLP that fires only for the edited fact"
-      ],
-      correct: 1,
+      options: ["It applies a rank-one update $W_{\\text{out}} \\leftarrow W_{\\text{out}} + \\Delta$ where $\\Delta = \\frac{(v_* - W_{\\text{out}} k_*) k_*^T}{k_*^T k_*}$ is chosen so the MLP maps the subject's key vector $k_*$ to a new value vector $v_*$ encoding the desired fact", "It fine-tunes the entire MLP layer with gradient descent on a corrective loss", "It deletes the attention head responsible for the old fact and retrains a new one", "It adds a new neuron to the MLP that fires only for the edited fact"],
+      correct: 0,
       explanation: "ROME treats the MLP as a key-value memory where the first projection computes keys and the second projection stores values. The rank-one update is a constrained least-squares solution: it modifies $W_{\\text{out}}$ minimally (in Frobenius norm) such that $W_{\\text{out}}^{\\text{new}} k_* = v_*$, where $v_*$ is optimized so the model's output distribution assigns high probability to the new target. This is equivalent to writing a single new key-value association into the MLP's implicit memory."
     },
     {
@@ -65,37 +50,22 @@ export const probingAssessment = {
     {
       type: "mc",
       question: "Amnesic probing addresses a key limitation of standard linear probing. Instead of training a probe to extract a feature, amnesic probing removes the feature's linear subspace from the representation and measures the effect on downstream task performance. What does this method reveal that standard probing cannot?",
-      options: [
-        "Whether the feature is present in the representation at all",
-        "Whether the model's downstream behavior actually depends on the linearly-encoded feature, by showing performance degrades when that information is projected out, thereby establishing a causal rather than merely correlational link",
-        "The exact neurons responsible for encoding the feature",
-        "The training data examples that caused the feature to be learned"
-      ],
-      correct: 1,
+      options: ["Whether the feature is present in the representation at all", "The exact neurons responsible for encoding the feature", "Whether the model's downstream behavior actually depends on the linearly-encoded feature, by showing performance degrades when that information is projected out, thereby establishing a causal rather than merely correlational link", "The training data examples that caused the feature to be learned"],
+      correct: 2,
       explanation: "Standard probing shows information presence; amnesic probing shows information usage. By computing the linear subspace encoding a feature (e.g., via INLP — Iterative Null-space Projection) and projecting it out, we can measure whether the model's behavior changes. If performance drops, the model's computation causally depends on that linearly-encoded information. If performance is unchanged despite high probe accuracy, the information was present but unused — a \"ghost feature.\" This bridges the gap between probing and causal analysis."
     },
     {
       type: "mc",
       question: "CheckList is a behavioral testing framework for NLP models that organizes tests into a matrix of linguistic capabilities versus test types. Which of the following best describes CheckList's test type taxonomy?",
-      options: [
-        "Training tests, validation tests, and deployment tests",
-        "Minimum Functionality Tests (simple sanity checks), Invariance tests (perturbations that should not change the output), and Directional Expectation tests (perturbations that should change the output in a predictable direction)",
-        "Unit tests on individual neurons, integration tests on layers, and system tests on full predictions",
-        "Accuracy tests, robustness tests, and fairness tests only"
-      ],
-      correct: 1,
+      options: ["Training tests, validation tests, and deployment tests", "Accuracy tests, robustness tests, and fairness tests only", "Unit tests on individual neurons, integration tests on layers, and system tests on full predictions", "Minimum Functionality Tests (simple sanity checks), Invariance tests (perturbations that should not change the output), and Directional Expectation tests (perturbations that should change the output in a predictable direction)"],
+      correct: 3,
       explanation: "CheckList defines three test types: MFT (Minimum Functionality Tests) target simple behaviors the model should handle trivially, akin to unit tests; INV (Invariance) tests apply label-preserving perturbations (e.g., adding irrelevant context, paraphrasing) and check that predictions remain stable; DIR (Directional Expectation) tests apply perturbations with known expected effects (e.g., adding \"This is great\" to a review should increase sentiment score). These are crossed with capabilities like negation, temporal reasoning, and coreference to create a comprehensive behavioral matrix."
     },
     {
       type: "mc",
       question: "A researcher trains a nonlinear (2-layer MLP) probe on frozen GPT-2 representations and achieves 95% accuracy on a syntactic task, while a linear probe achieves only 60%. A colleague argues this proves GPT-2 has rich syntactic representations. What is the strongest methodological concern?",
-      options: [
-        "Nonlinear probes are always invalid because they are too powerful",
-        "A sufficiently expressive nonlinear probe can learn the task itself rather than merely extracting information from the representation — high accuracy may reflect the probe's computational power rather than information present in the frozen features, making it essential to compare against a control baseline (e.g., probing random representations of the same dimensionality)",
-        "GPT-2 is too small to learn syntax so the result must be wrong",
-        "MLP probes cannot be trained on frozen representations"
-      ],
-      correct: 1,
+      options: ["A sufficiently expressive nonlinear probe can learn the task itself rather than merely extracting information from the representation — high accuracy may reflect the probe's computational power rather than information present in the frozen features, making it essential to compare against a control baseline (e.g., probing random representations of the same dimensionality)", "Nonlinear probes are always invalid because they are too powerful", "GPT-2 is too small to learn syntax so the result must be wrong", "MLP probes cannot be trained on frozen representations"],
+      correct: 0,
       explanation: "This is the selectivity concern raised by Hewitt & Liang (2019). A nonlinear probe with enough capacity can achieve high accuracy even on random representations of sufficient dimension, effectively learning a lookup table. The key diagnostic is to measure selectivity: accuracy on the linguistic task minus accuracy when probing random (control) representations. If selectivity is low, the probe is doing the computational work. Linear probes are preferred precisely because their limited capacity makes high accuracy more attributable to the representation rather than the probe."
     },
     {
@@ -113,25 +83,15 @@ export const probingAssessment = {
     {
       type: "mc",
       question: "A CheckList invariance test for a sentiment classifier perturbs inputs by changing named entities (e.g., replacing \"John\" with \"Mary\") and finds that 23% of predictions flip. What does this reveal?",
-      options: [
-        "The model has correctly learned that different people have different sentiments",
-        "The model exhibits a systematic failure of invariance to identity-irrelevant perturbations, indicating it has learned spurious correlations between names and sentiment labels rather than genuine linguistic understanding of sentiment-bearing content",
-        "The test is invalid because names can affect sentiment",
-        "The model needs more training data with those specific names"
-      ],
-      correct: 1,
+      options: ["The model has correctly learned that different people have different sentiments", "The test is invalid because names can affect sentiment", "The model exhibits a systematic failure of invariance to identity-irrelevant perturbations, indicating it has learned spurious correlations between names and sentiment labels rather than genuine linguistic understanding of sentiment-bearing content", "The model needs more training data with those specific names"],
+      correct: 2,
       explanation: "Name changes should not affect sentiment predictions in most contexts (e.g., \"John/Mary loved the movie\"). A 23% flip rate reveals the model has learned spurious associations, likely from training data biases where certain names co-occur with certain sentiment distributions. This is precisely the type of fragile, non-generalizable behavior CheckList was designed to detect. It exposes failures that aggregate accuracy metrics miss: the model might achieve 95% accuracy on a test set while harboring systematic biases that manifest in deployment."
     },
     {
       type: "mc",
       question: "Which of the following represents a fundamental limitation shared by all probing-based interpretability methods, regardless of whether the probe is linear or nonlinear?",
-      options: [
-        "Probes cannot be trained on GPU-accelerated hardware",
-        "Probing is purely correlational — it demonstrates what information is decodable from a representation but cannot establish whether the model's own computation accesses or uses that information during its forward pass, because the probe is an external decoder separate from the model's computational graph",
-        "Probes only work on English-language models",
-        "Probing requires access to the model's training data, which is usually unavailable"
-      ],
-      correct: 1,
+      options: ["Probes cannot be trained on GPU-accelerated hardware", "Probing requires access to the model's training data, which is usually unavailable", "Probes only work on English-language models", "Probing is purely correlational — it demonstrates what information is decodable from a representation but cannot establish whether the model's own computation accesses or uses that information during its forward pass, because the probe is an external decoder separate from the model's computational graph"],
+      correct: 3,
       explanation: "This is the core epistemological limitation of probing. A representation is a high-dimensional object, and any sufficiently rich representation will contain many decodable features as mathematical byproducts, even if the model never \"reads\" them. The probe is an external function that we attach; it has no connection to the model's actual computation. To establish causal usage, one must turn to interventional methods: activation patching (does restoring this information recover the output?), amnesic probing (does removing this information degrade the output?), or ablation studies."
     }
   ]
@@ -151,13 +111,8 @@ export const mechInterpAssessment = {
     {
       type: "mc",
       question: "Superposition in neural networks refers to the phenomenon where a model represents more features than it has dimensions. If a model has $d$ dimensions and needs to represent $m \\gg d$ features, how does it accomplish this?",
-      options: [
-        "It discards all but the $d$ most important features and ignores the rest",
-        "It assigns nearly-orthogonal directions to different features, tolerating small interference between them — features are packed as approximately orthogonal vectors in $\\mathbb{R}^d$, exploiting the fact that $\\mathbb{R}^d$ can contain far more nearly-orthogonal vectors than exactly orthogonal ones",
-        "It increases $d$ dynamically during inference to accommodate all features",
-        "It stores extra features in the model's parameter memory rather than in activations"
-      ],
-      correct: 1,
+      options: ["It assigns nearly-orthogonal directions to different features, tolerating small interference between them — features are packed as approximately orthogonal vectors in $\\mathbb{R}^d$, exploiting the fact that $\\mathbb{R}^d$ can contain far more nearly-orthogonal vectors than exactly orthogonal ones", "It discards all but the $d$ most important features and ignores the rest", "It increases $d$ dynamically during inference to accommodate all features", "It stores extra features in the model's parameter memory rather than in activations"],
+      correct: 0,
       explanation: "The key mathematical insight is that while $\\mathbb{R}^d$ has at most $d$ mutually orthogonal vectors, it can contain exponentially many nearly-orthogonal vectors. Specifically, the Johnson-Lindenstrauss lemma implies that $\\exp(\\Omega(d\\epsilon^2))$ vectors can be packed with pairwise dot products bounded by $\\epsilon$. Superposition exploits this: each feature gets a direction, and the model tolerates the small cross-talk (interference) between features. Toy models show this emerges naturally when features are sparse — the expected interference is proportional to feature co-occurrence probability."
     },
     {
@@ -175,37 +130,22 @@ export const mechInterpAssessment = {
     {
       type: "mc",
       question: "Induction heads are a specific circuit motif discovered in transformers. They implement the pattern: having seen \"A B ... A\" in context, predict \"B\" as the next token. What is the two-head mechanism that implements this?",
-      options: [
-        "A single attention head that memorizes all bigrams from training data",
-        "A \"previous token head\" in an earlier layer copies information about B to the A token's residual stream, and then an \"induction head\" in a later layer attends from the current A position back to positions where B's information was written, retrieving B as the prediction — the composition happens through the residual stream connecting the two layers",
-        "Two MLP layers that jointly perform a lookup table operation",
-        "A head that attends to the first occurrence of A and another that attends to the last token"
-      ],
-      correct: 1,
+      options: ["A single attention head that memorizes all bigrams from training data", "Two MLP layers that jointly perform a lookup table operation", "A \"previous token head\" in an earlier layer copies information about B to the A token's residual stream, and then an \"induction head\" in a later layer attends from the current A position back to positions where B's information was written, retrieving B as the prediction — the composition happens through the residual stream connecting the two layers", "A head that attends to the first occurrence of A and another that attends to the last token"],
+      correct: 2,
       explanation: "The induction head circuit involves composition between two attention heads across layers. In the earlier layer, a \"previous token head\" uses a shifted attention pattern to write the identity of each token's predecessor into the residual stream (at position $i$, it writes information about token $i-1$). In the later layer, the induction head uses key-query matching: when it sees an A token at the current position, it matches against positions where A appeared before, but reads the value written by the previous token head — which is B. This is K-composition: the later head's key/query computation uses information written by the earlier head."
     },
     {
       type: "mc",
       question: "Circuit-level analysis in mechanistic interpretability involves identifying the minimal subgraph of a transformer that implements a specific behavior. When analyzing a circuit for \"indirect object identification\" (e.g., in \"Mary gave the book to John, so John...\"), researchers found a circuit involving approximately 26 attention heads across multiple layers. What technique is used to verify that this circuit is both necessary and sufficient?",
-      options: [
-        "Training a new model from scratch with only those heads and checking it works",
-        "Knockout/ablation experiments: ablating heads outside the circuit should not affect performance on the task (sufficiency), and ablating heads inside the circuit should degrade performance (necessity) — together establishing that the identified subgraph is the minimal computational unit responsible for the behavior",
-        "Computing the gradient magnitude of each head's output with respect to the loss",
-        "Visualizing attention patterns and selecting heads that attend to the correct tokens"
-      ],
-      correct: 1,
+      options: ["Training a new model from scratch with only those heads and checking it works", "Visualizing attention patterns and selecting heads that attend to the correct tokens", "Computing the gradient magnitude of each head's output with respect to the loss", "Knockout/ablation experiments: ablating heads outside the circuit should not affect performance on the task (sufficiency), and ablating heads inside the circuit should degrade performance (necessity) — together establishing that the identified subgraph is the minimal computational unit responsible for the behavior"],
+      correct: 3,
       explanation: "Circuit verification requires demonstrating both necessity and sufficiency through interventions. For sufficiency, all heads outside the proposed circuit are ablated (e.g., by mean-ablating their outputs), and the model should still perform the task. For necessity, ablating any head inside the circuit should degrade performance. The IOI circuit analysis (Wang et al., 2022) used this methodology, identifying specific head roles: S-inhibition heads, name mover heads, backup name mover heads, and duplicate token heads, each serving a specific function in the information flow that resolves indirect object references."
     },
     {
       type: "mc",
       question: "Steering vectors are computed by taking the difference in mean activations between two sets of inputs (e.g., positive vs. negative sentiment) at a specific layer: $v = \\mathbb{E}[h_l | \\text{positive}] - \\mathbb{E}[h_l | \\text{negative}]$. Adding $\\alpha \\cdot v$ to the residual stream during generation steers the model's behavior. What is a key theoretical concern with this approach?",
-      options: [
-        "Steering vectors only work with models that have exactly 12 layers",
-        "The difference-in-means direction may conflate multiple independent features that happen to correlate with the contrast set, and steering along this direction may activate unintended features — superposition means concepts are not axis-aligned, so a single vector may be a mixture of several feature directions",
-        "Adding vectors to the residual stream always causes the model to output gibberish",
-        "Steering vectors require retraining the model, making them impractical"
-      ],
-      correct: 1,
+      options: ["The difference-in-means direction may conflate multiple independent features that happen to correlate with the contrast set, and steering along this direction may activate unintended features — superposition means concepts are not axis-aligned, so a single vector may be a mixture of several feature directions", "Steering vectors only work with models that have exactly 12 layers", "Adding vectors to the residual stream always causes the model to output gibberish", "Steering vectors require retraining the model, making them impractical"],
+      correct: 0,
       explanation: "Because of superposition, the direction $v$ obtained from difference-in-means is not guaranteed to correspond to a single clean feature. It may be a linear combination of several feature directions that happen to correlate with the contrast. When you steer along $v$, you may activate all of these features simultaneously, producing unintended side effects. For example, a \"truthfulness\" steering vector might also encode formality, topic, or other correlated attributes. SAE-based feature finding can help isolate cleaner individual feature directions for more precise steering."
     },
     {
@@ -223,37 +163,22 @@ export const mechInterpAssessment = {
     {
       type: "mc",
       question: "A sparse autoencoder trained on an LLM's residual stream activations produces a dictionary of 32,768 features from a 4,096-dimensional space. Researchers find that feature #7,291 activates strongly on text discussing \"the Golden Gate Bridge\" and related San Francisco landmarks. When this feature's activation is artificially amplified during generation, the model steers toward discussing San Francisco. What does this demonstrate?",
-      options: [
-        "That the model has memorized all facts about the Golden Gate Bridge in a single neuron",
-        "That SAEs can identify monosemantic (single-concept) feature directions from the polysemantic superposition in the residual stream, and that these learned features correspond to causally active directions — amplifying them changes model behavior in a predictable, concept-specific way",
-        "That the model's knowledge of San Francisco is stored only in this single feature",
-        "That SAEs always find geographically-organized features"
-      ],
-      correct: 1,
+      options: ["That the model has memorized all facts about the Golden Gate Bridge in a single neuron", "That the model's knowledge of San Francisco is stored only in this single feature", "That SAEs can identify monosemantic (single-concept) feature directions from the polysemantic superposition in the residual stream, and that these learned features correspond to causally active directions — amplifying them changes model behavior in a predictable, concept-specific way", "That SAEs always find geographically-organized features"],
+      correct: 2,
       explanation: "This example (from Anthropic's work on SAEs applied to Claude) demonstrates two key properties: (1) SAEs succeed at decomposing polysemantic activations into monosemantic features — individual dictionary elements that respond to coherent, interpretable concepts; (2) these features are not just decodable but causally active — intervening on them changes behavior. This is stronger than probing because the features are identified unsupervised (not trained for a specific labeling task) and verified through causal intervention. The 8x expansion ratio (32,768/4,096) reflects the degree of superposition."
     },
     {
       type: "mc",
       question: "K-composition, V-composition, and Q-composition describe how attention heads in different layers interact through the residual stream. In K-composition, a head $H_2$ in layer $l_2$ uses information written to the residual stream by head $H_1$ in layer $l_1 < l_2$ when computing its keys. Which of the following correctly describes a consequence?",
-      options: [
-        "K-composition allows $H_2$ to attend based on features computed by $H_1$, meaning $H_2$'s attention pattern depends on what $H_1$ wrote — this enables complex matching rules like \"attend to positions where the previous token was X\" (as in induction heads), which would be impossible with a single layer",
-        "K-composition means $H_2$ always copies $H_1$'s attention pattern exactly",
-        "K-composition only occurs between adjacent layers",
-        "K-composition requires $H_1$ and $H_2$ to have the same number of heads"
-      ],
-      correct: 0,
+      options: ["K-composition requires $H_1$ and $H_2$ to have the same number of heads", "K-composition means $H_2$ always copies $H_1$'s attention pattern exactly", "K-composition only occurs between adjacent layers", "K-composition allows $H_2$ to attend based on features computed by $H_1$, meaning $H_2$'s attention pattern depends on what $H_1$ wrote — this enables complex matching rules like \"attend to positions where the previous token was X\" (as in induction heads), which would be impossible with a single layer"],
+      correct: 3,
       explanation: "In K-composition, $H_2$'s key vectors $K_2 = W_K^{(2)} \\cdot (\\text{residual at } l_2)$ incorporate the output of $H_1$ via the residual stream. This means $H_2$ can match queries against keys that encode information from $H_1$'s computation. The induction head is the canonical example: $H_1$ (previous token head) writes token $i-1$'s identity at position $i$, and $H_2$'s keys reflect this, allowing $H_2$ to attend to positions based on what preceded them. Similarly, V-composition means $H_2$ reads values enriched by $H_1$, and Q-composition means queries are enriched."
     },
     {
       type: "mc",
       question: "Feature visualization in vision models involves optimizing an input image $x$ to maximize a specific neuron's activation: $x^* = \\arg\\max_x \\, a_k(x) - \\lambda R(x)$, where $a_k$ is the neuron's activation and $R(x)$ is a regularizer. Why is the regularizer essential?",
-      options: [
-        "Without regularization, the optimization always converges to a uniform gray image",
-        "Without regularization, the optimized input exploits high-frequency adversarial patterns that maximally activate the neuron but are visually meaningless — the regularizer (e.g., total variation, Gaussian blur, transformation robustness) constrains the solution to the natural image manifold so the visualization reflects what the neuron responds to on real inputs",
-        "The regularizer prevents the optimization from taking too many gradient steps",
-        "Regularization is only needed for convolutional networks, not transformers"
-      ],
-      correct: 1,
+      options: ["Without regularization, the optimized input exploits high-frequency adversarial patterns that maximally activate the neuron but are visually meaningless — the regularizer (e.g., total variation, Gaussian blur, transformation robustness) constrains the solution to the natural image manifold so the visualization reflects what the neuron responds to on real inputs", "Without regularization, the optimization always converges to a uniform gray image", "The regularizer prevents the optimization from taking too many gradient steps", "Regularization is only needed for convolutional networks, not transformers"],
+      correct: 0,
       explanation: "Unregularized feature visualization produces inputs with high-frequency noise patterns — adversarial-style artifacts that exploit the neuron's full receptive field in non-natural ways. These technically maximize activation but reveal the neuron's sensitivity to out-of-distribution inputs rather than its role in processing natural images. Common regularizers include: total variation penalty (encourages spatial smoothness), jitter/rotation augmentation (ensures the feature is robust to transforms), frequency penalization (suppresses high-frequency components), and learned priors from generative models."
     },
     {
@@ -285,37 +210,22 @@ export const trainingInterpAssessment = {
     {
       type: "mc",
       question: "Grokking refers to a phenomenon where a neural network first memorizes the training data (achieving near-zero training loss while validation loss remains high), and then, thousands of steps later, suddenly generalizes (validation loss drops sharply). On which type of task was grokking first demonstrated?",
-      options: [
-        "Large-scale language modeling on internet text",
-        "Modular arithmetic operations (e.g., $a \\circ b \\mod p$ for a binary operation $\\circ$ on elements of $\\mathbb{Z}/p\\mathbb{Z}$), where the model transitions from memorizing a lookup table to learning the underlying algebraic algorithm long after achieving perfect training accuracy",
-        "Image classification on ImageNet",
-        "Machine translation between English and French"
-      ],
-      correct: 1,
+      options: ["Large-scale language modeling on internet text", "Image classification on ImageNet", "Modular arithmetic operations (e.g., $a \\circ b \\mod p$ for a binary operation $\\circ$ on elements of $\\mathbb{Z}/p\\mathbb{Z}$), where the model transitions from memorizing a lookup table to learning the underlying algebraic algorithm long after achieving perfect training accuracy", "Machine translation between English and French"],
+      correct: 2,
       explanation: "Power et al. (2022) discovered grokking on algorithmic tasks over finite groups, particularly modular arithmetic (addition, multiplication, etc. mod a prime $p$). With a small training fraction (~30-50% of all $(a, b)$ pairs), the model achieves 100% training accuracy within ~$10^3$ steps by memorizing, but validation accuracy remains at chance until ~$10^5$ steps, when it suddenly jumps to ~100%. Mechanistic analysis by Neel Nanda et al. revealed the model learns interpretable Fourier-based algorithms: it represents numbers as points on a circle and computes the operation using trigonometric identities."
     },
     {
       type: "mc",
       question: "In the context of grokking, weight decay plays a critical role. Without weight decay, grokking either does not occur or takes much longer. What is the mechanistic explanation for why weight decay promotes grokking?",
-      options: [
-        "Weight decay prevents the model from learning at all, forcing it to randomly guess until it finds the right algorithm",
-        "Weight decay provides continuous pressure toward lower-norm solutions, and the generalizing circuit (which exploits algebraic structure) has lower parameter norm than the memorizing circuit (which requires a large lookup table) — over time, weight decay erodes the memorization solution and the structured algorithm emerges as the lower-norm attractor",
-        "Weight decay makes the learning rate effectively larger, speeding up all learning uniformly",
-        "Weight decay only affects the bias terms, which are irrelevant to memorization"
-      ],
-      correct: 1,
+      options: ["Weight decay prevents the model from learning at all, forcing it to randomly guess until it finds the right algorithm", "Weight decay only affects the bias terms, which are irrelevant to memorization", "Weight decay makes the learning rate effectively larger, speeding up all learning uniformly", "Weight decay provides continuous pressure toward lower-norm solutions, and the generalizing circuit (which exploits algebraic structure) has lower parameter norm than the memorizing circuit (which requires a large lookup table) — over time, weight decay erodes the memorization solution and the structured algorithm emerges as the lower-norm attractor"],
+      correct: 3,
       explanation: "The memorizing solution requires large weights to implement a lookup table over all training examples, while the generalizing solution (e.g., the Fourier algorithm for modular addition) uses structured, lower-norm weights. Weight decay penalizes $\\|\\theta\\|_2^2$, creating a persistent force toward the origin in parameter space. Initially, the memorization solution dominates because it's found first via gradient descent. But weight decay continuously shrinks it, eventually allowing the generalizing solution — which is a lower-norm fixed point — to take over. This explains the delayed generalization: it's the timescale of weight decay eroding a local minimum."
     },
     {
       type: "mc",
       question: "Phase transitions during neural network training refer to abrupt, qualitative changes in model behavior or internal representations. Which of the following best describes a phase transition observed in transformer language model training?",
-      options: [
-        "The loss decreases linearly throughout training with no sudden changes",
-        "Induction heads form at a specific point during training, coinciding with a discrete drop in loss on sequences requiring in-context pattern completion — before this transition, the model cannot perform in-context learning of bigram statistics; after it, the model suddenly acquires this capability",
-        "The model's vocabulary size increases during training",
-        "All attention heads simultaneously learn their final attention patterns in the first 100 steps"
-      ],
-      correct: 1,
+      options: ["Induction heads form at a specific point during training, coinciding with a discrete drop in loss on sequences requiring in-context pattern completion — before this transition, the model cannot perform in-context learning of bigram statistics; after it, the model suddenly acquires this capability", "The loss decreases linearly throughout training with no sudden changes", "The model's vocabulary size increases during training", "All attention heads simultaneously learn their final attention patterns in the first 100 steps"],
+      correct: 0,
       explanation: "Olsson et al. (2022) identified a sharp phase transition in transformer training where induction heads form. Before the transition, attention heads show only local patterns. At the transition (which occurs at a specific training step), induction heads emerge and the model acquires the ability to complete in-context \"A B ... A -> B\" patterns. This manifests as a visible bump/drop in the loss curve. The transition is abrupt rather than gradual, suggesting a bifurcation in the learning dynamics — the circuit \"snaps\" into place as compositions between layers become reinforcing."
     },
     {
@@ -333,37 +243,22 @@ export const trainingInterpAssessment = {
     {
       type: "mc",
       question: "Later work on the Lottery Ticket Hypothesis found that for larger networks, the original initialization $\\theta_0$ must be replaced with weights from early in training $\\theta_k$ (\"rewinding\" to step $k$) for the sparse network to train successfully. What does this suggest about the training dynamics?",
-      options: [
-        "The original hypothesis was completely wrong and should be abandoned",
-        "The early phase of training (steps $0$ to $k$) performs a critical restructuring of the initialization — it moves the parameters into a basin of attraction from which sparse training can succeed, suggesting that the \"lottery\" is not purely in the initialization but in the early training dynamics that establish the right loss landscape geometry for sparse optimization",
-        "Weight rewinding is just a regularization trick with no deeper meaning",
-        "Larger networks cannot be pruned at all"
-      ],
-      correct: 1,
+      options: ["The original hypothesis was completely wrong and should be abandoned", "Weight rewinding is just a regularization trick with no deeper meaning", "The early phase of training (steps $0$ to $k$) performs a critical restructuring of the initialization — it moves the parameters into a basin of attraction from which sparse training can succeed, suggesting that the \"lottery\" is not purely in the initialization but in the early training dynamics that establish the right loss landscape geometry for sparse optimization", "Larger networks cannot be pruned at all"],
+      correct: 2,
       explanation: "Frankle et al. (2020) showed that for larger models (e.g., ResNet-50), rewinding to $\\theta_0$ fails but rewinding to $\\theta_k$ (typically $k$ = 1-5% of total training) succeeds. This reveals that early training performs a kind of \"alignment\" — moving weights into a region of parameter space where the loss landscape supports sparse optimization. This connects to other findings about distinct training phases: an early \"chaotic\" phase where the network explores, followed by a more structured phase. The rewinding point $k$ often coincides with the stabilization of the loss Hessian's top eigenvectors."
     },
     {
       type: "mc",
       question: "Singular Learning Theory (SLT), developed by Watanabe, provides a Bayesian framework for understanding generalization in singular (non-regular) statistical models like neural networks. A key quantity is the learning coefficient $\\lambda$ (also called the real log canonical threshold, RLCT). How does $\\lambda$ relate to generalization?",
-      options: [
-        "$\\lambda$ is identical to the number of parameters $d$ and provides no additional information",
-        "The learning coefficient $\\lambda$ replaces $d/2$ in the BIC/MDL formula: the free energy scales as $\\lambda \\ln n$ (where $n$ is sample size) rather than $(d/2) \\ln n$ — for singular models, $\\lambda \\leq d/2$ because symmetries and degeneracies in the parameter space reduce the effective complexity, making $\\lambda$ a better predictor of generalization than raw parameter count",
-        "$\\lambda$ measures the model's training speed and has no connection to generalization",
-        "$\\lambda$ is only defined for linear models and cannot be applied to neural networks"
-      ],
-      correct: 1,
+      options: ["$\\lambda$ is identical to the number of parameters $d$ and provides no additional information", "$\\lambda$ is only defined for linear models and cannot be applied to neural networks", "$\\lambda$ measures the model's training speed and has no connection to generalization", "The learning coefficient $\\lambda$ replaces $d/2$ in the BIC/MDL formula: the free energy scales as $\\lambda \\ln n$ (where $n$ is sample size) rather than $(d/2) \\ln n$ — for singular models, $\\lambda \\leq d/2$ because symmetries and degeneracies in the parameter space reduce the effective complexity, making $\\lambda$ a better predictor of generalization than raw parameter count"],
+      correct: 3,
       explanation: "In regular statistical models, the Bayesian free energy (negative log marginal likelihood) is approximately $nL_n(\\hat{\\theta}) + (d/2)\\ln n$ (BIC). But neural networks are singular: the Fisher information matrix is degenerate, and the map from parameters to distributions is not one-to-one. Watanabe proved that for singular models, $d/2$ is replaced by the RLCT $\\lambda$, which captures the effective dimensionality of the model near the true distribution. Since $\\lambda \\leq d/2$, singular models are less complex than their parameter count suggests. This explains why overparameterized networks generalize: their effective complexity (measured by $\\lambda$) is much smaller than $d$."
     },
     {
       type: "mc",
       question: "In the context of grokking, the training process can be decomposed into distinct phases visible in the weight norm dynamics. Which sequence of phases is observed?",
-      options: [
-        "Random initialization, immediate generalization, followed by gradual forgetting",
-        "An initial phase where both training loss drops and weight norm grows (memorization via embedding growth), a plateau where training accuracy is perfect but generalization is absent, then a phase where weight norm decreases while validation accuracy suddenly improves (the generalizing circuit overtakes the memorizing one as weight decay compresses the representation)",
-        "Weight norm decreases monotonically throughout training while both losses decrease together",
-        "Weight norm remains constant while the model alternates between memorizing and generalizing"
-      ],
-      correct: 1,
+      options: ["An initial phase where both training loss drops and weight norm grows (memorization via embedding growth), a plateau where training accuracy is perfect but generalization is absent, then a phase where weight norm decreases while validation accuracy suddenly improves (the generalizing circuit overtakes the memorizing one as weight decay compresses the representation)", "Random initialization, immediate generalization, followed by gradual forgetting", "Weight norm decreases monotonically throughout training while both losses decrease together", "Weight norm remains constant while the model alternates between memorizing and generalizing"],
+      correct: 0,
       explanation: "The weight norm dynamics reveal the mechanistic story of grokking: (1) Weight norm grows as the model memorizes — it needs large weights to implement the lookup table; (2) A long plateau where training is perfect but generalization is absent — the model is stuck in the memorization basin; (3) Weight norm begins decreasing as weight decay overwhelms the memorization signal (since training loss is already zero, there is no gradient pressure to maintain large weights); (4) As the memorization circuit shrinks, the generalizing circuit — which has been slowly growing in the background — becomes dominant, causing sudden generalization."
     },
     {
@@ -381,25 +276,15 @@ export const trainingInterpAssessment = {
     {
       type: "mc",
       question: "In Singular Learning Theory, the multiplicity $m$ (the order of the largest pole of the zeta function) appears alongside the learning coefficient $\\lambda$ in the asymptotic expansion of the free energy. What role does $m$ play?",
-      options: [
-        "$m$ is the number of layers in the neural network",
-        "$m$ controls the coefficient of the $\\ln \\ln n$ term in the free energy expansion: $F_n = nL_n(\\hat{\\theta}) + \\lambda \\ln n - (m-1) \\ln \\ln n + O(1)$, reflecting the degree of degeneracy of the singularity — higher $m$ means the model has more symmetries near the optimal parameters, leading to slightly better generalization at finite sample sizes",
-        "$m$ is the batch size used during training",
-        "$m$ counts the number of local minima in the loss landscape"
-      ],
-      correct: 1,
+      options: ["$m$ is the number of layers in the neural network", "$m$ is the batch size used during training", "$m$ controls the coefficient of the $\\ln \\ln n$ term in the free energy expansion: $F_n = nL_n(\\hat{\\theta}) + \\lambda \\ln n - (m-1) \\ln \\ln n + O(1)$, reflecting the degree of degeneracy of the singularity — higher $m$ means the model has more symmetries near the optimal parameters, leading to slightly better generalization at finite sample sizes", "$m$ counts the number of local minima in the loss landscape"],
+      correct: 2,
       explanation: "The free energy asymptotic expansion in SLT is $F_n = nL_n(w_0) + \\lambda \\ln n - (m-1) \\ln \\ln n + O_p(1)$, where $\\lambda$ is the RLCT and $m$ is the multiplicity. While $\\lambda$ dominates at large $n$ (controlling the leading complexity term), $m$ provides a sub-leading correction. A larger $m$ indicates more degenerate singularities — more ways the parameters can be equivalent — which provides a modest additional compression benefit. In practice, $\\lambda$ is far more important for model selection, but $m$ breaks ties between models with equal $\\lambda$."
     },
     {
       type: "mc",
       question: "A researcher observes that a transformer trained on a synthetic task exhibits a sharp phase transition at step 5,000: a specific capability (e.g., multi-step reasoning) suddenly appears. They hypothesize this is due to a circuit \"snapping\" into place. Which empirical measurement would most directly support this hypothesis?",
-      options: [
-        "Showing that the loss curve has a kink at step 5,000",
-        "Demonstrating that specific attention head composition scores (measuring how much one head's output is read by another head's keys/queries) show a discontinuous jump at step 5,000, that ablating the composed heads after the transition destroys the capability, and that the circuit did not exist in any functional form before the transition — establishing that a specific computational structure crystallized at the transition point",
-        "Showing that gradient norms are largest at step 5,000",
-        "Demonstrating that the model's parameter count effectively increases at step 5,000"
-      ],
-      correct: 1,
+      options: ["Showing that the loss curve has a kink at step 5,000", "Demonstrating that the model's parameter count effectively increases at step 5,000", "Showing that gradient norms are largest at step 5,000", "Demonstrating that specific attention head composition scores (measuring how much one head's output is read by another head's keys/queries) show a discontinuous jump at step 5,000, that ablating the composed heads after the transition destroys the capability, and that the circuit did not exist in any functional form before the transition — establishing that a specific computational structure crystallized at the transition point"],
+      correct: 3,
       explanation: "A genuine circuit phase transition requires showing: (1) the circuit components (specific heads and their compositions) are functionally absent before the transition; (2) they appear abruptly at the transition point, measurable via composition scores $\\|W_{QK}^{(H_2)} W_{OV}^{(H_1)}\\|_F$ between heads; (3) the emerged circuit is causally necessary for the new capability (ablation destroys it). A loss curve kink alone is suggestive but insufficient — it could reflect a gradual improvement becoming visible. The composition score measurement directly tracks the formation of the computational structure."
     }
   ]
@@ -419,13 +304,8 @@ export const formalTheoryAssessment = {
     {
       type: "mc",
       question: "Transformers with hard attention (each head attends to exactly one position) and fixed precision have been analyzed in terms of circuit complexity classes. A constant-depth, polynomial-size, hard-attention transformer with $O(\\log n)$-precision arithmetic can be simulated by which circuit complexity class?",
-      options: [
-        "$\\text{P}$ (polynomial time Turing machines)",
-        "$\\text{TC}^0$ (constant-depth, polynomial-size threshold circuits) — transformers with logarithmic precision can compute any function in $\\text{TC}^0$, and $\\text{TC}^0$ can simulate such transformers, establishing an equivalence between constant-depth transformers and this class, which includes multiplication, sorting, and iterated addition",
-        "$\\text{NC}^1$ (logarithmic-depth, polynomial-size fan-in-2 circuits)",
-        "$\\text{EXPTIME}$ (exponential time Turing machines)"
-      ],
-      correct: 1,
+      options: ["$\\text{TC}^0$ (constant-depth, polynomial-size threshold circuits) — transformers with logarithmic precision can compute any function in $\\text{TC}^0$, and $\\text{TC}^0$ can simulate such transformers, establishing an equivalence between constant-depth transformers and this class, which includes multiplication, sorting, and iterated addition", "$\\text{P}$ (polynomial time Turing machines)", "$\\text{NC}^1$ (logarithmic-depth, polynomial-size fan-in-2 circuits)", "$\\text{EXPTIME}$ (exponential time Turing machines)"],
+      correct: 0,
       explanation: "Merrill & Sabharwal (2023) and related work showed that constant-depth transformers with $O(\\log n)$-precision (necessary to address $n$ positions) can be captured by $\\text{TC}^0$. The key insight is that attention is essentially a weighted average (a sum of products), which is a threshold operation. $\\text{TC}^0$ is powerful — it contains multiplication, division, sorting, and counting — but cannot solve problems requiring inherently sequential computation like evaluating arbitrary Boolean formulas ($\\text{NC}^1$-complete) or graph connectivity. This sets a formal ceiling on what fixed-depth transformers can compute."
     },
     {
@@ -443,37 +323,22 @@ export const formalTheoryAssessment = {
     {
       type: "mc",
       question: "Mesa-optimization refers to the phenomenon where a trained model (the base optimizer's output) internally implements its own optimization process. In the context of transformers, which of the following would constitute evidence of mesa-optimization?",
-      options: [
-        "The model achieves low training loss, indicating the base optimizer succeeded",
-        "The model's forward pass implements an iterative search or optimization algorithm within its layers — for example, each layer refines a solution by approximately minimizing an internal objective, and the model's in-context performance improves with depth in a manner consistent with running more steps of an internal optimizer rather than performing a fixed feedforward computation",
-        "The model's weights change during inference due to online learning",
-        "The model uses more FLOPs than a linear model"
-      ],
-      correct: 1,
+      options: ["The model achieves low training loss, indicating the base optimizer succeeded", "The model's weights change during inference due to online learning", "The model's forward pass implements an iterative search or optimization algorithm within its layers — for example, each layer refines a solution by approximately minimizing an internal objective, and the model's in-context performance improves with depth in a manner consistent with running more steps of an internal optimizer rather than performing a fixed feedforward computation", "The model uses more FLOPs than a linear model"],
+      correct: 2,
       explanation: "Mesa-optimization (Hubinger et al., 2019) is when the learned model itself contains an optimization algorithm. Evidence requires showing that the forward pass performs search/optimization, not just a fixed function. For transformers, this could mean: (1) representations at successive layers approximate iterates of an optimization algorithm; (2) in-context performance scales with depth in a way consistent with more optimization steps; (3) the model exhibits goal-directed behavior that generalizes beyond training distribution in ways consistent with optimizing an internal objective. The in-context learning as implicit GD result is arguably a concrete example of mesa-optimization."
     },
     {
       type: "mc",
       question: "A transformer with unbounded depth (i.e., the number of layers can grow with input length) and bounded precision has been shown to be Turing complete. What additional mechanism is required beyond standard self-attention and feedforward layers to achieve Turing completeness?",
-      options: [
-        "No additional mechanism is needed — standard transformers are Turing complete with any finite depth",
-        "The ability to adaptively decide when to stop (a halting mechanism) and to use the depth parameter as a function of input length — with depth $T(n)$ scaling with input size, the transformer can simulate $T(n)$ steps of a Turing machine, where each layer simulates one step by using attention to read from and write to a tape encoded in the sequence positions",
-        "An external memory module like a Neural Turing Machine tape",
-        "Replacing softmax attention with a lookup table"
-      ],
-      correct: 1,
+      options: ["No additional mechanism is needed — standard transformers are Turing complete with any finite depth", "Replacing softmax attention with a lookup table", "An external memory module like a Neural Turing Machine tape", "The ability to adaptively decide when to stop (a halting mechanism) and to use the depth parameter as a function of input length — with depth $T(n)$ scaling with input size, the transformer can simulate $T(n)$ steps of a Turing machine, where each layer simulates one step by using attention to read from and write to a tape encoded in the sequence positions"],
+      correct: 3,
       explanation: "Pérez et al. (2021) showed that transformers with unbounded depth are Turing complete. The construction encodes the Turing machine's tape in the sequence positions and state in the residual stream. Each layer simulates one transition: attention reads the current tape cell (matching the head position), the FFN computes the transition function (new state, write symbol, head movement), and the result is written back to the residual stream. The depth must scale with the number of simulation steps. A fixed-depth transformer cannot be Turing complete because it corresponds to $\\text{TC}^0$, which is strictly weaker than $\\text{P}$."
     },
     {
       type: "mc",
       question: "The expressiveness gap between soft attention (standard softmax attention) and hard attention (attending to exactly one position) has formal implications. Which statement correctly characterizes this gap?",
-      options: [
-        "Soft and hard attention are computationally equivalent for all tasks",
-        "Soft attention with $O(\\log n)$ precision is strictly more powerful than hard attention with $O(\\log n)$ precision — soft attention can compute weighted averages that aggregate information from all positions, enabling computations like counting and majority that require accumulating evidence across the entire input, while hard attention can only route information from a single position per head",
-        "Hard attention is more powerful because it can make discrete decisions",
-        "The distinction only matters for tasks with more than 1 million tokens"
-      ],
-      correct: 1,
+      options: ["Soft attention with $O(\\log n)$ precision is strictly more powerful than hard attention with $O(\\log n)$ precision — soft attention can compute weighted averages that aggregate information from all positions, enabling computations like counting and majority that require accumulating evidence across the entire input, while hard attention can only route information from a single position per head", "Soft and hard attention are computationally equivalent for all tasks", "Hard attention is more powerful because it can make discrete decisions", "The distinction only matters for tasks with more than 1 million tokens"],
+      correct: 0,
       explanation: "Hard attention selects a single position per head: $\\text{HardAttn}(Q, K, V)_i = V_{\\arg\\max_j Q_i^T K_j}$. This limits each head to routing information from one position. Soft attention computes weighted averages: $\\text{SoftAttn}(Q, K, V)_i = \\sum_j \\alpha_{ij} V_j$, allowing it to aggregate information (counts, means, sums) across all positions. With $O(\\log n)$ precision, soft-attention transformers can solve problems like MAJORITY (are there more 1s than 0s?) that hard-attention transformers with constant heads cannot, because aggregation over all positions is essential and cannot be decomposed into single-position lookups."
     },
     {
@@ -491,37 +356,22 @@ export const formalTheoryAssessment = {
     {
       type: "mc",
       question: "Garg et al. (2022) trained transformers to perform in-context learning of function classes (linear functions, sparse linear functions, decision trees, etc.) by presenting $(x_1, f(x_1)), \\ldots, (x_k, f(x_k)), x_{k+1}$ and training the model to predict $f(x_{k+1})$. A key finding compared the transformer's in-context learning performance to the optimal algorithm for each function class. What was observed?",
-      options: [
-        "The transformer always performed worse than the optimal algorithm",
-        "The transformer approximately matched the performance of the Bayes-optimal predictor for each function class — for linear functions it matched OLS, for sparse linear functions it matched Lasso, and for decision trees it matched the optimal tree learner — suggesting that transformers implicitly learn to implement near-optimal learning algorithms for the function classes in their training distribution",
-        "The transformer memorized the training functions and could not generalize to new functions",
-        "The transformer performed equally well on all function classes regardless of difficulty"
-      ],
-      correct: 1,
+      options: ["The transformer always performed worse than the optimal algorithm", "The transformer memorized the training functions and could not generalize to new functions", "The transformer approximately matched the performance of the Bayes-optimal predictor for each function class — for linear functions it matched OLS, for sparse linear functions it matched Lasso, and for decision trees it matched the optimal tree learner — suggesting that transformers implicitly learn to implement near-optimal learning algorithms for the function classes in their training distribution", "The transformer performed equally well on all function classes regardless of difficulty"],
+      correct: 2,
       explanation: "This result is remarkable because the transformer is trained with a single architecture and objective, yet its in-context predictions match specialized algorithms: OLS for linear regression, Lasso for sparse regression, etc. The transformer learns a general-purpose in-context learning algorithm that adapts to the function class. This supports the mesa-optimization view: the transformer has learned an internal algorithm flexible enough to approximate optimal estimation for each class. However, performance degrades when tested on function classes outside the training distribution, showing the learned algorithm is not fully general."
     },
     {
       type: "mc",
       question: "The problem of length generalization in transformers (the failure to generalize from training on short sequences to testing on long sequences) has been studied formally. What is the primary formal barrier to length generalization in standard transformers?",
-      options: [
-        "The vocabulary size is too small for longer sequences",
-        "Standard positional encodings (both sinusoidal and learned) create a distribution shift: the model sees position embeddings during testing that were never encountered during training — and more fundamentally, for tasks requiring sequential computation, the fixed depth means the model cannot increase its computation to match the increased sequence length, since the computational pattern must extrapolate rather than merely extend",
-        "Longer sequences require more parameters, but the model size is fixed",
-        "The softmax function becomes numerically unstable with longer sequences"
-      ],
-      correct: 1,
+      options: ["The vocabulary size is too small for longer sequences", "The softmax function becomes numerically unstable with longer sequences", "Longer sequences require more parameters, but the model size is fixed", "Standard positional encodings (both sinusoidal and learned) create a distribution shift: the model sees position embeddings during testing that were never encountered during training — and more fundamentally, for tasks requiring sequential computation, the fixed depth means the model cannot increase its computation to match the increased sequence length, since the computational pattern must extrapolate rather than merely extend"],
+      correct: 3,
       explanation: "Length generalization failure has two components: (1) Positional encoding OOD: learned positions beyond training length are untrained; sinusoidal positions have seen the frequencies but not the specific phase combinations. ALiBi, RoPE with NTK-aware scaling, and relative position encodings partially address this. (2) Computational insufficiency: for tasks like multi-digit addition or parity, the required computation grows with input length, but a fixed-depth transformer has constant compute per position. Even with perfect position handling, the model cannot allocate more \"thinking\" to longer inputs. This is why CoT helps — it provides additional computation proportional to the problem size."
     },
     {
       type: "mc",
       question: "Bai et al. (2023) proved that transformers can implement a variety of machine learning algorithms in-context, including gradient descent, ridge regression, and even more complex iterative algorithms. Their construction shows that a transformer with $L$ layers performing in-context linear regression can be understood as implementing what?",
-      options: [
-        "A random forest with $L$ trees",
-        "$L$ steps of preconditioned gradient descent, where each layer applies one step of the form $W_{t+1} = W_t - \\eta_t P_t \\nabla \\mathcal{L}(W_t)$, with the preconditioner $P_t$ and learning rate $\\eta_t$ implicitly parameterized by the attention and MLP weights — deeper transformers implement more optimization steps, converging closer to the optimal solution",
-        "A k-nearest-neighbors algorithm with $k = L$",
-        "An ensemble of $L$ independent linear models whose predictions are averaged"
-      ],
-      correct: 1,
+      options: ["$L$ steps of preconditioned gradient descent, where each layer applies one step of the form $W_{t+1} = W_t - \\eta_t P_t \\nabla \\mathcal{L}(W_t)$, with the preconditioner $P_t$ and learning rate $\\eta_t$ implicitly parameterized by the attention and MLP weights — deeper transformers implement more optimization steps, converging closer to the optimal solution", "A random forest with $L$ trees", "A k-nearest-neighbors algorithm with $k = L$", "An ensemble of $L$ independent linear models whose predictions are averaged"],
+      correct: 0,
       explanation: "Bai et al. provided a constructive proof that each transformer layer can implement one step of preconditioned gradient descent. The attention mechanism computes the gradient of the in-context least-squares loss by attending to the context examples, and the MLP applies the update with an implicit preconditioner. This extends the von Oswald et al. result by showing: (1) multi-layer transformers implement multi-step GD, not just one step; (2) the preconditioner can implement algorithms like ridge regression ($P = (X^TX + \\lambda I)^{-1}$); (3) the construction works for more general loss functions. Deeper models provably get closer to the optimal solution."
     },
     {

--- a/src/modules/assess-branch-g-and-tier0.js
+++ b/src/modules/assess-branch-g-and-tier0.js
@@ -18,25 +18,15 @@ export const peftAssessment = {
     {
       type: "mc",
       question: "In LoRA, the pretrained weight matrix $W_0 \\in \\mathbb{R}^{d \\times k}$ is frozen and the update is parameterized as $\\Delta W = BA$ where $B \\in \\mathbb{R}^{d \\times r}$ and $A \\in \\mathbb{R}^{r \\times k}$ with rank $r \\ll \\min(d, k)$. How many trainable parameters does this introduce per adapted weight matrix?",
-      options: [
-        "$d \\times k$ (same as the original matrix)",
-        "$r \\times (d + k)$",
-        "$r^2$",
-        "$d \\times k \\times r$"
-      ],
-      correct: 1,
+      options: ["$d \\times k$ (same as the original matrix)", "$r^2$", "$r \\times (d + k)$", "$d \\times k \\times r$"],
+      correct: 2,
       explanation: "Matrix $B$ has $d \\times r$ parameters and matrix $A$ has $r \\times k$ parameters, for a total of $r(d + k)$. Since $r \\ll \\min(d, k)$, this is dramatically fewer than the $d \\times k$ parameters in the full matrix. For example, with $d = k = 4096$ and $r = 16$, LoRA uses $2 \\times 4096 \\times 16 = 131{,}072$ parameters vs. $4096^2 = 16{,}777{,}216$ for the full matrix — a 128x reduction."
     },
     {
       type: "mc",
       question: "LoRA applies a scaling factor $\\frac{\\alpha}{r}$ to the low-rank update, so the forward pass computes $h = W_0 x + \\frac{\\alpha}{r} BAx$. What is the purpose of this $\\alpha / r$ scaling?",
-      options: [
-        "It normalizes the output to unit variance regardless of rank",
-        "It allows changing the rank $r$ without retuning the learning rate: the scaling keeps the effective update magnitude roughly constant across different rank choices, so $\\alpha$ can be fixed (e.g., $\\alpha = 16$) while sweeping $r$",
-        "It prevents gradient explosion in the backward pass by clipping the update",
-        "It ensures the low-rank matrices $A$ and $B$ remain orthogonal during training"
-      ],
-      correct: 1,
+      options: ["It allows changing the rank $r$ without retuning the learning rate: the scaling keeps the effective update magnitude roughly constant across different rank choices, so $\\alpha$ can be fixed (e.g., $\\alpha = 16$) while sweeping $r$", "It normalizes the output to unit variance regardless of rank", "It prevents gradient explosion in the backward pass by clipping the update", "It ensures the low-rank matrices $A$ and $B$ remain orthogonal during training"],
+      correct: 0,
       explanation: "When $\\alpha$ is fixed, increasing $r$ increases the capacity of the update but the $\\alpha / r$ factor reduces the per-component contribution, keeping the overall update magnitude stable. This means you can use the same learning rate and $\\alpha$ across experiments with different ranks. In practice, $\\alpha$ is often set equal to the first rank tried (e.g., $\\alpha = r = 16$), and subsequent rank sweeps only change $r$ while keeping $\\alpha$ and the learning rate constant."
     },
     {
@@ -66,37 +56,22 @@ export const peftAssessment = {
     {
       type: "mc",
       question: "QLoRA uses \"double quantization\" to reduce the memory overhead of quantization constants. What does this mean?",
-      options: [
-        "The model weights are quantized twice in sequence, first to INT8 then to INT4",
-        "The quantization constants (scale factors) used for NF4 quantization are themselves quantized to 8-bit, reducing their memory footprint from 32 bits to 8 bits per block",
-        "Two separate LoRA adapters are applied to each layer and averaged",
-        "The gradients are quantized to 4 bits during the backward pass"
-      ],
-      correct: 1,
+      options: ["The model weights are quantized twice in sequence, first to INT8 then to INT4", "The gradients are quantized to 4 bits during the backward pass", "Two separate LoRA adapters are applied to each layer and averaged", "The quantization constants (scale factors) used for NF4 quantization are themselves quantized to 8-bit, reducing their memory footprint from 32 bits to 8 bits per block"],
+      correct: 3,
       explanation: "Block-wise quantization (e.g., blocks of 64 weights) requires storing a scale factor per block. With FP32 scales, this adds $32/64 = 0.5$ bits per parameter. Double quantization quantizes these scale factors themselves — grouping 256 scale factors and quantizing them to FP8, reducing the overhead to roughly $8/64 + 32/(64 \\times 256) \\approx 0.127$ bits per parameter. This is critical: for a 65B parameter model, the savings are several gigabytes."
     },
     {
       type: "mc",
       question: "DoRA (Weight-Decomposed Low-Rank Adaptation) decomposes the weight update differently from standard LoRA. How does DoRA parameterize the adapted weight?",
-      options: [
-        "It applies LoRA to both the attention and MLP layers simultaneously with shared factors",
-        "It decomposes the weight into magnitude and direction components: $W' = m \\cdot \\frac{W_0 + BA}{\\|W_0 + BA\\|_c}$, where $m$ is a trainable magnitude vector and the direction is updated via LoRA, inspired by weight normalization",
-        "It doubles the rank of LoRA and applies dropout between the two low-rank matrices",
-        "It uses a dictionary of rank-1 updates and selects the top-$k$ at each step"
-      ],
-      correct: 1,
+      options: ["It applies LoRA to both the attention and MLP layers simultaneously with shared factors", "It doubles the rank of LoRA and applies dropout between the two low-rank matrices", "It decomposes the weight into magnitude and direction components: $W' = m \\cdot \\frac{W_0 + BA}{\\|W_0 + BA\\|_c}$, where $m$ is a trainable magnitude vector and the direction is updated via LoRA, inspired by weight normalization", "It uses a dictionary of rank-1 updates and selects the top-$k$ at each step"],
+      correct: 2,
       explanation: "DoRA is motivated by analyzing the difference between full fine-tuning and LoRA: full fine-tuning tends to make large directional changes with small magnitude changes, while LoRA couples both. By decomposing $W' = m \\cdot \\frac{V'}{\\|V'\\|_c}$ where $V' = W_0 + BA$ (direction via LoRA) and $m$ is a learnable per-column magnitude vector, DoRA decouples these two aspects. The $\\|\\cdot\\|_c$ denotes column-wise normalization. This consistently improves over LoRA, sometimes matching full fine-tuning performance."
     },
     {
       type: "mc",
       question: "LoRA+ proposes using different learning rates for matrices $A$ and $B$. Specifically, it recommends that $\\eta_B \\gg \\eta_A$. What is the theoretical justification?",
-      options: [
-        "Matrix $B$ has more parameters than $A$, so it needs a larger learning rate to converge at the same time",
-        "Analysis of the update dynamics shows that in standard LoRA, the effective learning rate for $B$ is suboptimal: $A$ acts as a feature extractor that changes slowly while $B$ maps features to outputs and should adapt faster. Setting $\\eta_B / \\eta_A = \\lambda$ with $\\lambda \\approx 16$ improves efficiency",
-        "A larger learning rate for $B$ acts as implicit regularization by adding noise",
-        "It compensates for the zero initialization of $B$, which starts further from the optimum"
-      ],
-      correct: 1,
+      options: ["Analysis of the update dynamics shows that in standard LoRA, the effective learning rate for $B$ is suboptimal: $A$ acts as a feature extractor that changes slowly while $B$ maps features to outputs and should adapt faster. Setting $\\eta_B / \\eta_A = \\lambda$ with $\\lambda \\approx 16$ improves efficiency", "Matrix $B$ has more parameters than $A$, so it needs a larger learning rate to converge at the same time", "A larger learning rate for $B$ acts as implicit regularization by adding noise", "It compensates for the zero initialization of $B$, which starts further from the optimum"],
+      correct: 0,
       explanation: "LoRA+ analyzes the training dynamics in the infinite-width limit and finds that using a single learning rate is inefficient: the two matrices play asymmetric roles. Matrix $A$ projects the input into the low-rank subspace (feature extraction), and $B$ maps from that subspace to the output. The optimal ratio $\\eta_B / \\eta_A$ depends on the width, but empirically $\\lambda \\approx 16$ works well across model sizes, yielding up to 2x speedup in training convergence with no additional cost."
     },
     {
@@ -114,13 +89,8 @@ export const peftAssessment = {
     {
       type: "mc",
       question: "Adapter methods (Houlsby et al., 2019) insert small bottleneck modules into transformer layers. How does a typical adapter block work, and how does it compare to LoRA?",
-      options: [
-        "Adapters replace the attention mechanism entirely with a smaller version",
-        "An adapter applies $h \\leftarrow h + f(hW_{\\text{down}})W_{\\text{up}}$, inserting a down-projection, nonlinearity $f$, and up-projection as a residual. Unlike LoRA, adapters add sequential computation (extra latency at inference) and cannot be merged into the base weights",
-        "Adapters are mathematically identical to LoRA but use a different initialization",
-        "Adapters only modify the embedding layer and final classification head"
-      ],
-      correct: 1,
+      options: ["Adapters replace the attention mechanism entirely with a smaller version", "Adapters only modify the embedding layer and final classification head", "Adapters are mathematically identical to LoRA but use a different initialization", "An adapter applies $h \\leftarrow h + f(hW_{\\text{down}})W_{\\text{up}}$, inserting a down-projection, nonlinearity $f$, and up-projection as a residual. Unlike LoRA, adapters add sequential computation (extra latency at inference) and cannot be merged into the base weights"],
+      correct: 3,
       explanation: "A Houlsby adapter projects from dimension $d$ to a bottleneck $m \\ll d$ via $W_{\\text{down}} \\in \\mathbb{R}^{d \\times m}$, applies a nonlinearity (e.g., ReLU), and projects back via $W_{\\text{up}} \\in \\mathbb{R}^{m \\times d}$, with a skip connection. This adds $2md + m$ trainable parameters per adapter. The key disadvantage vs. LoRA is inference overhead: adapters are sequential modules that cannot be folded into the pretrained weights, adding latency proportional to their depth. LoRA's $\\Delta W = BA$ can be merged into $W_0$ post-training, yielding zero inference overhead."
     },
     {
@@ -152,13 +122,8 @@ export const memoryEfficientAssessment = {
     {
       type: "mc",
       question: "Gradient checkpointing trades memory for compute by not storing all intermediate activations. For a network with $L$ sequential layers, what is the optimal memory reduction achievable?",
-      options: [
-        "Memory drops from $O(L)$ to $O(1)$ with no additional compute",
-        "Memory drops from $O(L)$ to $O(\\sqrt{L})$ by placing checkpoints at $\\sqrt{L}$ evenly-spaced layers and recomputing activations within each segment during the backward pass, at the cost of at most one extra forward pass",
-        "Memory drops from $O(L)$ to $O(\\log L)$ using a recursive binary checkpointing scheme",
-        "Memory is halved by checkpointing every other layer"
-      ],
-      correct: 1,
+      options: ["Memory drops from $O(L)$ to $O(\\sqrt{L})$ by placing checkpoints at $\\sqrt{L}$ evenly-spaced layers and recomputing activations within each segment during the backward pass, at the cost of at most one extra forward pass", "Memory drops from $O(L)$ to $O(1)$ with no additional compute", "Memory drops from $O(L)$ to $O(\\log L)$ using a recursive binary checkpointing scheme", "Memory is halved by checkpointing every other layer"],
+      correct: 0,
       explanation: "With $\\sqrt{L}$ checkpoints, the network is divided into $\\sqrt{L}$ segments of $\\sqrt{L}$ layers each. During the backward pass, the activations within a segment are recomputed from its checkpoint. Only one segment's activations ($\\sqrt{L}$) plus the checkpoints ($\\sqrt{L}$) are in memory at once, giving $O(\\sqrt{L})$ total. The compute overhead is at most one extra forward pass because each activation is recomputed exactly once. For a 96-layer model, this reduces activation memory from 96 units to about 10 units."
     },
     {
@@ -176,37 +141,22 @@ export const memoryEfficientAssessment = {
     {
       type: "mc",
       question: "8-bit Adam (as in bitsandbytes) reduces optimizer memory by quantizing the optimizer states. How does it maintain training stability despite the quantization?",
-      options: [
-        "It uses stochastic rounding to ensure unbiased quantization in expectation",
-        "It uses dynamic quantization with block-wise scaling: the first and second moments are stored in INT8 with per-block normalization factors, and a dynamic exponent is maintained to track the range, preserving the ratio between large and small values across training",
-        "It only quantizes the second moment, keeping the first moment in FP32",
-        "It falls back to FP32 Adam for layers with high gradient variance"
-      ],
-      correct: 1,
+      options: ["It uses stochastic rounding to ensure unbiased quantization in expectation", "It falls back to FP32 Adam for layers with high gradient variance", "It only quantizes the second moment, keeping the first moment in FP32", "It uses dynamic quantization with block-wise scaling: the first and second moments are stored in INT8 with per-block normalization factors, and a dynamic exponent is maintained to track the range, preserving the ratio between large and small values across training"],
+      correct: 3,
       explanation: "8-bit Adam stores $m_t$ and $v_t$ in INT8 (1 byte each instead of 4), reducing optimizer state memory from $12N$ to roughly $6N$ bytes. Block-wise quantization divides the state into blocks of 2048 values, computing a separate scaling factor per block. A dynamic exponent tracks the tensor-wide range, allowing the block-wise quantization to adapt as moment values grow or shrink during training. Empirically, this introduces negligible degradation: the quantization error in the moments is small relative to the noise in SGD."
     },
     {
       type: "mc",
       question: "Adafactor reduces memory by factoring the second moment matrix. Instead of storing the full second moment $v_t \\in \\mathbb{R}^{m \\times n}$, what does it store?",
-      options: [
-        "A single scalar representing the mean of $v_t$",
-        "A rank-1 factorization: row-wise statistics $r_t \\in \\mathbb{R}^m$ and column-wise statistics $c_t \\in \\mathbb{R}^n$, then reconstructs the second moment as $v_t \\approx r_t c_t^\\top / \\textbf{1}^\\top c_t$, reducing memory from $O(mn)$ to $O(m + n)$",
-        "A random projection of $v_t$ into a lower-dimensional space",
-        "Only the diagonal entries of $v_t$, assuming off-diagonal terms are zero"
-      ],
-      correct: 1,
+      options: ["A single scalar representing the mean of $v_t$", "A random projection of $v_t$ into a lower-dimensional space", "A rank-1 factorization: row-wise statistics $r_t \\in \\mathbb{R}^m$ and column-wise statistics $c_t \\in \\mathbb{R}^n$, then reconstructs the second moment as $v_t \\approx r_t c_t^\\top / \\textbf{1}^\\top c_t$, reducing memory from $O(mn)$ to $O(m + n)$", "Only the diagonal entries of $v_t$, assuming off-diagonal terms are zero"],
+      correct: 2,
       explanation: "For a weight matrix $W \\in \\mathbb{R}^{m \\times n}$, Adam stores $mn$ values for $v_t$. Adafactor instead maintains row factors $r_t \\in \\mathbb{R}^m$ (mean of $v_t$ along columns) and column factors $c_t \\in \\mathbb{R}^n$ (mean along rows), using only $m + n$ values. The approximation $\\hat{v}_t = r_t c_t^\\top / \\textbf{1}^\\top c_t$ preserves the row and column marginals. For a $4096 \\times 4096$ matrix, this reduces second moment storage from $16{,}777{,}216$ to $8{,}192$ values — a 2048x reduction."
     },
     {
       type: "mc",
       question: "GaLore (Gradient Low-Rank Projection) reduces memory by projecting gradients into a low-rank subspace. How does it differ from LoRA?",
-      options: [
-        "GaLore is identical to LoRA but applies it during pretraining instead of fine-tuning",
-        "GaLore projects the gradient $G \\in \\mathbb{R}^{m \\times n}$ to $\\tilde{G} = P^\\top G Q$ where $P, Q$ are obtained from periodic SVD of the gradient, maintains optimizer states only in the low-rank space, then projects back for the weight update — unlike LoRA, the full-rank weight $W$ itself is updated, enabling full-rank training with low-rank memory",
-        "GaLore quantizes the gradient to 1-bit and uses error feedback",
-        "GaLore freezes random subsets of weights each step to reduce active parameter count"
-      ],
-      correct: 1,
+      options: ["GaLore projects the gradient $G \\in \\mathbb{R}^{m \\times n}$ to $\\tilde{G} = P^\\top G Q$ where $P, Q$ are obtained from periodic SVD of the gradient, maintains optimizer states only in the low-rank space, then projects back for the weight update — unlike LoRA, the full-rank weight $W$ itself is updated, enabling full-rank training with low-rank memory", "GaLore is identical to LoRA but applies it during pretraining instead of fine-tuning", "GaLore quantizes the gradient to 1-bit and uses error feedback", "GaLore freezes random subsets of weights each step to reduce active parameter count"],
+      correct: 0,
       explanation: "The key distinction: LoRA constrains the weight update to a fixed low-rank subspace for the entire training run ($\\Delta W = BA$). GaLore periodically (e.g., every 200 steps) computes the SVD of the full gradient to find the current top-$r$ subspace, projects gradients into it, runs Adam in that compressed space (storing $r(m+n)$ instead of $mn$ for moments), then projects back to apply a full-rank update to $W$. Because the projection subspace is updated, the cumulative weight change can have rank much higher than $r$, enabling full-rank training dynamics with low-rank memory cost."
     },
     {
@@ -224,37 +174,22 @@ export const memoryEfficientAssessment = {
     {
       type: "mc",
       question: "ZeRO (Zero Redundancy Optimizer) has three stages that progressively partition optimizer states across data-parallel workers. What does each stage partition?",
-      options: [
-        "Stage 1: activations; Stage 2: gradients; Stage 3: weights",
-        "Stage 1: optimizer states ($m_t$, $v_t$, FP32 master weights); Stage 2: optimizer states + gradients; Stage 3: optimizer states + gradients + model parameters. Each worker stores only a $1/N$ shard and communicates via all-gather/reduce-scatter as needed",
-        "Stage 1: layers 1 to L/3; Stage 2: layers L/3 to 2L/3; Stage 3: layers 2L/3 to L",
-        "Stage 1: attention weights; Stage 2: MLP weights; Stage 3: embeddings"
-      ],
-      correct: 1,
+      options: ["Stage 1: activations; Stage 2: gradients; Stage 3: weights", "Stage 1: attention weights; Stage 2: MLP weights; Stage 3: embeddings", "Stage 1: layers 1 to L/3; Stage 2: layers L/3 to 2L/3; Stage 3: layers 2L/3 to L", "Stage 1: optimizer states ($m_t$, $v_t$, FP32 master weights); Stage 2: optimizer states + gradients; Stage 3: optimizer states + gradients + model parameters. Each worker stores only a $1/N$ shard and communicates via all-gather/reduce-scatter as needed"],
+      correct: 3,
       explanation: "With $N$ data-parallel workers, standard data parallelism replicates everything. ZeRO Stage 1 partitions only optimizer states: each worker stores $1/N$ of $m_t$, $v_t$, and the FP32 master copy, reducing optimizer memory by $N$x. Stage 2 additionally partitions gradients (reduce-scatter instead of all-reduce). Stage 3 further partitions the model parameters themselves, requiring an all-gather before each forward/backward computation. Each stage trades more communication for less memory. Stage 3 with 64 GPUs reduces per-GPU memory by up to 64x."
     },
     {
       type: "mc",
       question: "Activation memory during training scales with batch size $B$, sequence length $L$, hidden dimension $d$, and number of layers $N$. For a transformer, which component dominates the activation memory?",
-      options: [
-        "The word embedding table, which stores $V \\times d$ parameters",
-        "The attention score matrices: each layer stores the $B \\times H \\times L \\times L$ attention scores (before and after softmax), where $H$ is the number of heads. For long sequences, this $O(BHL^2)$ per-layer cost dominates and grows quadratically with sequence length",
-        "The final logit output of shape $B \\times L \\times V$",
-        "The dropout masks, which require one bit per activation"
-      ],
-      correct: 1,
+      options: ["The word embedding table, which stores $V \\times d$ parameters", "The final logit output of shape $B \\times L \\times V$", "The attention score matrices: each layer stores the $B \\times H \\times L \\times L$ attention scores (before and after softmax), where $H$ is the number of heads. For long sequences, this $O(BHL^2)$ per-layer cost dominates and grows quadratically with sequence length", "The dropout masks, which require one bit per activation"],
+      correct: 2,
       explanation: "For a hidden size $d = 4096$, 32 heads, $L = 4096$ sequence length, and batch size $B = 1$: each layer's attention scores require $B \\times H \\times L^2 = 1 \\times 32 \\times 4096^2 \\approx 537M$ values (stored pre- and post-softmax for the backward pass). The linear layer activations are $O(BLd)$ per layer, which is much smaller when $L \\gg d/H$. This quadratic scaling is why FlashAttention (which avoids materializing the full attention matrix) and gradient checkpointing are critical for long-context training."
     },
     {
       type: "mc",
       question: "Communication-efficient distributed training techniques aim to reduce the bandwidth cost of gradient synchronization. Which of the following correctly describes gradient compression via top-$k$ sparsification with error feedback?",
-      options: [
-        "Only the top-$k$ gradient values by magnitude are communicated. The residual (uncommmunicated values) is discarded, introducing permanent bias into the training",
-        "Only the top-$k$ gradient values by magnitude are communicated. The residual error $e_t = g_t - \\text{TopK}(g_t + e_{t-1})$ is accumulated locally and added to the next iteration's gradient before sparsification, ensuring that all gradient information is eventually communicated",
-        "Gradients are randomly sampled with probability $k/d$, and unsampled coordinates are set to zero",
-        "The gradient is projected to $k$ dimensions via a random matrix, communicated, and projected back"
-      ],
-      correct: 1,
+      options: ["Only the top-$k$ gradient values by magnitude are communicated. The residual error $e_t = g_t - \\text{TopK}(g_t + e_{t-1})$ is accumulated locally and added to the next iteration's gradient before sparsification, ensuring that all gradient information is eventually communicated", "Only the top-$k$ gradient values by magnitude are communicated. The residual (uncommmunicated values) is discarded, introducing permanent bias into the training", "Gradients are randomly sampled with probability $k/d$, and unsampled coordinates are set to zero", "The gradient is projected to $k$ dimensions via a random matrix, communicated, and projected back"],
+      correct: 0,
       explanation: "Top-$k$ sparsification without error feedback causes training divergence because small but persistent gradient signals are permanently lost. Error feedback fixes this: at each step, the accumulated residual $e_{t-1}$ is added to the current gradient $g_t$, and top-$k$ is applied to $g_t + e_{t-1}$. The difference between the input and the sparsified output becomes the new residual. This guarantees that every gradient component eventually accumulates enough magnitude to be communicated. With $k = 0.1\\%$ of parameters, this achieves 1000x compression with minimal accuracy loss."
     },
     {
@@ -286,25 +221,15 @@ export const hardwareAwareAssessment = {
     {
       type: "mc",
       question: "FlashAttention computes exact standard attention but with reduced HBM (High Bandwidth Memory) accesses. It achieves this by tiling the computation into SRAM. What is the key insight that makes this possible?",
-      options: [
-        "It approximates the attention matrix with a low-rank factorization, trading accuracy for speed",
-        "It tiles $Q$, $K$, $V$ into blocks that fit in SRAM and uses the online softmax trick (tracking running max and sum) to compute exact attention without ever materializing the full $N \\times N$ attention matrix in HBM, reducing HBM accesses from $O(N^2)$ to $O(N^2 d / M)$ where $M$ is the SRAM size",
-        "It replaces softmax with ReLU attention, which can be computed blockwise without tracking normalization constants",
-        "It uses tensor cores to compute the full $N \\times N$ attention matrix faster, without changing the memory access pattern"
-      ],
-      correct: 1,
+      options: ["It approximates the attention matrix with a low-rank factorization, trading accuracy for speed", "It uses tensor cores to compute the full $N \\times N$ attention matrix faster, without changing the memory access pattern", "It replaces softmax with ReLU attention, which can be computed blockwise without tracking normalization constants", "It tiles $Q$, $K$, $V$ into blocks that fit in SRAM and uses the online softmax trick (tracking running max and sum) to compute exact attention without ever materializing the full $N \\times N$ attention matrix in HBM, reducing HBM accesses from $O(N^2)$ to $O(N^2 d / M)$ where $M$ is the SRAM size"],
+      correct: 3,
       explanation: "The core challenge is that softmax requires knowing the maximum and sum across the entire row to normalize. The online softmax algorithm (Milakov & Gimelshein, 2018) maintains running statistics: as each new block of $K$ is processed, the running max $m$ and sum $l$ are updated, and previously computed partial results are rescaled. This means each block of $Q$ can be processed against all blocks of $K$ sequentially, storing only $O(B_r \\times d)$ intermediate results in SRAM at a time. The FLOPs are identical to standard attention ($O(N^2 d)$), but HBM reads/writes drop from $O(N^2 + Nd)$ to $O(N^2 d / M)$."
     },
     {
       type: "mc",
       question: "The roofline model characterizes whether an operation is compute-bound or memory-bound. What determines which regime an operation falls into?",
-      options: [
-        "The total number of parameters in the model — larger models are always compute-bound",
-        "The arithmetic intensity $I = \\text{FLOPs} / \\text{Bytes}$ of the operation compared to the machine's compute-to-bandwidth ratio $\\pi / \\beta$ (peak FLOP/s divided by peak memory bandwidth). If $I < \\pi / \\beta$, the operation is memory-bound; if $I > \\pi / \\beta$, it is compute-bound",
-        "The batch size alone — small batches are memory-bound and large batches are compute-bound",
-        "Whether the GPU uses FP32 or FP16 — FP16 is always compute-bound due to tensor cores"
-      ],
-      correct: 1,
+      options: ["The total number of parameters in the model — larger models are always compute-bound", "The batch size alone — small batches are memory-bound and large batches are compute-bound", "The arithmetic intensity $I = \\text{FLOPs} / \\text{Bytes}$ of the operation compared to the machine's compute-to-bandwidth ratio $\\pi / \\beta$ (peak FLOP/s divided by peak memory bandwidth). If $I < \\pi / \\beta$, the operation is memory-bound; if $I > \\pi / \\beta$, it is compute-bound", "Whether the GPU uses FP32 or FP16 — FP16 is always compute-bound due to tensor cores"],
+      correct: 2,
       explanation: "The roofline model plots attainable FLOP/s against arithmetic intensity $I$ (FLOPs per byte transferred). Below the ridge point $I^* = \\pi / \\beta$, performance is limited by memory bandwidth (e.g., elementwise ops have $I \\approx 1$ FLOP/byte). Above it, performance is limited by peak compute (e.g., large matrix multiplications have $I \\approx 2n$ for $n \\times n$ matmul). For an A100 with $\\pi = 312$ TFLOP/s (FP16) and $\\beta = 2$ TB/s, the ridge point is $I^* = 156$ FLOP/byte. Operations must perform at least 156 FLOPs per byte loaded to be compute-bound."
     },
     {
@@ -334,73 +259,43 @@ export const hardwareAwareAssessment = {
     {
       type: "mc",
       question: "FP8 training uses two FP8 formats: E4M3 (4 exponent bits, 3 mantissa bits) and E5M2 (5 exponent bits, 2 mantissa bits). How are these typically used in practice?",
-      options: [
-        "E4M3 is used for all computations and E5M2 is used only for storage",
-        "E4M3 (higher precision, smaller range) is used for forward pass weights and activations, while E5M2 (lower precision, larger range) is used for gradients in the backward pass, because gradients have a wider dynamic range and benefit more from the extra exponent bit",
-        "Both formats are used interchangeably, selected randomly per operation",
-        "E5M2 is used for the forward pass because it has more exponent bits for representing weights"
-      ],
-      correct: 1,
+      options: ["E4M3 is used for all computations and E5M2 is used only for storage", "E5M2 is used for the forward pass because it has more exponent bits for representing weights", "Both formats are used interchangeably, selected randomly per operation", "E4M3 (higher precision, smaller range) is used for forward pass weights and activations, while E5M2 (lower precision, larger range) is used for gradients in the backward pass, because gradients have a wider dynamic range and benefit more from the extra exponent bit"],
+      correct: 3,
       explanation: "E4M3 has range $\\pm 448$ with higher precision (8 significand values per exponent), suitable for weights and activations whose distribution is relatively concentrated. E5M2 has range $\\pm 57344$ with lower precision (4 significand values per exponent), better for gradients which can span many orders of magnitude, especially in early layers or with loss scaling. Per-tensor scaling factors $s$ are maintained: values are stored as $x_{\\text{FP8}} = \\text{cast}(x / s)$ and restored as $x \\approx s \\cdot x_{\\text{FP8}}$. The scaling factors are updated periodically based on the observed tensor statistics."
     },
     {
       type: "mc",
       question: "Per-tensor scaling is essential for FP8 training. Why can't you simply cast FP32/FP16 values to FP8 without scaling?",
-      options: [
-        "FP8 casting without scaling would cause type errors in the GPU hardware",
-        "FP8 has extremely limited dynamic range (e.g., E4M3 max is 448). Without scaling, tensors whose values exceed this range overflow to INF, while tensors with small values (e.g., gradients of $10^{-4}$) lose precision to quantization noise. Per-tensor scaling maps the tensor's range into the FP8 representable range, maximizing the use of available precision",
-        "Scaling is only needed for backward compatibility with older GPU architectures",
-        "Without scaling, FP8 matmuls produce outputs in a non-standard format that cannot be accumulated"
-      ],
-      correct: 1,
+      options: ["FP8 casting without scaling would cause type errors in the GPU hardware", "Scaling is only needed for backward compatibility with older GPU architectures", "FP8 has extremely limited dynamic range (e.g., E4M3 max is 448). Without scaling, tensors whose values exceed this range overflow to INF, while tensors with small values (e.g., gradients of $10^{-4}$) lose precision to quantization noise. Per-tensor scaling maps the tensor's range into the FP8 representable range, maximizing the use of available precision", "Without scaling, FP8 matmuls produce outputs in a non-standard format that cannot be accumulated"],
+      correct: 2,
       explanation: "E4M3 can represent values from $2^{-9}$ to $448$, roughly 6 orders of magnitude. Transformer weights might range from $-0.5$ to $0.5$, using only a fraction of FP8's range and losing precision. Gradients might range from $10^{-7}$ to $10^{-2}$, falling partially below E4M3's minimum. Per-tensor scaling computes $s = \\max(|x|) / 448$ (for E4M3) and stores $x/s$ in FP8, placing the maximum value at FP8's maximum. Delayed scaling (using statistics from the previous iteration) is used to avoid the synchronization cost of computing the current tensor's max before casting."
     },
     {
       type: "mc",
       question: "Operator fusion combines multiple sequential GPU operations into a single kernel launch. Why does this provide significant speedups for operations like LayerNorm followed by a GeLU activation?",
-      options: [
-        "Fused operators use a more efficient mathematical formulation that reduces FLOPs",
-        "Without fusion, each elementwise operation reads its input from HBM, computes, and writes the output back to HBM. Fusing multiple operations into a single kernel reads data from HBM once, performs all operations in registers/SRAM, and writes the final result once, eliminating intermediate HBM round-trips. Since these operations are memory-bound, the speedup is proportional to the number of fused operations",
-        "Fusion allows the GPU to use specialized hardware units designed for compound operations",
-        "Fusion reduces the precision requirements, allowing FP8 to be used instead of FP16"
-      ],
-      correct: 1,
+      options: ["Without fusion, each elementwise operation reads its input from HBM, computes, and writes the output back to HBM. Fusing multiple operations into a single kernel reads data from HBM once, performs all operations in registers/SRAM, and writes the final result once, eliminating intermediate HBM round-trips. Since these operations are memory-bound, the speedup is proportional to the number of fused operations", "Fused operators use a more efficient mathematical formulation that reduces FLOPs", "Fusion allows the GPU to use specialized hardware units designed for compound operations", "Fusion reduces the precision requirements, allowing FP8 to be used instead of FP16"],
+      correct: 0,
       explanation: "Consider LayerNorm ($\\mu = \\text{mean}(x)$, $\\sigma = \\text{std}(x)$, $y = (x - \\mu)/\\sigma \\cdot \\gamma + \\beta$) followed by GeLU ($z = y \\cdot \\Phi(y)$). Unfused: read $x$ from HBM, write intermediate $y$ to HBM, read $y$ from HBM, write $z$ to HBM — 4 HBM transfers. Fused: read $x$ from HBM, compute both operations in SRAM/registers, write $z$ to HBM — 2 HBM transfers. Since these are memory-bound (arithmetic intensity $\\approx 10$ FLOP/byte, well below the ridge point), halving the memory traffic nearly halves the wall-clock time. `torch.compile` automates this fusion."
     },
     {
       type: "mc",
       question: "In the GPU memory hierarchy, what are the relative sizes and bandwidths of registers, L1/shared memory (SRAM), L2 cache, and HBM on an NVIDIA A100?",
-      options: [
-        "Registers: 256 KB/SM at ~50 TB/s aggregate; L1/SRAM: 192 KB/SM at ~19 TB/s aggregate; L2: 40 MB at ~5 TB/s; HBM: 80 GB at 2 TB/s. Each level trades capacity for bandwidth by roughly an order of magnitude",
-        "All levels have roughly the same bandwidth, but differ in capacity",
-        "HBM is faster than SRAM but smaller, which is why data is cached in HBM",
-        "Registers: 1 MB/SM; L1: 10 MB; L2: 1 GB; HBM: 80 GB, all at uniform 2 TB/s bandwidth"
-      ],
-      correct: 0,
+      options: ["All levels have roughly the same bandwidth, but differ in capacity", "Registers: 256 KB/SM at ~50 TB/s aggregate; L1/SRAM: 192 KB/SM at ~19 TB/s aggregate; L2: 40 MB at ~5 TB/s; HBM: 80 GB at 2 TB/s. Each level trades capacity for bandwidth by roughly an order of magnitude", "HBM is faster than SRAM but smaller, which is why data is cached in HBM", "Registers: 1 MB/SM; L1: 10 MB; L2: 1 GB; HBM: 80 GB, all at uniform 2 TB/s bandwidth"],
+      correct: 1,
       explanation: "The memory hierarchy follows a clear pattern: as capacity increases, bandwidth decreases. Registers (256 KB per SM, ~27.6 MB total across 108 SMs) can be accessed in a single cycle at aggregate bandwidths exceeding 50 TB/s. Shared memory/L1 (192 KB per SM, configurable) provides ~19 TB/s aggregate. L2 cache (40 MB, shared across all SMs) offers ~5 TB/s. HBM (80 GB) provides 2 TB/s. Efficient kernel design maximizes data reuse at the fastest level — this is exactly what FlashAttention and operator fusion exploit."
     },
     {
       type: "mc",
       question: "A matrix multiplication $C = AB$ where $A \\in \\mathbb{R}^{M \\times K}$ and $B \\in \\mathbb{R}^{K \\times N}$ has arithmetic intensity $I = \\frac{2MNK}{(MK + KN + MN) \\times \\text{bytes\\_per\\_element}}$. For large square matrices ($M = N = K = n$), what does $I$ simplify to, and what does this imply?",
-      options: [
-        "$I \\approx 2/3$ FLOP/byte, so matmuls are always memory-bound",
-        "$I \\approx \\frac{2n}{3 \\times \\text{bytes\\_per\\_element}}$, which grows linearly with $n$. For FP16 with $n = 4096$, $I \\approx 1365$ FLOP/byte, far above the A100 ridge point of ~156 FLOP/byte, making large matmuls firmly compute-bound",
-        "$I = n^2$, growing quadratically and making all matmuls compute-bound",
-        "$I = 2$, regardless of matrix size"
-      ],
-      correct: 1,
+      options: ["$I \\approx 2/3$ FLOP/byte, so matmuls are always memory-bound", "$I = 2$, regardless of matrix size", "$I = n^2$, growing quadratically and making all matmuls compute-bound", "$I \\approx \\frac{2n}{3 \\times \\text{bytes\\_per\\_element}}$, which grows linearly with $n$. For FP16 with $n = 4096$, $I \\approx 1365$ FLOP/byte, far above the A100 ridge point of ~156 FLOP/byte, making large matmuls firmly compute-bound"],
+      correct: 3,
       explanation: "For square matrices: FLOPs $= 2n^3$, bytes transferred $= 3n^2 \\times \\text{bytes\\_per\\_element}$ (reading $A$, $B$, and writing $C$). So $I = 2n^3 / (3n^2 \\times \\text{bpe}) = 2n/(3 \\times \\text{bpe})$. For FP16 (bpe = 2), $I = n/3$. At $n = 4096$, $I \\approx 1365$, vastly exceeding the A100 ridge point. This is why ML workloads are structured around large matrix multiplications — they efficiently utilize the GPU's compute capacity. Small or skinny matrices (e.g., batch size 1 during inference) have much lower $I$ and become memory-bound."
     },
     {
       type: "mc",
       question: "When profiling a transformer training step with PyTorch Profiler or NVIDIA Nsight Systems, you observe that GPU utilization is only 40%. The trace shows many small gaps between kernel launches. What is the most likely cause and solution?",
-      options: [
-        "The model is too large for the GPU, causing constant HBM thrashing",
-        "CPU overhead: the Python-side kernel launch overhead and data preprocessing cannot keep the GPU busy. Small, non-fused kernels exacerbate this because each requires a separate CPU-side launch. Solutions include `torch.compile` (which fuses kernels and uses CUDA graphs to batch launches), increasing batch size (to make each kernel launch do more work), and moving data preprocessing to a separate process",
-        "The GPU has a hardware defect and should be replaced",
-        "40% utilization is normal for transformer training and cannot be improved"
-      ],
-      correct: 1,
+      options: ["The model is too large for the GPU, causing constant HBM thrashing", "The GPU has a hardware defect and should be replaced", "CPU overhead: the Python-side kernel launch overhead and data preprocessing cannot keep the GPU busy. Small, non-fused kernels exacerbate this because each requires a separate CPU-side launch. Solutions include `torch.compile` (which fuses kernels and uses CUDA graphs to batch launches), increasing batch size (to make each kernel launch do more work), and moving data preprocessing to a separate process", "40% utilization is normal for transformer training and cannot be improved"],
+      correct: 2,
       explanation: "Each CUDA kernel launch has ~10-20 microseconds of CPU-side overhead. With hundreds of small kernels per training step (each elementwise op, each matmul, each reduction), this adds up. The GPU finishes a small kernel before the CPU can launch the next one. `torch.compile` addresses this by: (1) fusing elementwise ops into fewer kernels, (2) using CUDA graphs to record and replay entire sequences of kernel launches with a single CPU call, eliminating per-kernel launch overhead. CUDA graphs alone can improve throughput by 10-30% for small-batch workloads."
     }
   ]
@@ -420,13 +315,8 @@ export const optimizationAssessment = {
     {
       type: "mc",
       question: "The KKT (Karush-Kuhn-Tucker) conditions are necessary conditions for optimality in constrained optimization. For the problem $\\min f(x)$ subject to $g_i(x) \\leq 0$ and $h_j(x) = 0$, which of the following correctly states the complementary slackness condition?",
-      options: [
-        "All inequality constraints must be active (binding) at the optimum: $g_i(x^*) = 0$ for all $i$",
-        "For each inequality constraint, $\\mu_i g_i(x^*) = 0$, meaning either the constraint is active ($g_i(x^*) = 0$) or its dual variable is zero ($\\mu_i = 0$). An inactive constraint contributes no force to the optimality conditions",
-        "The gradient of $f$ must be zero at the optimum, regardless of the constraints",
-        "The dual variables $\\mu_i$ must all be strictly positive"
-      ],
-      correct: 1,
+      options: ["For each inequality constraint, $\\mu_i g_i(x^*) = 0$, meaning either the constraint is active ($g_i(x^*) = 0$) or its dual variable is zero ($\\mu_i = 0$). An inactive constraint contributes no force to the optimality conditions", "All inequality constraints must be active (binding) at the optimum: $g_i(x^*) = 0$ for all $i$", "The gradient of $f$ must be zero at the optimum, regardless of the constraints", "The dual variables $\\mu_i$ must all be strictly positive"],
+      correct: 0,
       explanation: "The KKT conditions are: (1) Stationarity: $\\nabla f + \\sum_i \\mu_i \\nabla g_i + \\sum_j \\lambda_j \\nabla h_j = 0$; (2) Primal feasibility: $g_i(x^*) \\leq 0$, $h_j(x^*) = 0$; (3) Dual feasibility: $\\mu_i \\geq 0$; (4) Complementary slackness: $\\mu_i g_i(x^*) = 0$. The intuition for complementary slackness: if constraint $i$ is not active (i.e., $g_i(x^*) < 0$, we have slack), then $\\mu_i$ must be 0 — the constraint does not influence the solution. Only active constraints can have $\\mu_i > 0$, pushing the solution away from infeasibility."
     },
     {
@@ -444,25 +334,15 @@ export const optimizationAssessment = {
     {
       type: "mc",
       question: "In high-dimensional non-convex optimization (such as neural network training), saddle points are much more prevalent than local minima. What is the theoretical basis for this claim?",
-      options: [
-        "Neural network loss functions are convex in all but one direction, so saddle points are rare",
-        "At a critical point, each eigenvalue of the Hessian is independently positive or negative with roughly equal probability. In $d$ dimensions, a local minimum requires all $d$ eigenvalues to be positive (probability $\\sim 2^{-d}$), making local minima exponentially rare compared to saddle points (which have a mix of signs). This is supported by random matrix theory applied to the loss landscape",
-        "Saddle points only occur in linear networks, not in networks with nonlinear activations",
-        "Local minima are more common but harder to find, so optimizers encounter saddle points more often"
-      ],
-      correct: 1,
+      options: ["Neural network loss functions are convex in all but one direction, so saddle points are rare", "Local minima are more common but harder to find, so optimizers encounter saddle points more often", "Saddle points only occur in linear networks, not in networks with nonlinear activations", "At a critical point, each eigenvalue of the Hessian is independently positive or negative with roughly equal probability. In $d$ dimensions, a local minimum requires all $d$ eigenvalues to be positive (probability $\\sim 2^{-d}$), making local minima exponentially rare compared to saddle points (which have a mix of signs). This is supported by random matrix theory applied to the loss landscape"],
+      correct: 3,
       explanation: "Bray and Dean (2007) showed that for random Gaussian fields in high dimensions, the probability of a critical point being a local minimum decreases exponentially with dimension. Dauphin et al. (2014) connected this to neural networks: at a critical point of a $d$-dimensional loss surface, the Hessian has $d$ eigenvalues. If each sign is roughly random, the probability that all are positive (local min) is $\\sim 2^{-d}$. For $d = 10^9$ parameters, local minima are astronomically rare. Most critical points are saddle points with $O(d)$ negative eigenvalues, which SGD can escape via noise."
     },
     {
       type: "mc",
       question: "SGD with mini-batches uses gradient estimates $\\hat{g} = \\frac{1}{|B|} \\sum_{i \\in B} \\nabla \\ell_i(\\theta)$. How does the gradient noise from mini-batch sampling act as regularization?",
-      options: [
-        "The noise causes the optimizer to diverge from good solutions, requiring early stopping as a compensating regularizer",
-        "The noise in mini-batch gradients has covariance approximately $\\frac{\\Sigma}{|B|}$ where $\\Sigma$ is the per-sample gradient covariance. This noise biases SGD toward flatter minima: sharp minima (large Hessian eigenvalues) are destabilized because gradient noise causes escape, while flat minima (small eigenvalues) are stable. The noise implicitly penalizes sharpness, acting as a form of regularization controlled by the learning rate-to-batch size ratio $\\eta / |B|$",
-        "SGD noise has no regularization effect; any observed generalization benefit is due to the learning rate schedule",
-        "The noise adds a constant L2 penalty to the loss, equivalent to weight decay"
-      ],
-      correct: 1,
+      options: ["The noise causes the optimizer to diverge from good solutions, requiring early stopping as a compensating regularizer", "SGD noise has no regularization effect; any observed generalization benefit is due to the learning rate schedule", "The noise in mini-batch gradients has covariance approximately $\\frac{\\Sigma}{|B|}$ where $\\Sigma$ is the per-sample gradient covariance. This noise biases SGD toward flatter minima: sharp minima (large Hessian eigenvalues) are destabilized because gradient noise causes escape, while flat minima (small eigenvalues) are stable. The noise implicitly penalizes sharpness, acting as a form of regularization controlled by the learning rate-to-batch size ratio $\\eta / |B|$", "The noise adds a constant L2 penalty to the loss, equivalent to weight decay"],
+      correct: 2,
       explanation: "The SGD noise covariance is $C = \\frac{\\Sigma}{|B|}$, and the effective temperature of the stochastic process is governed by $\\eta / |B|$ (learning rate divided by batch size). Near a minimum with Hessian $H$, the noise causes fluctuations of order $\\sqrt{\\eta \\sigma^2 / |B|}$ in each eigendirection. If $\\eta \\lambda_{\\max}(H) \\sigma^2 / |B|$ is too large, the optimizer escapes the minimum. This means sharp minima (large $\\lambda_{\\max}$) are destabilized first. This is why reducing batch size or increasing learning rate (both increase $\\eta / |B|$) can improve generalization."
     },
     {
@@ -480,13 +360,8 @@ export const optimizationAssessment = {
     {
       type: "mc",
       question: "Why does Adam work particularly well for transformers compared to SGD with momentum?",
-      options: [
-        "Adam uses less memory than SGD with momentum",
-        "Transformers have loss landscapes with highly non-uniform curvature: the Hessian eigenvalue spectrum spans many orders of magnitude (from attention logits to embedding weights). Adam's per-parameter adaptive learning rate ($\\eta / \\sqrt{\\hat{v}_t}$) effectively rescales each parameter's update by the inverse of its RMS gradient, providing implicit preconditioning that handles this curvature variation. SGD uses a single learning rate for all parameters",
-        "Adam converges to the global minimum while SGD gets stuck in local minima",
-        "Adam is only preferred because of its default hyperparameters, not because of any algorithmic advantage"
-      ],
-      correct: 1,
+      options: ["Transformers have loss landscapes with highly non-uniform curvature: the Hessian eigenvalue spectrum spans many orders of magnitude (from attention logits to embedding weights). Adam's per-parameter adaptive learning rate ($\\eta / \\sqrt{\\hat{v}_t}$) effectively rescales each parameter's update by the inverse of its RMS gradient, providing implicit preconditioning that handles this curvature variation. SGD uses a single learning rate for all parameters", "Adam uses less memory than SGD with momentum", "Adam converges to the global minimum while SGD gets stuck in local minima", "Adam is only preferred because of its default hyperparameters, not because of any algorithmic advantage"],
+      correct: 0,
       explanation: "In a transformer, the gradient magnitudes across different parameter groups can differ by orders of magnitude (e.g., attention QK projections vs. output embeddings). Adam's update $\\Delta \\theta_i \\propto \\hat{m}_i / \\sqrt{\\hat{v}_i}$ normalizes each parameter's step size by its gradient RMS, effectively adapting to local curvature. This approximates a diagonal preconditioner: $\\Delta \\theta \\approx \\text{diag}(\\hat{v})^{-1/2} \\hat{m}$, compared to the ideal Newton step $H^{-1} g$. For SGD, a single learning rate must compromise between too large for some parameters and too small for others, making it harder to tune and slower to converge."
     },
     {
@@ -504,13 +379,8 @@ export const optimizationAssessment = {
     {
       type: "mc",
       question: "The debate around sharp vs. flat minima and generalization has been ongoing. What is the main criticism of using sharpness (eigenvalues of the Hessian) as a predictor of generalization?",
-      options: [
-        "The Hessian is too expensive to compute, making sharpness impractical as a metric",
-        "Dinh et al. (2017) showed that for networks with ReLU activations, sharpness is not reparameterization-invariant: you can reparameterize the network (e.g., scale one layer's weights by $\\alpha$ and the next by $1/\\alpha$) to make any minimum arbitrarily sharp or flat without changing the function the network computes or its generalization",
-        "Flat minima always generalize worse than sharp minima in practice",
-        "The Hessian is always positive definite at local minima, so all minima have the same sharpness"
-      ],
-      correct: 1,
+      options: ["The Hessian is too expensive to compute, making sharpness impractical as a metric", "The Hessian is always positive definite at local minima, so all minima have the same sharpness", "Flat minima always generalize worse than sharp minima in practice", "Dinh et al. (2017) showed that for networks with ReLU activations, sharpness is not reparameterization-invariant: you can reparameterize the network (e.g., scale one layer's weights by $\\alpha$ and the next by $1/\\alpha$) to make any minimum arbitrarily sharp or flat without changing the function the network computes or its generalization"],
+      correct: 3,
       explanation: "For a network with ReLU activations and layers $W_1, W_2$, the function $f(x) = W_2 \\cdot \\text{ReLU}(W_1 x)$ is identical to $f(x) = (W_2/\\alpha) \\cdot \\text{ReLU}(\\alpha W_1 x)$ for any $\\alpha > 0$ (by homogeneity of ReLU). But scaling $W_1$ by $\\alpha$ multiplies the Hessian eigenvalues by $\\alpha^2$, making the minimum arbitrarily sharp. This means raw sharpness cannot predict generalization. Recent work defines sharpness measures that are reparameterization-invariant (e.g., SAM's sharpness-aware minimization uses normalized perturbations) to address this critique."
     },
     {
@@ -528,13 +398,8 @@ export const optimizationAssessment = {
     {
       type: "mc",
       question: "Sharpness-Aware Minimization (SAM) modifies the training objective to explicitly seek flat minima. What does SAM optimize?",
-      options: [
-        "SAM adds an L2 penalty to encourage small weights, which indirectly leads to flat minima",
-        "SAM minimizes the worst-case loss in a neighborhood: $\\min_\\theta \\max_{\\|\\epsilon\\| \\leq \\rho} \\mathcal{L}(\\theta + \\epsilon)$. At each step, it first computes the adversarial perturbation $\\hat{\\epsilon} = \\rho \\nabla \\mathcal{L}(\\theta) / \\|\\nabla \\mathcal{L}(\\theta)\\|$ and then takes a gradient step at the perturbed point: $\\theta \\leftarrow \\theta - \\eta \\nabla \\mathcal{L}(\\theta + \\hat{\\epsilon})$",
-        "SAM computes the Hessian trace and adds it as a regularization term to the loss",
-        "SAM randomly perturbs the weights each step and averages the resulting losses"
-      ],
-      correct: 1,
+      options: ["SAM adds an L2 penalty to encourage small weights, which indirectly leads to flat minima", "SAM computes the Hessian trace and adds it as a regularization term to the loss", "SAM minimizes the worst-case loss in a neighborhood: $\\min_\\theta \\max_{\\|\\epsilon\\| \\leq \\rho} \\mathcal{L}(\\theta + \\epsilon)$. At each step, it first computes the adversarial perturbation $\\hat{\\epsilon} = \\rho \\nabla \\mathcal{L}(\\theta) / \\|\\nabla \\mathcal{L}(\\theta)\\|$ and then takes a gradient step at the perturbed point: $\\theta \\leftarrow \\theta - \\eta \\nabla \\mathcal{L}(\\theta + \\hat{\\epsilon})$", "SAM randomly perturbs the weights each step and averages the resulting losses"],
+      correct: 2,
       explanation: "SAM's minimax objective seeks parameters $\\theta$ where not just $\\mathcal{L}(\\theta)$ is low, but the loss remains low for all perturbations $\\epsilon$ within an $\\ell_2$ ball of radius $\\rho$. This explicitly penalizes sharp minima where small perturbations cause large loss increases. The practical algorithm uses a first-order approximation: the inner maximization is approximated by a single gradient ascent step (giving $\\hat{\\epsilon}$), and the outer minimization takes a gradient step at $\\theta + \\hat{\\epsilon}$. This requires two forward-backward passes per step (2x compute cost) but consistently improves generalization across vision and language tasks."
     }
   ]
@@ -554,13 +419,8 @@ export const systemsAssessment = {
     {
       type: "mc",
       question: "An NVIDIA GPU organizes execution into Streaming Multiprocessors (SMs), each running multiple warps. What is a warp, and why does warp-level execution matter for ML kernel performance?",
-      options: [
-        "A warp is a group of 64 threads that share an instruction cache. Warps are purely a software abstraction",
-        "A warp is a group of 32 threads that execute the same instruction simultaneously (SIMT — Single Instruction, Multiple Threads). If threads within a warp take different branches (warp divergence), both paths are executed serially with threads masked, reducing throughput. For ML kernels, data-parallel operations (like elementwise ops) naturally avoid divergence, while operations with data-dependent branching can suffer significant slowdowns",
-        "A warp is a hardware unit that performs matrix multiplication using tensor cores",
-        "A warp is a memory controller that manages 32 consecutive bytes in HBM"
-      ],
-      correct: 1,
+      options: ["A warp is a group of 32 threads that execute the same instruction simultaneously (SIMT — Single Instruction, Multiple Threads). If threads within a warp take different branches (warp divergence), both paths are executed serially with threads masked, reducing throughput. For ML kernels, data-parallel operations (like elementwise ops) naturally avoid divergence, while operations with data-dependent branching can suffer significant slowdowns", "A warp is a group of 64 threads that share an instruction cache. Warps are purely a software abstraction", "A warp is a hardware unit that performs matrix multiplication using tensor cores", "A warp is a memory controller that manages 32 consecutive bytes in HBM"],
+      correct: 0,
       explanation: "The warp is the fundamental unit of execution on NVIDIA GPUs. All 32 threads in a warp share a program counter and execute in lockstep. When an `if` statement causes some threads to take one branch and others a different branch, the hardware serializes: it executes the `if` path (masking threads that took `else`), then the `else` path (masking the others). For ML, this means kernels should minimize data-dependent branching. Quantization kernels that branch on per-element conditions can suffer severe warp divergence. Structured operations (matmul, reductions, elementwise) naturally keep warps coherent."
     },
     {
@@ -578,37 +438,22 @@ export const systemsAssessment = {
     {
       type: "mc",
       question: "`torch.compile` transforms PyTorch code for faster execution. What does it actually do under the hood?",
-      options: [
-        "It converts PyTorch code to C++ and compiles it with GCC for faster execution",
-        "It uses TorchDynamo to capture the computational graph by intercepting Python bytecode, then passes the graph to a backend compiler (TorchInductor by default) that performs operator fusion, memory planning, and generates optimized Triton kernels or CUDA code. Graph breaks occur when unsupported Python constructs are encountered",
-        "It simply enables CUDA graphs for all operations without any graph transformation",
-        "It replaces PyTorch operations with pre-optimized cuDNN library calls"
-      ],
-      correct: 1,
+      options: ["It converts PyTorch code to C++ and compiles it with GCC for faster execution", "It replaces PyTorch operations with pre-optimized cuDNN library calls", "It simply enables CUDA graphs for all operations without any graph transformation", "It uses TorchDynamo to capture the computational graph by intercepting Python bytecode, then passes the graph to a backend compiler (TorchInductor by default) that performs operator fusion, memory planning, and generates optimized Triton kernels or CUDA code. Graph breaks occur when unsupported Python constructs are encountered"],
+      correct: 3,
       explanation: "The `torch.compile` pipeline has three stages: (1) TorchDynamo modifies CPython's frame evaluation to trace through Python bytecode, capturing the computation as an FX graph while handling Python control flow via guards and graph breaks. (2) AOTAutograd traces the forward and backward passes ahead-of-time, enabling joint optimization. (3) TorchInductor (the default backend) applies optimizations like operator fusion (combining pointwise ops into single kernels), memory planning (reusing buffers), and code generation (emitting optimized Triton kernels). The result is significantly fewer, larger kernel launches."
     },
     {
       type: "mc",
       question: "In data-parallel distributed training, all-reduce is the standard collective communication operation for synchronizing gradients. What does all-reduce compute, and what is the bandwidth cost of the ring all-reduce algorithm?",
-      options: [
-        "All-reduce sends all gradients to a central server, which computes the mean and broadcasts it back. The cost is $O(N \\cdot M)$ where $N$ is the number of workers and $M$ is the message size",
-        "All-reduce computes the sum (or mean) of tensors across all $N$ workers and places the result on every worker. Ring all-reduce achieves this in $2(N-1)/N \\cdot M$ bytes of data transferred per worker (asymptotically $2M$), which is independent of $N$ — making it bandwidth-optimal. It proceeds in two phases: reduce-scatter and all-gather, each taking $N-1$ steps",
-        "All-reduce randomly selects one worker's gradients and copies them to all others",
-        "All-reduce only works with 2 workers and must be composed recursively for larger clusters"
-      ],
-      correct: 1,
+      options: ["All-reduce sends all gradients to a central server, which computes the mean and broadcasts it back. The cost is $O(N \\cdot M)$ where $N$ is the number of workers and $M$ is the message size", "All-reduce randomly selects one worker's gradients and copies them to all others", "All-reduce computes the sum (or mean) of tensors across all $N$ workers and places the result on every worker. Ring all-reduce achieves this in $2(N-1)/N \\cdot M$ bytes of data transferred per worker (asymptotically $2M$), which is independent of $N$ — making it bandwidth-optimal. It proceeds in two phases: reduce-scatter and all-gather, each taking $N-1$ steps", "All-reduce only works with 2 workers and must be composed recursively for larger clusters"],
+      correct: 2,
       explanation: "Ring all-reduce arranges $N$ workers in a logical ring. Phase 1 (reduce-scatter): over $N-1$ steps, each worker sends a $1/N$-th chunk of its data to the next worker while receiving and accumulating a chunk from the previous worker. After $N-1$ steps, each worker holds the fully reduced version of one chunk. Phase 2 (all-gather): over $N-1$ steps, these reduced chunks are circulated so every worker gets all chunks. Total data per worker: $(N-1)/N \\cdot M$ per phase, or $2(N-1)/N \\cdot M$ total. This is bandwidth-optimal: the lower bound is $2(N-1)/N \\cdot M$. The latency is $O(N)$ steps, which tree-based algorithms reduce to $O(\\log N)$."
     },
     {
       type: "mc",
       question: "A parameter server architecture is an alternative to all-reduce for distributed training. How does it differ, and when is each approach preferred?",
-      options: [
-        "Parameter servers are always faster than all-reduce because they use asynchronous updates",
-        "In a parameter server architecture, dedicated server nodes store model parameters, and worker nodes push gradients and pull updated weights. This enables asynchronous SGD (workers don't wait for each other) but introduces stale gradients. All-reduce is synchronous and bandwidth-optimal for dense gradients. Parameter servers are preferred for sparse models (e.g., recommendation models with large embedding tables) where each worker only accesses a subset of parameters",
-        "Parameter servers and all-reduce are mathematically identical and always produce the same result",
-        "Parameter servers only work on CPUs while all-reduce only works on GPUs"
-      ],
-      correct: 1,
+      options: ["In a parameter server architecture, dedicated server nodes store model parameters, and worker nodes push gradients and pull updated weights. This enables asynchronous SGD (workers don't wait for each other) but introduces stale gradients. All-reduce is synchronous and bandwidth-optimal for dense gradients. Parameter servers are preferred for sparse models (e.g., recommendation models with large embedding tables) where each worker only accesses a subset of parameters", "Parameter servers are always faster than all-reduce because they use asynchronous updates", "Parameter servers and all-reduce are mathematically identical and always produce the same result", "Parameter servers only work on CPUs while all-reduce only works on GPUs"],
+      correct: 0,
       explanation: "Parameter servers split the model across server nodes. Workers compute gradients on their data, push gradients to servers, and pull updated parameters. This naturally handles sparse updates: if a worker only touches embedding rows $\\{5, 1000, 50000\\}$, it only communicates those rows, not the entire embedding table. Asynchronous PS allows workers to proceed without synchronization barriers, improving throughput but introducing gradient staleness that can hurt convergence. For dense transformer training, synchronous all-reduce is preferred because all parameters are updated every step and ring all-reduce is bandwidth-optimal for this pattern."
     },
     {
@@ -626,37 +471,22 @@ export const systemsAssessment = {
     {
       type: "mc",
       question: "When profiling a training run with PyTorch Profiler, you see that a single linear layer (`nn.Linear(4096, 4096)`) takes 0.5ms with batch size 1 but only 0.6ms with batch size 64. What explains this sublinear scaling of time with batch size?",
-      options: [
-        "PyTorch automatically reduces precision for larger batches to maintain speed",
-        "With batch size 1, the matmul is $y = Wx$ where $W \\in \\mathbb{R}^{4096 \\times 4096}$ and $x \\in \\mathbb{R}^{4096}$: 33M FLOPs but 32MB of weight data to load — arithmetic intensity of ~1 FLOP/byte (memory-bound). With batch size 64, $X \\in \\mathbb{R}^{64 \\times 4096}$: 2.1B FLOPs but the same 32MB of weights — arithmetic intensity of ~64 FLOP/byte (compute-bound). The weights are loaded once and reused across all batch elements, so increasing batch size is nearly free until compute saturation",
-        "The GPU dynamically overclocks when it detects larger batch sizes",
-        "Batch size 64 triggers a different CUDA kernel that uses a faster algorithm"
-      ],
-      correct: 1,
+      options: ["PyTorch automatically reduces precision for larger batches to maintain speed", "Batch size 64 triggers a different CUDA kernel that uses a faster algorithm", "The GPU dynamically overclocks when it detects larger batch sizes", "With batch size 1, the matmul is $y = Wx$ where $W \\in \\mathbb{R}^{4096 \\times 4096}$ and $x \\in \\mathbb{R}^{4096}$: 33M FLOPs but 32MB of weight data to load — arithmetic intensity of ~1 FLOP/byte (memory-bound). With batch size 64, $X \\in \\mathbb{R}^{64 \\times 4096}$: 2.1B FLOPs but the same 32MB of weights — arithmetic intensity of ~64 FLOP/byte (compute-bound). The weights are loaded once and reused across all batch elements, so increasing batch size is nearly free until compute saturation"],
+      correct: 3,
       explanation: "This is the classic memory-bound to compute-bound transition. For $y = WX^\\top$ with $W \\in \\mathbb{R}^{m \\times k}$, $X \\in \\mathbb{R}^{B \\times k}$: FLOPs $= 2mBk$, bytes $\\approx (mk + Bk) \\times 2$ (FP16). Arithmetic intensity $I \\approx 2mB/(m+B)$ FLOP/byte. For $m = k = 4096$: $B = 1$ gives $I \\approx 2$, $B = 64$ gives $I \\approx 124$, and $B = 256$ gives $I \\approx 470$. On an A100 (ridge point ~156), $B = 64$ is still somewhat memory-bound but much closer to compute-bound, while $B = 256$ is fully compute-bound. This is why batching is critical for inference throughput."
     },
     {
       type: "mc",
       question: "NVIDIA Nsight Systems and Nsight Compute are two profiling tools. What is the key difference between them, and when would you use each?",
-      options: [
-        "They are identical tools with different names for different GPU architectures",
-        "Nsight Systems provides a system-level timeline view showing CPU activity, GPU kernel launches, memory transfers, and inter-device communication across the entire application. Nsight Compute provides detailed per-kernel analysis: occupancy, memory throughput, compute utilization, warp stall reasons, and roofline analysis. Use Nsight Systems first to identify bottleneck regions, then Nsight Compute to drill into specific slow kernels",
-        "Nsight Systems profiles CPU code and Nsight Compute profiles GPU memory",
-        "Nsight Compute is the newer version that replaces Nsight Systems entirely"
-      ],
-      correct: 1,
+      options: ["They are identical tools with different names for different GPU architectures", "Nsight Systems profiles CPU code and Nsight Compute profiles GPU memory", "Nsight Systems provides a system-level timeline view showing CPU activity, GPU kernel launches, memory transfers, and inter-device communication across the entire application. Nsight Compute provides detailed per-kernel analysis: occupancy, memory throughput, compute utilization, warp stall reasons, and roofline analysis. Use Nsight Systems first to identify bottleneck regions, then Nsight Compute to drill into specific slow kernels", "Nsight Compute is the newer version that replaces Nsight Systems entirely"],
+      correct: 2,
       explanation: "The profiling workflow is: (1) Run Nsight Systems (`nsys profile python train.py`) to get the full timeline. Look for gaps between kernel launches (CPU overhead), unexpectedly slow kernels, or communication stalls. (2) Once you identify a specific kernel, use Nsight Compute (`ncu --set full python train.py --kernel-name regex:my_kernel`) to analyze it in detail: is it compute-bound or memory-bound? What is the occupancy? Are there bank conflicts in shared memory? What are the warp stall reasons? This two-level approach efficiently narrows down performance issues."
     },
     {
       type: "mc",
       question: "GPU occupancy measures the ratio of active warps to the maximum possible warps per SM. Why is 100% occupancy not always optimal, and what limits occupancy?",
-      options: [
-        "100% occupancy is always optimal because more warps means more parallelism",
-        "Occupancy is limited by three resources per SM: registers per thread, shared memory per block, and the maximum number of thread blocks. A kernel using many registers per thread can only run a few warps concurrently. However, fewer warps with more registers can outperform many warps with fewer registers, because register pressure causes spills to local memory (slow). The optimal occupancy balances latency hiding (more warps to cover memory stalls) against per-thread resource availability",
-        "Occupancy is always 100% on modern GPUs due to hardware scheduling improvements",
-        "Occupancy only matters for graphics workloads, not ML training"
-      ],
-      correct: 1,
+      options: ["Occupancy is limited by three resources per SM: registers per thread, shared memory per block, and the maximum number of thread blocks. A kernel using many registers per thread can only run a few warps concurrently. However, fewer warps with more registers can outperform many warps with fewer registers, because register pressure causes spills to local memory (slow). The optimal occupancy balances latency hiding (more warps to cover memory stalls) against per-thread resource availability", "100% occupancy is always optimal because more warps means more parallelism", "Occupancy is always 100% on modern GPUs due to hardware scheduling improvements", "Occupancy only matters for graphics workloads, not ML training"],
+      correct: 0,
       explanation: "An A100 SM has 65,536 registers and supports up to 64 warps (2048 threads). A kernel using 128 registers per thread allows $65536 / (128 \\times 32) = 16$ warps per SM, giving 25% occupancy. Reducing to 64 registers allows 32 warps (50% occupancy) but may require spilling registers to local memory (~100x slower than register access). For compute-bound kernels (like matmul), fewer warps with full register usage often wins. For memory-bound kernels, more warps are needed to hide memory latency through warp switching. Shared memory limits work similarly: more shared memory per block means fewer blocks per SM."
     },
     {

--- a/src/modules/assess-tier1-part1.js
+++ b/src/modules/assess-tier1-part1.js
@@ -15,25 +15,15 @@ export const transformerAssessment = {
     {
       type: "mc",
       question: "In scaled dot-product attention, queries and keys are divided by $\\sqrt{d_k}$ before the softmax. What failure mode does this scaling prevent?",
-      options: [
-        "It prevents the attention weights from summing to more than 1",
-        "It prevents the dot products from growing large in magnitude, which would push softmax into saturated regions where gradients vanish",
-        "It normalizes the queries and keys to unit length, ensuring cosine similarity",
-        "It compensates for the fact that values have a different dimensionality than queries and keys"
-      ],
-      correct: 1,
+      options: ["It prevents the attention weights from summing to more than 1", "It normalizes the queries and keys to unit length, ensuring cosine similarity", "It prevents the dot products from growing large in magnitude, which would push softmax into saturated regions where gradients vanish", "It compensates for the fact that values have a different dimensionality than queries and keys"],
+      correct: 2,
       explanation: "When $d_k$ is large, dot products $q \\cdot k$ have variance proportional to $d_k$ (assuming unit-variance components). Without scaling, large dot products push softmax into regions where one logit dominates — the output approaches a one-hot vector, entropy collapses to near zero, and gradients through the softmax become vanishingly small. Dividing by $\\sqrt{d_k}$ keeps the variance of the logits at $O(1)$ regardless of dimension."
     },
     {
       type: "mc",
       question: "RoPE (Rotary Position Embeddings) encodes position by rotating query/key vectors in 2D subspaces of the embedding. Why does this enable better length generalization than learned absolute positional embeddings?",
-      options: [
-        "RoPE uses fewer parameters, so it is less prone to overfitting on short sequences",
-        "RoPE makes the dot product $q_m^\\top k_n$ depend only on the relative distance $(m - n)$ via a rotation in the complex plane, so the model never sees an absolute position index it hasn't trained on",
-        "RoPE projects positions into a Fourier basis, which is always periodic and can therefore handle any length",
-        "RoPE embeddings decay to zero at long distances, acting as an implicit windowed attention"
-      ],
-      correct: 1,
+      options: ["RoPE uses fewer parameters, so it is less prone to overfitting on short sequences", "RoPE embeddings decay to zero at long distances, acting as an implicit windowed attention", "RoPE projects positions into a Fourier basis, which is always periodic and can therefore handle any length", "RoPE makes the dot product $q_m^\\top k_n$ depend only on the relative distance $(m - n)$ via a rotation in the complex plane, so the model never sees an absolute position index it hasn't trained on"],
+      correct: 3,
       explanation: "RoPE applies a rotation $R_{\\theta, m}$ to position $m$, so $q_m^\\top k_n = (R_{\\theta,m} q)^\\top (R_{\\theta,n} k) = q^\\top R_{\\theta, n-m} k$. The attention logit depends only on the relative offset $(m - n)$, not the absolute positions. Learned absolute embeddings assign a fixed vector to each position index, so at inference time positions beyond the training length have never been seen. RoPE's relative formulation avoids this, though it still degrades at very long distances without further techniques (e.g., NTK-aware scaling, YaRN)."
     },
     {
@@ -63,25 +53,15 @@ export const transformerAssessment = {
     {
       type: "mc",
       question: "Pre-LN (LayerNorm before attention/FFN) is now standard over Post-LN (LayerNorm after). What training stability problem does Pre-LN solve?",
-      options: [
-        "Pre-LN prevents activation magnitudes from growing unboundedly across layers, allowing stable training without careful learning rate warmup — Post-LN amplifies gradients in early layers, causing divergence",
-        "Pre-LN is mathematically equivalent to Post-LN but uses less memory during backpropagation",
-        "Pre-LN eliminates the need for residual connections entirely",
-        "Pre-LN ensures that the output distribution matches the input distribution at initialization, solving internal covariate shift"
-      ],
-      correct: 0,
+      options: ["Pre-LN eliminates the need for residual connections entirely", "Pre-LN is mathematically equivalent to Post-LN but uses less memory during backpropagation", "Pre-LN prevents activation magnitudes from growing unboundedly across layers, allowing stable training without careful learning rate warmup — Post-LN amplifies gradients in early layers, causing divergence", "Pre-LN ensures that the output distribution matches the input distribution at initialization, solving internal covariate shift"],
+      correct: 2,
       explanation: "In Post-LN, the residual path feeds raw (unnormalized) outputs back into the stream, and normalization happens after the addition. This causes gradient magnitudes to vary dramatically across layers — early layers receive amplified gradients, leading to instability. Pre-LN normalizes inputs before each sub-layer, ensuring the residual path carries well-behaved signals. Xiong et al. (2020) showed Pre-LN removes the need for careful warmup schedules. The tradeoff: some work suggests Post-LN produces slightly better final performance when it can be stabilized (e.g., with careful init or additional techniques)."
     },
     {
       type: "mc",
       question: "Grouped Query Attention (GQA) with $G$ groups uses $G$ key-value heads shared across $H$ query heads (where $G < H$). If a model has $H = 32$ query heads and uses GQA with $G = 8$, what is the KV cache memory reduction compared to standard MHA, and how does this compare to MQA?",
-      options: [
-        "KV cache is reduced by $32\\times$ vs MHA; MQA would reduce it by $8\\times$",
-        "KV cache is reduced by $4\\times$ vs MHA ($8/32$); MQA ($G=1$) would reduce it by $32\\times$ but with greater quality degradation",
-        "KV cache is the same size as MHA; GQA only reduces compute, not memory",
-        "KV cache is reduced by $8\\times$ vs MHA; MQA and GQA have identical memory footprints"
-      ],
-      correct: 1,
+      options: ["KV cache is reduced by $32\\times$ vs MHA; MQA would reduce it by $8\\times$", "KV cache is reduced by $8\\times$ vs MHA; MQA and GQA have identical memory footprints", "KV cache is the same size as MHA; GQA only reduces compute, not memory", "KV cache is reduced by $4\\times$ vs MHA ($8/32$); MQA ($G=1$) would reduce it by $32\\times$ but with greater quality degradation"],
+      correct: 3,
       explanation: "In MHA, we store $H = 32$ distinct key-value pairs per layer per token. GQA with $G = 8$ stores only 8, so the KV cache shrinks by $32/8 = 4\\times$. MQA uses $G = 1$ (a single shared KV head), shrinking it by $32\\times$. GQA is a middle ground: it recovers most of MQA's memory savings while preserving quality closer to MHA. LLaMA 2 70B uses GQA with $G = 8$ for exactly this tradeoff. The quality gap between MQA and MHA is measurable on long-form generation tasks where KV diversity matters."
     },
     {
@@ -99,37 +79,22 @@ export const transformerAssessment = {
     {
       type: "mc",
       question: "Consider a transformer with $L = 32$ layers, $d_{\\text{model}} = 4096$, $H = 32$ heads, and SwiGLU FFN with hidden dim $\\frac{8}{3} \\times 4096 \\approx 10923$. Approximately how many parameters are in the model (ignoring embeddings and final layer norm)?",
-      options: [
-        "About 1.5B — each layer has roughly 50M parameters",
-        "About 7B — each layer has roughly 220M parameters from attention ($4d^2$) plus FFN ($3 \\times d \\times d_{\\text{ff}}$)",
-        "About 13B — the FFN dominates with $8d^2$ per layer",
-        "About 30B — attention and FFN contribute equally at $8d^2$ each"
-      ],
-      correct: 1,
+      options: ["About 7B — each layer has roughly 220M parameters from attention ($4d^2$) plus FFN ($3 \\times d \\times d_{\\text{ff}}$)", "About 1.5B — each layer has roughly 50M parameters", "About 13B — the FFN dominates with $8d^2$ per layer", "About 30B — attention and FFN contribute equally at $8d^2$ each"],
+      correct: 0,
       explanation: "Per layer: Attention has $W_Q, W_K, W_V, W_O$ each of size $d^2$, totaling $4d^2 \\approx 4 \\times 16.8M \\approx 67M$. SwiGLU FFN has three matrices: $W_1, V$ of size $d \\times d_{\\text{ff}}$ and $W_2$ of size $d_{\\text{ff}} \\times d$, totaling $3 \\times d \\times d_{\\text{ff}} \\approx 3 \\times 4096 \\times 10923 \\approx 134M$. Plus two LayerNorms at $2 \\times 2d \\approx 16K$. Per layer $\\approx 201M$. Multiply by 32 layers $\\approx 6.4B$. Adding embeddings ($V \\times d$) brings it near 7B. This matches LLaMA 7B's architecture."
     },
     {
       type: "mc",
       question: "An \"induction head\" is a two-head circuit that implements a specific attention pattern. What computation does it perform, and why is it considered a key mechanism for in-context learning?",
-      options: [
-        "It attends to the most frequent token in the context and copies it to the output, implementing a unigram frequency estimator",
-        "It uses one head to identify previous occurrences of the current token and a second head to copy what followed those occurrences — implementing the rule 'if A B ... A, predict B'",
-        "It computes the average of all key vectors to produce a summary representation of the context",
-        "It detects syntactic patterns like subject-verb agreement by attending to structurally related positions"
-      ],
-      correct: 1,
+      options: ["It attends to the most frequent token in the context and copies it to the output, implementing a unigram frequency estimator", "It computes the average of all key vectors to produce a summary representation of the context", "It uses one head to identify previous occurrences of the current token and a second head to copy what followed those occurrences — implementing the rule 'if A B ... A, predict B'", "It detects syntactic patterns like subject-verb agreement by attending to structurally related positions"],
+      correct: 2,
       explanation: "Induction heads (Olsson et al., 2022) are a two-step circuit: (1) a \"previous-token head\" shifts information backward so each token's residual stream contains info about the preceding token; (2) an \"induction head\" uses this to find previous instances of the current token and attend to what came after them. This implements \"A B ... A $\\to$ B\" — a bigram copy operation that generalizes to longer patterns. Olsson et al. found that induction heads form during a phase transition early in training that coincides with a sharp drop in loss, and they account for the majority of in-context learning ability."
     },
     {
       type: "mc",
       question: "Why is the attention mechanism $O(n^2 d)$ in sequence length $n$, and which component specifically creates the quadratic bottleneck?",
-      options: [
-        "The $QK^\\top$ matrix multiplication produces an $n \\times n$ attention matrix, and both computing and storing this matrix scale quadratically in sequence length",
-        "The value projection $W_V$ has $n^2$ parameters that must be learned",
-        "The softmax normalization requires summing over $n^2$ elements",
-        "The residual connections require adding $n^2$ vectors together"
-      ],
-      correct: 0,
+      options: ["The residual connections require adding $n^2$ vectors together", "The value projection $W_V$ has $n^2$ parameters that must be learned", "The softmax normalization requires summing over $n^2$ elements", "The $QK^\\top$ matrix multiplication produces an $n \\times n$ attention matrix, and both computing and storing this matrix scale quadratically in sequence length"],
+      correct: 3,
       explanation: "The attention score matrix $A = \\text{softmax}(QK^\\top / \\sqrt{d_k})$ has shape $n \\times n$. Computing the $n \\times n$ dot products costs $O(n^2 d_k)$, storing the matrix costs $O(n^2)$ memory, and the matrix-vector product $AV$ costs $O(n^2 d_v)$. For long contexts (e.g., $n = 128K$), this $n^2$ term dominates everything. This is why methods like FlashAttention (which avoids materializing the full attention matrix via tiling), linear attention, and sparse attention exist — they aim to reduce either the compute or memory from $O(n^2)$."
     }
   ]
@@ -150,49 +115,29 @@ export const tokenizationAssessment = {
     {
       type: "mc",
       question: "Byte Pair Encoding (BPE) builds its vocabulary by iteratively merging the most frequent adjacent pair of tokens. If the training corpus contains the words \"low\" (5x), \"lower\" (2x), \"newest\" (6x), \"widest\" (3x), and the initial vocabulary is characters, which pair is merged first?",
-      options: [
-        "('e', 's') — appears 9 times across 'newest' and 'widest'",
-        "('l', 'o') — appears 7 times across 'low' and 'lower'",
-        "('n', 'e') — appears 6 times in 'newest'",
-        "('w', 'i') — appears 3 times in 'widest'"
-      ],
-      correct: 0,
+      options: ["('l', 'o') — appears 7 times across 'low' and 'lower'", "('e', 's') — appears 9 times across 'newest' and 'widest'", "('n', 'e') — appears 6 times in 'newest'", "('w', 'i') — appears 3 times in 'widest'"],
+      correct: 1,
       explanation: "BPE counts pair frequencies across the entire corpus weighted by word frequency. ('e', 's') appears in 'newest' (6 times) and 'widest' (3 times) = 9 total occurrences. ('l', 'o') appears in 'low' (5) + 'lower' (2) = 7. ('n', 'e') appears 6 times. So ('e', 's') $\\to$ 'es' is the first merge. This greedy approach builds common subwords bottom-up. Note that BPE is deterministic given the corpus — the merge order defines the tokenizer completely."
     },
     {
       type: "mc",
       question: "A GPT-style tokenizer with vocabulary size 50,257 tokenizes the arithmetic expression \"123456 + 789\" into tokens [\"123\", \"456\", \" +\", \" 789\"]. Why does this tokenization make arithmetic difficult for the model?",
-      options: [
-        "The model cannot represent numbers larger than the vocabulary size",
-        "The digit groupings are misaligned with place value — \"123456\" splits into \"123\" and \"456\", so the model must learn that the first token's digits occupy the hundred-thousands, ten-thousands, and thousands places, while the second token's digits are hundreds, tens, and ones — a positional encoding the tokenizer doesn't preserve",
-        "The \"+\" operator is merged with a space, confusing the model about its semantic role",
-        "The model has no embedding for the number 123456 since it exceeds the vocabulary"
-      ],
-      correct: 1,
+      options: ["The digit groupings are misaligned with place value — \"123456\" splits into \"123\" and \"456\", so the model must learn that the first token's digits occupy the hundred-thousands, ten-thousands, and thousands places, while the second token's digits are hundreds, tens, and ones — a positional encoding the tokenizer doesn't preserve", "The model cannot represent numbers larger than the vocabulary size", "The \"+\" operator is merged with a space, confusing the model about its semantic role", "The model has no embedding for the number 123456 since it exceeds the vocabulary"],
+      correct: 0,
       explanation: "Tokenization destroys digit-level positional structure. When \"123456\" becomes [\"123\", \"456\"], the model must implicitly learn that \"123\" means $123 \\times 1000$ (not just 123) based on the following token. Worse, the same token \"123\" might mean 123, 123000, or 123000000 depending on context. Each digit's place value is a function of total number length and token boundaries — information the model must infer rather than directly access. This is why digit-level tokenization (one token per digit) dramatically improves arithmetic performance."
     },
     {
       type: "mc",
       question: "The **fertility ratio** of a tokenizer for a language is the average number of tokens produced per word. A tokenizer trained predominantly on English text has a fertility ratio of 1.2 for English but 3.8 for Tamil. What concrete consequence does this have?",
-      options: [
-        "Tamil text will have higher perplexity because the model has seen less Tamil data",
-        "Tamil text consumes roughly $3.2\\times$ more context window and costs $3.2\\times$ more per word in API pricing, and the model sees $3.2\\times$ fewer Tamil words in the same context length — systematically disadvantaging Tamil users",
-        "The model will produce more fluent Tamil because it has more tokens to work with per word",
-        "Tamil sentences will be more compressible because they use more tokens"
-      ],
-      correct: 1,
+      options: ["Tamil text will have higher perplexity because the model has seen less Tamil data", "The model will produce more fluent Tamil because it has more tokens to work with per word", "Tamil text consumes roughly $3.2\\times$ more context window and costs $3.2\\times$ more per word in API pricing, and the model sees $3.2\\times$ fewer Tamil words in the same context length — systematically disadvantaging Tamil users", "Tamil sentences will be more compressible because they use more tokens"],
+      correct: 2,
       explanation: "High fertility ratio means each Tamil word is fragmented into many tokens. With a 4096-token context window, English gets ~3400 words of context while Tamil gets only ~1080 words — a $3.2\\times$ reduction. API costs (priced per token) are proportionally higher per word. During training, each Tamil word also requires more forward-pass steps, reducing effective data efficiency. This is a systematic fairness issue: the tokenizer itself creates unequal capability across languages. Solutions include multilingual-aware BPE training, byte-level models, or language-specific tokenizers."
     },
     {
       type: "mc",
       question: "**MegaByte** (Yu et al., 2023) proposes a byte-level architecture that avoids subword tokenization entirely. What is the primary architectural innovation that makes byte-level modeling tractable despite sequences being ~4x longer than subword sequences?",
-      options: [
-        "It uses a convolutional backbone instead of attention, avoiding the quadratic cost entirely",
-        "It uses a hierarchical architecture with a large \"global\" model operating on patches of bytes and a smaller \"local\" model predicting individual bytes within each patch, amortizing the cost of the large model",
-        "It applies aggressive byte-level pruning to remove redundant bytes before processing",
-        "It uses a fixed-size sliding window attention, limiting the effective context to 512 bytes"
-      ],
-      correct: 1,
+      options: ["It uses a convolutional backbone instead of attention, avoiding the quadratic cost entirely", "It uses a fixed-size sliding window attention, limiting the effective context to 512 bytes", "It applies aggressive byte-level pruning to remove redundant bytes before processing", "It uses a hierarchical architecture with a large \"global\" model operating on patches of bytes and a smaller \"local\" model predicting individual bytes within each patch, amortizing the cost of the large model"],
+      correct: 3,
       explanation: "MegaByte splits byte sequences into fixed-size patches (e.g., 8 bytes). A large transformer processes patch-level representations (sequence length divided by patch size, so $n/8$), and a smaller transformer predicts individual bytes within each patch conditioned on the global representation. The large model's $O((n/p)^2)$ cost is dramatically reduced, and the small model only operates on short sequences of length $p$. This \"patch-level then byte-level\" hierarchy avoids the $O(n^2)$ cost on raw byte sequences while eliminating the need for a fixed tokenizer vocabulary."
     },
     {
@@ -210,37 +155,22 @@ export const tokenizationAssessment = {
     {
       type: "mc",
       question: "Increasing BPE vocabulary size from 32K to 128K tokens has which set of tradeoffs?",
-      options: [
-        "Strictly better: shorter sequences, faster training, no downsides",
-        "Shorter sequences and better compression, but larger embedding matrices ($V \\times d$ parameters), sparser token frequency distributions (many rare tokens with poor embeddings), and higher memory for the softmax output layer",
-        "No effect on sequence length; it only changes the model's ability to represent rare words",
-        "Longer sequences because more tokens are available, leading to finer-grained representations"
-      ],
-      correct: 1,
+      options: ["Shorter sequences and better compression, but larger embedding matrices ($V \\times d$ parameters), sparser token frequency distributions (many rare tokens with poor embeddings), and higher memory for the softmax output layer", "Strictly better: shorter sequences, faster training, no downsides", "No effect on sequence length; it only changes the model's ability to represent rare words", "Longer sequences because more tokens are available, leading to finer-grained representations"],
+      correct: 0,
       explanation: "Larger vocab $\\Rightarrow$ more common strings get dedicated tokens $\\Rightarrow$ shorter sequences (better compression, faster inference). But: the embedding table grows from $32K \\times d$ to $128K \\times d$ (at $d = 4096$, that's 400M extra parameters). Many tokens in a 128K vocab are rare, so their embeddings are poorly trained. The final softmax over 128K classes is also more expensive. LLaMA uses 32K, GPT-4 uses ~100K, and Gemini uses 256K — the optimal size depends on the multilingual coverage needed and the model size (larger models can afford larger vocabs because the embedding table is a smaller fraction of total parameters)."
     },
     {
       type: "mc",
       question: "**WordPiece** (used in BERT) and **Unigram LM** (used in SentencePiece/T5) differ fundamentally in how they construct vocabularies. Which statement correctly describes the difference?",
-      options: [
-        "WordPiece builds bottom-up by merging pairs that maximize likelihood of the training corpus; Unigram LM starts with a large candidate vocabulary and prunes tokens whose removal least reduces the corpus likelihood — a top-down approach",
-        "WordPiece operates on characters while Unigram LM operates on bytes",
-        "WordPiece is deterministic while Unigram LM randomly samples tokenizations during training",
-        "WordPiece produces fixed-length tokens while Unigram LM produces variable-length tokens"
-      ],
-      correct: 0,
+      options: ["WordPiece is deterministic while Unigram LM randomly samples tokenizations during training", "WordPiece operates on characters while Unigram LM operates on bytes", "WordPiece builds bottom-up by merging pairs that maximize likelihood of the training corpus; Unigram LM starts with a large candidate vocabulary and prunes tokens whose removal least reduces the corpus likelihood — a top-down approach", "WordPiece produces fixed-length tokens while Unigram LM produces variable-length tokens"],
+      correct: 2,
       explanation: "WordPiece is bottom-up (like BPE) but selects merges that maximize corpus log-likelihood rather than raw frequency. Unigram LM is top-down: it starts with a large set of candidate subwords, assigns probabilities via an EM-like algorithm, and iteratively removes tokens that contribute least to corpus likelihood. A key advantage of Unigram LM is that it naturally supports multiple tokenizations of the same string with associated probabilities — enabling subword regularization (sampling different tokenizations during training as data augmentation). BPE/WordPiece produce a single deterministic segmentation."
     },
     {
       type: "mc",
       question: "A language model is asked \"How many r's are in 'strawberry'?\" and answers \"2\" (incorrect — the answer is 3). The tokenizer segments 'strawberry' as [\"str\", \"aw\", \"berry\"]. Why does the tokenization contribute to this failure?",
-      options: [
-        "The tokenizer removes duplicate characters during encoding",
-        "The model never sees individual characters — it sees subword tokens, so it cannot directly count character occurrences within tokens. The 'r' in \"str\", the lack of 'r' in \"aw\", and the 'r' in \"berry\" are not represented at the character level in the model's input",
-        "The tokenizer assigns the same embedding to 'r' regardless of context",
-        "The model's vocabulary does not contain the character 'r' as a standalone token"
-      ],
-      correct: 1,
+      options: ["The tokenizer removes duplicate characters during encoding", "The model's vocabulary does not contain the character 'r' as a standalone token", "The tokenizer assigns the same embedding to 'r' regardless of context", "The model never sees individual characters — it sees subword tokens, so it cannot directly count character occurrences within tokens. The 'r' in \"str\", the lack of 'r' in \"aw\", and the 'r' in \"berry\" are not represented at the character level in the model's input"],
+      correct: 3,
       explanation: "Subword tokenization is a lossy abstraction for character-level tasks. The model receives embeddings for [\"str\", \"aw\", \"berry\"] — there's no explicit representation of individual characters. To count 'r's, the model must have learned (from training data) the character composition of each token in its vocabulary — essentially memorizing a lookup table. It must recall that \"str\" contains one 'r', \"aw\" contains zero, and \"berry\" contains two 'r's, then sum to 3. This implicit character knowledge is unreliable, which is why character-level tasks (counting, spelling, anagrams) remain challenging for subword-tokenized models."
     },
     {
@@ -258,13 +188,8 @@ export const tokenizationAssessment = {
     {
       type: "mc",
       question: "A researcher notices that their 7B parameter model has a vocabulary of 256K tokens with $d_{\\text{model}} = 4096$. The embedding and language model head together account for what fraction of total model parameters, and is this a concern?",
-      options: [
-        "About 0.3% — negligible at any model scale",
-        "About 30% ($2 \\times 256K \\times 4096 \\approx 2.1B$ out of ~7B) — a serious concern because these parameters are sparsely trained (each token's embedding updates only when that token appears) and the capacity is wasted on rare tokens",
-        "Exactly 50% — embeddings always account for half of transformer parameters",
-        "About 5% — noticeable but not worth addressing"
-      ],
-      correct: 1,
+      options: ["About 30% ($2 \\times 256K \\times 4096 \\approx 2.1B$ out of ~7B) — a serious concern because these parameters are sparsely trained (each token's embedding updates only when that token appears) and the capacity is wasted on rare tokens", "About 0.3% — negligible at any model scale", "Exactly 50% — embeddings always account for half of transformer parameters", "About 5% — noticeable but not worth addressing"],
+      correct: 0,
       explanation: "With untied embeddings: input embedding = $256K \\times 4096 \\approx 1.05B$ params. Output (LM head) = another $1.05B$. Total $\\approx 2.1B$ out of 7B = 30%. This is disproportionately large. Most of these parameters correspond to rare tokens that appear infrequently in training data, so their embeddings are poorly learned. Solutions include: tying input/output embeddings (halving the cost), using a smaller vocab, or factorizing the embedding matrix. LLaMA uses 32K vocab with untied embeddings — the embedding table is only $\\sim 260M$ params, a much healthier ratio at $\\sim 3.7\\%$."
     }
   ]
@@ -285,25 +210,15 @@ export const pretrainingAssessment = {
     {
       type: "mc",
       question: "The autoregressive language modeling objective maximizes $\\sum_{t=1}^{T} \\log P(x_t \\mid x_{<t}; \\theta)$. **Teacher forcing** means that during training:",
-      options: [
-        "The model's own predictions from the previous step are fed as input to the next step, allowing it to learn from its mistakes",
-        "The ground-truth token $x_{t-1}$ is always provided as input when predicting $x_t$, regardless of what the model would have predicted — creating a train/inference mismatch called exposure bias",
-        "A separate \"teacher\" model provides soft labels for knowledge distillation",
-        "The learning rate is forced to follow a predetermined schedule rather than adapting"
-      ],
-      correct: 1,
+      options: ["The model's own predictions from the previous step are fed as input to the next step, allowing it to learn from its mistakes", "A separate \"teacher\" model provides soft labels for knowledge distillation", "The ground-truth token $x_{t-1}$ is always provided as input when predicting $x_t$, regardless of what the model would have predicted — creating a train/inference mismatch called exposure bias", "The learning rate is forced to follow a predetermined schedule rather than adapting"],
+      correct: 2,
       explanation: "During training, the model always sees the true previous tokens $x_{<t}$ (teacher forcing), but at inference it must consume its own potentially incorrect predictions. This creates **exposure bias**: the model never learns to recover from its own errors during training. In practice, LLMs are robust to this because (1) at scale, the model's predictions are usually correct, and (2) techniques like nucleus sampling avoid low-probability regions. Teacher forcing enables efficient parallelized training via causal masking — all positions can be computed in a single forward pass."
     },
     {
       type: "mc",
       question: "Chinchilla scaling laws (Hoffmann et al., 2022) suggest that for compute-optimal training, data tokens $D$ and parameters $N$ should scale roughly as $D \\approx 20N$. A 7B parameter model trained on 300B tokens — is this compute-optimal?",
-      options: [
-        "Yes — $300B / 7B \\approx 43$, which exceeds the 20:1 ratio, meaning the model is slightly over-trained on data but still compute-efficient",
-        "No — Chinchilla says $D \\approx 20N = 140B$ tokens is optimal, so 300B tokens means this model is significantly over-trained relative to compute-optimal allocation; those FLOPs would be better spent on a larger model with fewer tokens",
-        "No — the model needs far more data; the Chinchilla ratio suggests $D \\approx 20N = 140T$ tokens",
-        "Yes — Chinchilla scaling only applies to models above 50B parameters"
-      ],
-      correct: 1,
+      options: ["Yes — $300B / 7B \\approx 43$, which exceeds the 20:1 ratio, meaning the model is slightly over-trained on data but still compute-efficient", "Yes — Chinchilla scaling only applies to models above 50B parameters", "No — the model needs far more data; the Chinchilla ratio suggests $D \\approx 20N = 140T$ tokens", "No — Chinchilla says $D \\approx 20N = 140B$ tokens is optimal, so 300B tokens means this model is significantly over-trained relative to compute-optimal allocation; those FLOPs would be better spent on a larger model with fewer tokens"],
+      correct: 3,
       explanation: "Chinchilla-optimal for 7B params: $D \\approx 20 \\times 7B = 140B$ tokens. Training on 300B tokens means the compute budget spent on extra tokens ($300B - 140B = 160B$ extra tokens $\\times$ 6 $\\times$ 7B FLOPs/token) could instead have been used to train a ~13B model on 140B tokens for better performance. However, LLaMA (Touvron et al., 2023) deliberately over-trained on data because inference cost depends only on model size — a smaller, over-trained model is cheaper to deploy. This led to the \"LLaMA regime\" insight: Chinchilla-optimal isn't deployment-optimal."
     },
     {
@@ -321,37 +236,22 @@ export const pretrainingAssessment = {
     {
       type: "mc",
       question: "Learning rate warmup (linearly increasing LR from ~0 to peak over the first ~1-2% of training) is standard practice. What happens if you skip warmup and start at the peak learning rate?",
-      options: [
-        "Training is slightly slower but converges to the same final loss",
-        "Early gradient updates are too large because the model's loss landscape is poorly conditioned at random initialization — Adam's variance estimates are also unreliable with few samples, producing oversized steps that can cause irreversible divergence",
-        "The model immediately converges to a local minimum near initialization",
-        "Warmup is only necessary for SGD; Adam-based optimizers don't need it"
-      ],
-      correct: 1,
+      options: ["Early gradient updates are too large because the model's loss landscape is poorly conditioned at random initialization — Adam's variance estimates are also unreliable with few samples, producing oversized steps that can cause irreversible divergence", "Training is slightly slower but converges to the same final loss", "The model immediately converges to a local minimum near initialization", "Warmup is only necessary for SGD; Adam-based optimizers don't need it"],
+      correct: 0,
       explanation: "Two factors make high initial LR dangerous: (1) At initialization, the loss landscape is highly curved and poorly conditioned — large steps overshoot. (2) Adam divides by $\\sqrt{\\hat{v}_t}$, the running estimate of squared gradients. With few steps, $\\hat{v}_t$ is a poor estimate, and the bias correction factor $1/(1-\\beta_2^t)$ amplifies early updates. Together, these cause enormous effective step sizes. Warmup gives Adam time to calibrate its moment estimates and lets the model find a smoother region of the loss landscape before taking full-sized steps."
     },
     {
       type: "mc",
       question: "The **cosine learning rate schedule** decays the LR as $\\eta_t = \\eta_{\\min} + \\frac{1}{2}(\\eta_{\\max} - \\eta_{\\min})(1 + \\cos(\\pi t / T))$. Compared to linear decay, why has cosine become standard for LLM pretraining?",
-      options: [
-        "Cosine decay is mathematically optimal for convex optimization",
-        "Cosine maintains a higher LR for longer during mid-training (slower initial decay), allowing continued exploration, then aggressively anneals at the end for fine convergence — the slow-fast decay profile empirically gives better final loss than linear",
-        "Cosine decay uses less compute because it requires fewer gradient computations",
-        "Cosine decay is equivalent to linear decay but is easier to implement in distributed settings"
-      ],
-      correct: 1,
+      options: ["Cosine decay is mathematically optimal for convex optimization", "Cosine decay uses less compute because it requires fewer gradient computations", "Cosine maintains a higher LR for longer during mid-training (slower initial decay), allowing continued exploration, then aggressively anneals at the end for fine convergence — the slow-fast decay profile empirically gives better final loss than linear", "Cosine decay is equivalent to linear decay but is easier to implement in distributed settings"],
+      correct: 2,
       explanation: "Cosine decay's concave shape means the LR stays near $\\eta_{\\max}$ for roughly the first third of training, then drops steeply. This gives the model more time at high LR to escape poor basins and explore the loss landscape before committing to a solution. Linear decay reduces LR at a constant rate, which may reduce it too quickly in mid-training. Empirically, Loshchilov & Hutter (2016) showed cosine outperforms linear decay, and variants like cosine with warm restarts (SGDR) further improve performance by periodically resetting the LR."
     },
     {
       type: "mc",
       question: "The **linear scaling rule** states that when increasing batch size by a factor of $k$, the learning rate should also be scaled by $k$. What is the theoretical justification?",
-      options: [
-        "Larger batches have larger gradients, so a larger LR is needed to normalize them",
-        "A $k\\times$ larger batch produces a gradient estimate with $k\\times$ less variance, which is equivalent to taking $k$ steps with the original batch — matching this requires $k\\times$ the LR per step to cover the same distance in weight space",
-        "Larger batches require more epochs to converge, and higher LR compensates by covering more ground per step",
-        "The linear scaling rule is a heuristic with no theoretical basis — it just works empirically"
-      ],
-      correct: 1,
+      options: ["Larger batches have larger gradients, so a larger LR is needed to normalize them", "The linear scaling rule is a heuristic with no theoretical basis — it just works empirically", "Larger batches require more epochs to converge, and higher LR compensates by covering more ground per step", "A $k\\times$ larger batch produces a gradient estimate with $k\\times$ less variance, which is equivalent to taking $k$ steps with the original batch — matching this requires $k\\times$ the LR per step to cover the same distance in weight space"],
+      correct: 3,
       explanation: "With batch size $B$, one step moves weights by $\\eta \\cdot \\frac{1}{B}\\sum_{i=1}^{B} \\nabla_i$. With batch size $kB$, one step moves by $\\eta' \\cdot \\frac{1}{kB}\\sum_{i=1}^{kB} \\nabla_i$. If we want one large-batch step to equal $k$ small-batch steps (in expectation), we need $\\eta' = k\\eta$. This holds in the linear regime where the loss is approximately quadratic. Goyal et al. (2017) validated this up to batch sizes of 8K for ResNets. For very large batches, the linear regime breaks down and $\\sqrt{k}$ scaling or LARS/LAMB optimizers are needed."
     },
     {
@@ -369,37 +269,22 @@ export const pretrainingAssessment = {
     {
       type: "mc",
       question: "GPT-style models initialize the weights of residual-path projections (the output projections of attention and FFN) with a scaling factor of $\\frac{1}{\\sqrt{2L}}$ where $L$ is the number of layers. Why?",
-      options: [
-        "It makes the model output zero at initialization, which stabilizes the first gradient step",
-        "Each of the $2L$ residual contributions (one from attention, one from FFN per layer) adds variance to the residual stream — scaling by $\\frac{1}{\\sqrt{2L}}$ keeps the total variance at initialization approximately constant regardless of depth, preventing signal explosion in deep networks",
-        "It ensures all layers contribute equally to the final output at convergence",
-        "It compensates for the variance reduction caused by LayerNorm at each layer"
-      ],
-      correct: 1,
+      options: ["Each of the $2L$ residual contributions (one from attention, one from FFN per layer) adds variance to the residual stream — scaling by $\\frac{1}{\\sqrt{2L}}$ keeps the total variance at initialization approximately constant regardless of depth, preventing signal explosion in deep networks", "It makes the model output zero at initialization, which stabilizes the first gradient step", "It ensures all layers contribute equally to the final output at convergence", "It compensates for the variance reduction caused by LayerNorm at each layer"],
+      correct: 0,
       explanation: "The residual stream accumulates outputs from $2L$ sub-layers (attention + FFN per layer). If each sub-layer adds independent noise with variance $\\sigma^2$, the total variance after $2L$ additions is $2L\\sigma^2$, which grows with depth. Initializing output projections with std $\\propto 1/\\sqrt{2L}$ makes each contribution's variance $\\sigma^2/(2L)$, so the total remains $\\sigma^2$ regardless of $L$. This is critical for training stability: without it, activations in a 96-layer model would have $\\sim 14\\times$ the standard deviation of a 1-layer model at initialization. GPT-2 introduced this; it's sometimes called the \"residual scaling\" trick."
     },
     {
       type: "mc",
       question: "**Emergence** in LLMs refers to capabilities that appear abruptly as model scale increases — near-random performance below a threshold, then sharp improvement above it. Which recent finding has complicated the narrative around emergence?",
-      options: [
-        "Emerged capabilities are always predictable from smaller models using power laws",
-        "Schaeffer et al. (2023) showed that many \"emergent\" abilities are artifacts of using discontinuous evaluation metrics (like exact-match accuracy) — when measured with continuous metrics (like token-level log-likelihood), performance improves smoothly and predictably with scale, not abruptly",
-        "Emergence only occurs in models with more than 100B parameters",
-        "Emergence is caused by phase transitions in the weight matrices analogous to physical phase transitions"
-      ],
-      correct: 1,
+      options: ["Emerged capabilities are always predictable from smaller models using power laws", "Emergence only occurs in models with more than 100B parameters", "Schaeffer et al. (2023) showed that many \"emergent\" abilities are artifacts of using discontinuous evaluation metrics (like exact-match accuracy) — when measured with continuous metrics (like token-level log-likelihood), performance improves smoothly and predictably with scale, not abruptly", "Emergence is caused by phase transitions in the weight matrices analogous to physical phase transitions"],
+      correct: 2,
       explanation: "Schaeffer et al. (2023) demonstrated that apparent emergence is often a measurement artifact. Exact-match accuracy is a step function of model capability — a model that gets 90% of characters right in an answer still scores 0 on exact-match. As scale increases, per-token accuracy improves smoothly, and at some point crosses the threshold where entire answers are correct, causing exact-match to jump suddenly. Using continuous metrics like Brier score or per-token cross-entropy, the improvement is gradual and predictable from scaling laws. This doesn't mean all emergent behaviors are artifacts, but many reported cases are."
     },
     {
       type: "mc",
       question: "A pretraining run uses AdamW with $\\beta_1 = 0.9$, $\\beta_2 = 0.95$, weight decay $\\lambda = 0.1$, batch size 4M tokens, cosine LR schedule with peak $3 \\times 10^{-4}$, and gradient clipping at 1.0. The training loss suddenly becomes NaN at step 50,000. Which diagnostic would you check FIRST?",
-      options: [
-        "Whether the vocabulary size is correct",
-        "The gradient norm history just before the NaN — a sudden spike above the clipping threshold, combined with checking for Inf/NaN in the most recent batch's activations and whether $\\beta_2 = 0.95$ (lower than typical 0.999) causes Adam's second moment to adapt too slowly to sudden gradient changes",
-        "Whether the cosine schedule has decayed the LR too aggressively by step 50K",
-        "Whether the tokenizer produced unknown tokens in the problematic batch"
-      ],
-      correct: 1,
+      options: ["Whether the vocabulary size is correct", "Whether the tokenizer produced unknown tokens in the problematic batch", "Whether the cosine schedule has decayed the LR too aggressively by step 50K", "The gradient norm history just before the NaN — a sudden spike above the clipping threshold, combined with checking for Inf/NaN in the most recent batch's activations and whether $\\beta_2 = 0.95$ (lower than typical 0.999) causes Adam's second moment to adapt too slowly to sudden gradient changes"],
+      correct: 3,
       explanation: "NaN loss almost always traces back to numerical overflow in activations or gradients. The diagnostic chain: (1) Check gradient norm logs — was there a spike at step 49,999-50,000 that exceeded clip threshold? (2) Check for Inf/NaN in specific layers' activations (often the embedding or final logits). (3) Note that $\\beta_2 = 0.95$ (as used in LLaMA) makes Adam's second moment estimate more responsive but also more volatile — a sudden large gradient can cause the denominator $\\sqrt{v_t}$ to be small if previous gradients were small, leading to an enormous update. The fix: roll back to a checkpoint before the spike, optionally skip the offending batch, or add loss scaling."
     }
   ]

--- a/src/modules/assess-tier1-part2.js
+++ b/src/modules/assess-tier1-part2.js
@@ -29,37 +29,22 @@ export const dataAssessment = {
     {
       type: "mc",
       question: "**MinHash** is used for near-duplicate detection in large corpora. It works by:",
-      options: [
-        "Computing exact MD5 hashes of each document and comparing them",
-        "Applying multiple hash functions to token n-gram shingle sets and estimating Jaccard similarity from the fraction of matching minimum hash values",
-        "Training a neural network to embed documents and clustering them",
-        "Sorting all documents alphabetically and comparing adjacent pairs"
-      ],
-      correct: 1,
+      options: ["Applying multiple hash functions to token n-gram shingle sets and estimating Jaccard similarity from the fraction of matching minimum hash values", "Computing exact MD5 hashes of each document and comparing them", "Training a neural network to embed documents and clustering them", "Sorting all documents alphabetically and comparing adjacent pairs"],
+      correct: 0,
       explanation: "MinHash approximates the Jaccard similarity $J(A, B) = |A \\cap B| / |A \\cup B|$ between shingle sets. For each of $k$ hash functions, the minimum hash value is recorded. The fraction of matching minimums across two documents estimates their Jaccard similarity. This is efficient because it reduces each document to a fixed-size signature, enabling Locality-Sensitive Hashing (LSH) for scalable pairwise comparison without computing all $O(n^2)$ pairs."
     },
     {
       type: "mc",
       question: "What is the key difference between **exact deduplication** and **near-deduplication** in data pipelines?",
-      options: [
-        "Exact dedup is more computationally expensive",
-        "Exact dedup removes byte-identical or hash-identical documents (or n-gram spans), while near-dedup removes documents above a similarity threshold, catching paraphrases, boilerplate variations, and templated content",
-        "Near-dedup only works on code, not natural language",
-        "They produce identical results but near-dedup is faster"
-      ],
-      correct: 1,
+      options: ["Exact dedup is more computationally expensive", "Near-dedup only works on code, not natural language", "Exact dedup removes byte-identical or hash-identical documents (or n-gram spans), while near-dedup removes documents above a similarity threshold, catching paraphrases, boilerplate variations, and templated content", "They produce identical results but near-dedup is faster"],
+      correct: 2,
       explanation: "Exact dedup uses cryptographic hashes (SHA-256, MD5) on full documents or suffix arrays on n-gram spans to find verbatim matches. Near-dedup (MinHash + LSH, SimHash) catches documents that are substantially similar but not identical — e.g., the same news article republished with minor edits, or pages with shared templates. Both are necessary: exact dedup is cheap and catches copies; near-dedup catches the long tail of near-copies that dominate web crawls."
     },
     {
       type: "mc",
       question: "**Perplexity filtering** uses a language model (often a small KenLM n-gram model trained on curated text like Wikipedia) to score documents. Documents are kept if:",
-      options: [
-        "Their perplexity is as high as possible, indicating novel content",
-        "Their perplexity falls within a middle range — not too low (repetitive/templated) and not too high (gibberish/non-fluent)",
-        "Their perplexity exactly matches Wikipedia's average perplexity",
-        "Their perplexity is below a fixed threshold of 100"
-      ],
-      correct: 1,
+      options: ["Their perplexity is as high as possible, indicating novel content", "Their perplexity is below a fixed threshold of 100", "Their perplexity exactly matches Wikipedia's average perplexity", "Their perplexity falls within a middle range — not too low (repetitive/templated) and not too high (gibberish/non-fluent)"],
+      correct: 3,
       explanation: "The key insight from CCNet and related work is that both extremes are bad. Very low perplexity indicates repetitive boilerplate (cookie notices, navigation menus) that the LM finds trivially predictable. Very high perplexity indicates garbled text, foreign-language fragments, or encoding artifacts. The \"Goldilocks zone\" in the middle captures fluent, diverse, informative text. The exact thresholds are tuned empirically per domain."
     },
     {
@@ -77,37 +62,22 @@ export const dataAssessment = {
     {
       type: "mc",
       question: "**Model collapse** from training on self-generated data occurs because:",
-      options: [
-        "The model runs out of GPU memory",
-        "Each generation step loses information from the tails of the distribution — the model's approximation errors compound across generations, causing the distribution to narrow and eventually degenerate, losing minority patterns and rare knowledge",
-        "Synthetic data has more tokens than real data",
-        "The tokenizer cannot encode synthetic text"
-      ],
-      correct: 1,
+      options: ["Each generation step loses information from the tails of the distribution — the model's approximation errors compound across generations, causing the distribution to narrow and eventually degenerate, losing minority patterns and rare knowledge", "The model runs out of GPU memory", "Synthetic data has more tokens than real data", "The tokenizer cannot encode synthetic text"],
+      correct: 0,
       explanation: "Shumailov et al. (2023) showed that iteratively training on model-generated data causes progressive loss of distributional tails. The model slightly underweights low-probability events; when these outputs become training data, those events become even rarer in the next generation. Over multiple iterations, this positive feedback loop collapses the distribution to a narrow mode. Mathematically, each generation is like repeatedly applying an imperfect density estimator, and the composition amplifies errors — analogous to photocopying a photocopy."
     },
     {
       type: "mc",
       question: "A common **data mixing** strategy for pre-training assigns sampling weights to different domains (web, books, code, Wikipedia, etc.). The **DoReMi** approach determines these weights by:",
-      options: [
-        "Setting weights proportional to each domain's raw byte count",
-        "Using a small proxy model to learn domain weights that minimize worst-case excess loss across domains, then applying those weights to train the large model",
-        "Always upsampling code to 50% of the mixture",
-        "Randomly shuffling all domains together with equal probability"
-      ],
-      correct: 1,
+      options: ["Setting weights proportional to each domain's raw byte count", "Always upsampling code to 50% of the mixture", "Using a small proxy model to learn domain weights that minimize worst-case excess loss across domains, then applying those weights to train the large model", "Randomly shuffling all domains together with equal probability"],
+      correct: 2,
       explanation: "DoReMi (Xie et al., 2023) trains a small proxy model with distributionally robust optimization (DRO) to find domain weights that minimize the worst-case excess loss over a reference model. These optimized weights are then transferred to train the full-scale model. This avoids expensive hyperparameter sweeps at scale and consistently outperforms heuristic mixtures. The key insight is that optimal mixing ratios are not proportional to data size — rare but high-quality domains (code, math) often deserve upsampling."
     },
     {
       type: "mc",
       question: "**Benchmark contamination** occurs when test data appears in the training corpus. Which detection method is most robust?",
-      options: [
-        "Checking if the model's accuracy exceeds 90% on the benchmark",
-        "Searching for exact n-gram overlaps (e.g., 8-gram or longer) between training data and benchmark instances, combined with analyzing performance gaps between contaminated and clean subsets of the benchmark",
-        "Asking the model if it has seen the benchmark before",
-        "Running the benchmark with a different random seed"
-      ],
-      correct: 1,
+      options: ["Checking if the model's accuracy exceeds 90% on the benchmark", "Running the benchmark with a different random seed", "Asking the model if it has seen the benchmark before", "Searching for exact n-gram overlaps (e.g., 8-gram or longer) between training data and benchmark instances, combined with analyzing performance gaps between contaminated and clean subsets of the benchmark"],
+      correct: 3,
       explanation: "The standard approach (used in GPT-4, Llama, etc.) is n-gram overlap detection: if a training document shares a long n-gram (typically 8-13 grams) with a benchmark instance, that instance is flagged as contaminated. The complementary analysis compares performance on contaminated vs. clean subsets — a large gap indicates the model is benefiting from memorization rather than genuine capability. Neither method alone is sufficient: n-gram search has false negatives (paraphrased contamination), so the performance gap analysis provides a second signal."
     },
     {
@@ -125,13 +95,8 @@ export const dataAssessment = {
     {
       type: "mc",
       question: "A team deduplicates a 15TB web crawl and finds that 40% of documents are near-duplicates. After dedup, they train two models: one on the full 15TB (with duplicates) and one on the deduplicated 9TB. Based on empirical findings (e.g., from the Llama and Chinchilla papers), what is the most likely outcome?",
-      options: [
-        "The 15TB model is strictly better because it saw more tokens",
-        "Both models perform identically because the information content is the same",
-        "The deduplicated 9TB model matches or outperforms the 15TB model on held-out evaluation, trains faster per epoch, and memorizes less — showing that unique tokens matter more than raw token count",
-        "The deduplicated model catastrophically forgets the duplicate content"
-      ],
-      correct: 2,
+      options: ["The deduplicated 9TB model matches or outperforms the 15TB model on held-out evaluation, trains faster per epoch, and memorizes less — showing that unique tokens matter more than raw token count", "Both models perform identically because the information content is the same", "The 15TB model is strictly better because it saw more tokens", "The deduplicated model catastrophically forgets the duplicate content"],
+      correct: 0,
       explanation: "Empirically (Lee et al., 2022; Llama papers), deduplication consistently improves or maintains downstream quality while reducing training cost. Duplicate data wastes compute on memorizing repeated patterns rather than learning new ones, inflates training loss estimates (the model appears to perform better because it has memorized training examples), and increases the risk of verbatim regurgitation. The deduplicated model achieves better generalization per FLOP because each gradient step carries more novel information. This is why modern pipelines invest heavily in dedup despite its computational cost."
     }
   ]
@@ -153,25 +118,15 @@ export const evaluationAssessment = {
     {
       type: "mc",
       question: "Perplexity is the standard offline evaluation metric for language models. Its primary **limitation** as a measure of model quality is:",
-      options: [
-        "It is too expensive to compute",
-        "It measures next-token prediction accuracy on a fixed corpus but does not capture instruction-following ability, reasoning quality, factual accuracy, or user preference — a model can have excellent perplexity yet produce unhelpful or harmful outputs",
-        "It only works for models with fewer than 1 billion parameters",
-        "It requires labeled data with human annotations"
-      ],
-      correct: 1,
+      options: ["It is too expensive to compute", "It only works for models with fewer than 1 billion parameters", "It measures next-token prediction accuracy on a fixed corpus but does not capture instruction-following ability, reasoning quality, factual accuracy, or user preference — a model can have excellent perplexity yet produce unhelpful or harmful outputs", "It requires labeled data with human annotations"],
+      correct: 2,
       explanation: "Perplexity measures $2^{H(P, Q)}$ — how well the model predicts the next token in a held-out corpus. A model can achieve low perplexity by being excellent at surface-level statistical patterns while failing at reasoning, following instructions, or producing factually correct content. This is why the field moved beyond perplexity to task-specific benchmarks and human evaluation. Perplexity remains useful for comparing base models on the same data distribution, but tells you little about downstream utility."
     },
     {
       type: "mc",
       question: "In **N-shot prompting** for evaluation, you prepend $N$ input-output examples to the test query. Increasing $N$ from 0 to 5 typically helps because:",
-      options: [
-        "It fine-tunes the model on those examples",
-        "The examples specify the task format and output space, reducing ambiguity about what is expected — the model leverages in-context learning to condition its distribution on the demonstrated pattern without any weight updates",
-        "It increases the model's parameter count",
-        "It reduces the model's perplexity on the training set"
-      ],
-      correct: 1,
+      options: ["It fine-tunes the model on those examples", "It reduces the model's perplexity on the training set", "It increases the model's parameter count", "The examples specify the task format and output space, reducing ambiguity about what is expected — the model leverages in-context learning to condition its distribution on the demonstrated pattern without any weight updates"],
+      correct: 3,
       explanation: "Few-shot prompting exploits in-context learning (ICL): the model conditions on the demonstrations to infer the task distribution. Crucially, no gradient update occurs — the model uses its pre-trained ability to recognize patterns in context. The demonstrations serve as a soft specification of the task: they disambiguate output format, label space, and style. However, results are sensitive to example selection, ordering, and format, which is why evaluation protocols must standardize these choices."
     },
     {
@@ -189,37 +144,22 @@ export const evaluationAssessment = {
     {
       type: "mc",
       question: "**HumanEval** and **GSM8K** measure fundamentally different capabilities. HumanEval tests code generation (writing Python functions from docstrings), while GSM8K tests grade-school math word problems. A model scoring 90% on HumanEval but 40% on GSM8K most likely:",
-      options: [
-        "Has a bug in its math tokenizer",
-        "Was trained with heavy code emphasis but lacks robust multi-step arithmetic and reasoning chains — code generation relies more on pattern completion from the docstring, while GSM8K requires chaining 2-8 arithmetic operations with intermediate reasoning",
-        "Is overfitting to GSM8K's test set",
-        "Needs a larger context window for math problems"
-      ],
-      correct: 1,
+      options: ["Was trained with heavy code emphasis but lacks robust multi-step arithmetic and reasoning chains — code generation relies more on pattern completion from the docstring, while GSM8K requires chaining 2-8 arithmetic operations with intermediate reasoning", "Has a bug in its math tokenizer", "Is overfitting to GSM8K's test set", "Needs a larger context window for math problems"],
+      correct: 0,
       explanation: "This capability gap is common and informative. HumanEval functions can often be solved by recognizing the pattern from the docstring and generating idiomatic Python — a strong pattern-matching ability. GSM8K requires constructing multi-step reasoning chains: parsing the word problem, identifying relevant quantities, chaining 2-8 arithmetic operations correctly, and arriving at a numerical answer. Errors compound at each step. This dissociation reveals that code completion and mathematical reasoning are partially independent capabilities."
     },
     {
       type: "mc",
       question: "**Goodhart's Law** — \"when a measure becomes a target, it ceases to be a good measure\" — manifests in LLM benchmarks when:",
-      options: [
-        "Benchmarks become too easy for all models",
-        "Models or training pipelines are optimized specifically to maximize benchmark scores (e.g., training on benchmark-similar data, prompt engineering for the exact format), inflating scores without proportional improvement in genuine capability",
-        "Too many benchmarks exist for any single model to complete",
-        "The benchmark questions are poorly written"
-      ],
-      correct: 1,
+      options: ["Benchmarks become too easy for all models", "Too many benchmarks exist for any single model to complete", "Models or training pipelines are optimized specifically to maximize benchmark scores (e.g., training on benchmark-similar data, prompt engineering for the exact format), inflating scores without proportional improvement in genuine capability", "The benchmark questions are poorly written"],
+      correct: 2,
       explanation: "Goodhart's Law is pervasive in LLM evaluation. Examples include: training data contamination (benchmark questions leak into pre-training corpora), benchmark-specific prompt optimization, generating synthetic training data that mimics benchmark formats, and cherry-picking evaluation configurations. The result is that leaderboard rankings may reflect optimization pressure on the benchmark rather than genuine capability differences. This motivates held-out evaluation (Chatbot Arena), dynamic benchmarks that refresh questions, and multi-benchmark evaluation suites."
     },
     {
       type: "mc",
       question: "**Chatbot Arena** uses ELO ratings derived from pairwise human preferences. Its key methodological advantage over static benchmarks is:",
-      options: [
-        "It is cheaper to run",
-        "It continuously collects fresh human judgments on diverse, user-generated prompts — making it resistant to contamination, Goodhart's Law, and benchmark saturation, while directly measuring what users actually care about",
-        "It uses automated scoring instead of human evaluation",
-        "It only tests English language ability"
-      ],
-      correct: 1,
+      options: ["It is cheaper to run", "It only tests English language ability", "It uses automated scoring instead of human evaluation", "It continuously collects fresh human judgments on diverse, user-generated prompts — making it resistant to contamination, Goodhart's Law, and benchmark saturation, while directly measuring what users actually care about"],
+      correct: 3,
       explanation: "Chatbot Arena addresses core limitations of static benchmarks: (1) prompts come from real users, not a fixed test set, so they cannot be trained on; (2) evaluation is continuous, so the benchmark evolves with model capabilities; (3) pairwise comparison (\"which response is better?\") is a more natural and reliable judgment than absolute scoring; (4) ELO ratings handle transitive preferences and provide a single ranking. The main limitations are cost, speed (thousands of comparisons needed per model), potential demographic bias in the user population, and sensitivity to response length/formatting."
     },
     {
@@ -237,37 +177,22 @@ export const evaluationAssessment = {
     {
       type: "mc",
       question: "The **elicitation gap** refers to the difference between:",
-      options: [
-        "The model's training loss and test loss",
-        "A model's latent capability and the performance actually measured — the same model can appear much stronger or weaker depending on the prompting strategy, number of shots, chain-of-thought usage, and other evaluation choices that affect how well the model's knowledge is elicited",
-        "The gap between open-source and closed-source model performance",
-        "The time between model training and model deployment"
-      ],
-      correct: 1,
+      options: ["A model's latent capability and the performance actually measured — the same model can appear much stronger or weaker depending on the prompting strategy, number of shots, chain-of-thought usage, and other evaluation choices that affect how well the model's knowledge is elicited", "The model's training loss and test loss", "The gap between open-source and closed-source model performance", "The time between model training and model deployment"],
+      correct: 0,
       explanation: "The elicitation gap is critical for interpreting benchmarks. The same model might score 40% on a math benchmark with zero-shot prompting but 75% with chain-of-thought and 5-shot prompting. The model's knowledge did not change — only how well the evaluation protocol extracted it. This means benchmark comparisons are only valid when using identical elicitation methods, and low scores may reflect poor elicitation rather than missing capability. It also implies that current benchmarks likely underestimate model capabilities, especially for models that are sensitive to prompt formatting."
     },
     {
       type: "mc",
       question: "A **contamination-robust** evaluation strategy should include:",
-      options: [
-        "Running benchmarks only once per model",
-        "Multiple layers of defense: n-gram overlap detection between training data and test sets, canary string insertion in benchmarks, performance comparison between contaminated and clean subsets, rephrased/perturbed versions of benchmark questions to test whether performance drops (indicating memorization vs. understanding), and temporal holdouts using data created after the training cutoff",
-        "Using only perplexity as the evaluation metric",
-        "Keeping all benchmark questions secret forever"
-      ],
-      correct: 1,
+      options: ["Running benchmarks only once per model", "Using only perplexity as the evaluation metric", "Multiple layers of defense: n-gram overlap detection between training data and test sets, canary string insertion in benchmarks, performance comparison between contaminated and clean subsets, rephrased/perturbed versions of benchmark questions to test whether performance drops (indicating memorization vs. understanding), and temporal holdouts using data created after the training cutoff", "Keeping all benchmark questions secret forever"],
+      correct: 2,
       explanation: "No single method catches all contamination. N-gram detection misses paraphrased contamination. Canary strings (unique identifiers embedded in test sets) detect if the test set was ingested but do not catch reformulated questions. Rephrased variants distinguish memorization from understanding: if performance drops sharply on semantically equivalent but syntactically different questions, the model likely memorized rather than learned. Temporal holdouts (benchmarks created after training cutoff) are the gold standard but require continuous benchmark creation. A robust evaluation combines all these approaches."
     },
     {
       type: "mc",
       question: "You evaluate two models on a new reasoning benchmark. Model A scores 82% with standard prompting. Model B scores 71% with standard prompting but 88% with chain-of-thought. A reviewer claims Model A is superior. The most accurate response is:",
-      options: [
-        "The reviewer is correct — 82% > 71%",
-        "Model B is better because 88% > 82%",
-        "The comparison is invalid without controlling for elicitation: Model B demonstrates higher latent capability when properly elicited (88% vs. 82%), but the models should be compared using the best-known elicitation strategy for each, with clear reporting of which strategies were used — raw scores under different elicitation regimes are not directly comparable",
-        "Neither model can be evaluated because the benchmark is new"
-      ],
-      correct: 2,
+      options: ["The reviewer is correct — 82% > 71%", "Model B is better because 88% > 82%", "Neither model can be evaluated because the benchmark is new", "The comparison is invalid without controlling for elicitation: Model B demonstrates higher latent capability when properly elicited (88% vs. 82%), but the models should be compared using the best-known elicitation strategy for each, with clear reporting of which strategies were used — raw scores under different elicitation regimes are not directly comparable"],
+      correct: 3,
       explanation: "This question tests understanding of the elicitation gap and evaluation methodology. Fair comparison requires either: (1) fixing the elicitation method and comparing (in which case report both standard and CoT for each model), or (2) reporting peak performance under best elicitation for each model. Model B's 88% under CoT suggests stronger underlying reasoning capability than Model A's 82%. However, the full picture requires testing Model A with CoT as well. The fundamental point is that benchmark scores are a function of both model capability AND evaluation protocol — reporting scores without specifying the protocol is incomplete."
     }
   ]
@@ -301,37 +226,22 @@ export const distributedTrainingAssessment = {
     {
       type: "mc",
       question: "**Tensor parallelism** and **pipeline parallelism** split the model across GPUs in fundamentally different ways. Tensor parallelism:",
-      options: [
-        "Assigns different training examples to different GPUs",
-        "Splits individual layers (e.g., partitioning weight matrices column-wise or row-wise) across GPUs so each GPU computes a portion of every layer's output, requiring intra-layer communication at each forward and backward step",
-        "Assigns entire layers to different GPUs in sequence",
-        "Replicates the model on every GPU"
-      ],
-      correct: 1,
+      options: ["Splits individual layers (e.g., partitioning weight matrices column-wise or row-wise) across GPUs so each GPU computes a portion of every layer's output, requiring intra-layer communication at each forward and backward step", "Assigns different training examples to different GPUs", "Assigns entire layers to different GPUs in sequence", "Replicates the model on every GPU"],
+      correct: 0,
       explanation: "Tensor parallelism (Megatron-LM style) partitions weight matrices within a layer. For example, a linear layer $Y = XW$ can be split column-wise: $W = [W_1 | W_2]$, with each GPU computing $XW_i$. This requires an all-reduce after each layer to combine partial results. Pipeline parallelism, by contrast, assigns whole layers to different GPUs — GPU 0 runs layers 1-10, GPU 1 runs layers 11-20, etc. Tensor parallelism has higher communication frequency (every layer) but lower latency per communication; pipeline parallelism has lower communication frequency but suffers from the bubble problem."
     },
     {
       type: "mc",
       question: "**ZeRO Stage 1** shards the **optimizer states** across GPUs while each GPU still holds a full copy of parameters and gradients. For a model with $\\Psi$ parameters using Adam in mixed precision, Stage 1 reduces per-GPU optimizer memory from $12\\Psi$ bytes to approximately:",
-      options: [
-        "$12\\Psi$ bytes — no savings",
-        "$12\\Psi / N$ bytes, where $N$ is the number of GPUs — each GPU stores only $1/N$ of Adam's first moment ($m$), second moment ($v$), and FP32 master weights",
-        "$4\\Psi$ bytes — only the FP16 parameters",
-        "$2\\Psi$ bytes — only the FP16 gradients"
-      ],
-      correct: 1,
+      options: ["$12\\Psi$ bytes — no savings", "$4\\Psi$ bytes — only the FP16 parameters", "$12\\Psi / N$ bytes, where $N$ is the number of GPUs — each GPU stores only $1/N$ of Adam's first moment ($m$), second moment ($v$), and FP32 master weights", "$2\\Psi$ bytes — only the FP16 gradients"],
+      correct: 2,
       explanation: "Adam requires per-parameter state: FP32 master weights (4 bytes), FP32 first moment $m$ (4 bytes), and FP32 second moment $v$ (4 bytes) = 12 bytes per parameter. ZeRO Stage 1 partitions these 12$\\Psi$ bytes across $N$ GPUs, so each GPU stores $12\\Psi/N$ bytes of optimizer state. The FP16 parameters ($2\\Psi$) and FP16 gradients ($2\\Psi$) remain fully replicated. For a 7B model on 8 GPUs: optimizer memory drops from 84 GB to ~10.5 GB per GPU, while parameter and gradient memory remain at 14 GB + 14 GB."
     },
     {
       type: "mc",
       question: "**ZeRO Stage 3** (or equivalently, **FSDP** — Fully Sharded Data Parallel) shards parameters, gradients, AND optimizer states. The key runtime overhead compared to DDP is:",
-      options: [
-        "No additional overhead — it is strictly better",
-        "All-gather operations to reconstruct full parameter tensors before each forward/backward computation, and reduce-scatter operations to distribute gradients — trading communication volume for memory savings",
-        "It requires twice as many GPUs",
-        "It cannot overlap communication with computation"
-      ],
-      correct: 1,
+      options: ["No additional overhead — it is strictly better", "It cannot overlap communication with computation", "It requires twice as many GPUs", "All-gather operations to reconstruct full parameter tensors before each forward/backward computation, and reduce-scatter operations to distribute gradients — trading communication volume for memory savings"],
+      correct: 3,
       explanation: "In ZeRO-3/FSDP, each GPU stores only a $1/N$ shard of every parameter tensor. Before computing a layer's forward pass, an all-gather reconstructs the full parameters from all shards. After the backward pass, a reduce-scatter distributes gradient shards. The total communication volume per step is $3 \\times 2\\Psi$ (vs. $2\\Psi$ for DDP), a 3x increase. However, this communication can be overlapped with computation by prefetching the next layer's parameters during the current layer's computation. The memory savings are dramatic: total per-GPU memory approaches $(12\\Psi + 2\\Psi + 2\\Psi) / N = 16\\Psi/N$."
     },
     {
@@ -349,61 +259,36 @@ export const distributedTrainingAssessment = {
     {
       type: "mc",
       question: "The **1F1B** (one-forward-one-backward) pipeline schedule works by:",
-      options: [
-        "Running all forward passes first, then all backward passes",
-        "After an initial warmup phase, alternating between one forward micro-batch and one backward micro-batch on each pipeline stage — this limits the number of in-flight micro-batches per stage to at most $p$ (the pipeline depth), bounding peak activation memory",
-        "Running forward and backward passes simultaneously on the same micro-batch",
-        "Eliminating the pipeline bubble entirely"
-      ],
-      correct: 1,
+      options: ["After an initial warmup phase, alternating between one forward micro-batch and one backward micro-batch on each pipeline stage — this limits the number of in-flight micro-batches per stage to at most $p$ (the pipeline depth), bounding peak activation memory", "Running all forward passes first, then all backward passes", "Running forward and backward passes simultaneously on the same micro-batch", "Eliminating the pipeline bubble entirely"],
+      correct: 0,
       explanation: "In 1F1B, each stage goes through a warmup phase (receiving and forwarding micro-batches), then enters a steady state where it performs one forward pass followed by one backward pass in alternation. This means each stage holds activations for at most $p$ micro-batches at any time (rather than all $m$ micro-batches in the naive all-forward-then-all-backward schedule). The bubble fraction remains $(p-1)/m$, but peak memory is dramatically reduced. Interleaved scheduling (where virtual pipeline stages are assigned cyclically) can further reduce the bubble to $(p-1)/(m \\cdot v)$ where $v$ is the number of virtual stages."
     },
     {
       type: "mc",
       question: "**BF16** (bfloat16) is preferred over **FP16** for LLM training because:",
-      options: [
-        "BF16 has higher precision for small numbers",
-        "BF16 uses the same 8-bit exponent as FP32 (range $\\pm 3.4 \\times 10^{38}$), avoiding the overflow/underflow issues that plague FP16 (5-bit exponent, range $\\pm 65504$) — this eliminates the need for loss scaling even though BF16 has less mantissa precision (7 bits vs FP16's 10 bits)",
-        "BF16 uses less memory than FP16",
-        "BF16 is the only format supported by modern GPUs"
-      ],
-      correct: 1,
+      options: ["BF16 has higher precision for small numbers", "BF16 uses less memory than FP16", "BF16 uses the same 8-bit exponent as FP32 (range $\\pm 3.4 \\times 10^{38}$), avoiding the overflow/underflow issues that plague FP16 (5-bit exponent, range $\\pm 65504$) — this eliminates the need for loss scaling even though BF16 has less mantissa precision (7 bits vs FP16's 10 bits)", "BF16 is the only format supported by modern GPUs"],
+      correct: 2,
       explanation: "FP16 has 5 exponent bits (range $\\sim 6 \\times 10^{-8}$ to $6.5 \\times 10^4$) and 10 mantissa bits. BF16 has 8 exponent bits (same range as FP32: $\\sim 10^{-38}$ to $\\sim 10^{38}$) and 7 mantissa bits. In LLM training, gradients and activations span a wide dynamic range — FP16's limited range causes underflow (small gradients become zero) or overflow (large activations become inf), requiring careful loss scaling. BF16's FP32-matching range avoids these issues entirely at the cost of slightly reduced precision. Both use 16 bits (2 bytes per value). The practical result: BF16 training is nearly as stable as FP32 with half the memory."
     },
     {
       type: "mc",
       question: "**Activation checkpointing** (gradient checkpointing) trades compute for memory by:",
-      options: [
-        "Compressing activations using quantization",
-        "Discarding intermediate activations during the forward pass and recomputing them from saved checkpoints during the backward pass — this reduces activation memory from $O(L)$ to $O(\\sqrt{L})$ (with optimal checkpoint placement) at the cost of one additional forward pass, roughly 33% more compute",
-        "Storing activations on CPU instead of GPU",
-        "Reducing the number of layers in the model"
-      ],
-      correct: 1,
+      options: ["Compressing activations using quantization", "Reducing the number of layers in the model", "Storing activations on CPU instead of GPU", "Discarding intermediate activations during the forward pass and recomputing them from saved checkpoints during the backward pass — this reduces activation memory from $O(L)$ to $O(\\sqrt{L})$ (with optimal checkpoint placement) at the cost of one additional forward pass, roughly 33% more compute"],
+      correct: 3,
       explanation: "During the forward pass, only activations at checkpoint boundaries are saved; intermediate activations are discarded. During the backward pass, when intermediate activations are needed for gradient computation, the forward pass is re-run from the nearest checkpoint. With checkpoints every $\\sqrt{L}$ layers (for $L$ total layers), memory is $O(\\sqrt{L})$ and compute increases by ~33% (one extra forward pass). This is often the single most impactful memory optimization: for a 70B model, it can reduce activation memory from hundreds of GB to a manageable level. The tradeoff is almost always worthwhile — memory is the binding constraint, not compute."
     },
     {
       type: "mc",
       question: "A **70B parameter model** trained with Adam in mixed precision requires approximately how much **optimizer state memory** (across all GPUs combined)?",
-      options: [
-        "140 GB (2 bytes per parameter for FP16 weights)",
-        "280 GB (4 bytes per parameter for FP32 master copy only)",
-        "840 GB (12 bytes per parameter: FP32 master weights + FP32 first moment + FP32 second moment)",
-        "70 GB (1 byte per parameter)"
-      ],
-      correct: 2,
+      options: ["140 GB (2 bytes per parameter for FP16 weights)", "840 GB (12 bytes per parameter: FP32 master weights + FP32 first moment + FP32 second moment)", "280 GB (4 bytes per parameter for FP32 master copy only)", "70 GB (1 byte per parameter)"],
+      correct: 1,
       explanation: "Adam maintains three FP32 buffers per parameter: (1) master copy of weights — 4 bytes, (2) first moment estimate $m$ — 4 bytes, (3) second moment estimate $v$ — 4 bytes. Total: $12 \\times 70 \\times 10^9 = 840 \\times 10^9$ bytes $= 840$ GB. This is the dominant memory cost and the primary motivation for ZeRO/FSDP. On 8 GPUs with ZeRO Stage 1, this drops to ~105 GB/GPU. Adding the FP16 model parameters (140 GB) and FP16 gradients (140 GB), total memory is ~1120 GB, or ~140 GB/GPU with 8-way ZeRO-1 for optimizer states alone (parameters and gradients still replicated at Stage 1)."
     },
     {
       type: "mc",
       question: "**Sequence parallelism** addresses a specific limitation of tensor parallelism. In standard Megatron-style tensor parallelism, operations like LayerNorm and dropout are **replicated** on every GPU. Sequence parallelism fixes this by:",
-      options: [
-        "Splitting the vocabulary across GPUs",
-        "Partitioning the sequence dimension across GPUs for these replicated operations (LayerNorm, dropout, activation functions), so each GPU processes a portion of the sequence — then transitioning back to tensor-parallel partitioning for the attention and MLP computations",
-        "Using a longer context window",
-        "Replacing LayerNorm with a parallelizable alternative"
-      ],
-      correct: 1,
+      options: ["Partitioning the sequence dimension across GPUs for these replicated operations (LayerNorm, dropout, activation functions), so each GPU processes a portion of the sequence — then transitioning back to tensor-parallel partitioning for the attention and MLP computations", "Splitting the vocabulary across GPUs", "Using a longer context window", "Replacing LayerNorm with a parallelizable alternative"],
+      correct: 0,
       explanation: "In tensor parallelism, matrix multiplications (attention projections, MLP layers) are split across GPUs, but LayerNorm, dropout, and activation functions operate on the full hidden dimension and are redundantly computed on every GPU. Sequence parallelism (Korthikanti et al., 2022) partitions these operations along the sequence dimension instead: each GPU handles $\\text{seq\\_len}/N$ tokens for LayerNorm/dropout, then the layout transitions to tensor-parallel for the split matrix multiplications. This eliminates the redundant computation and memory for these operations, saving ~30-40% of activation memory that would otherwise be wasted on replicated non-tensor-parallel regions."
     }
   ]

--- a/src/modules/entropy-cross-entropy-mi.js
+++ b/src/modules/entropy-cross-entropy-mi.js
@@ -20,14 +20,23 @@ export const entropyEasy = {
     {
       type: "mc",
       question: "Distribution A: $P = (0.25, 0.25, 0.25, 0.25)$. Distribution B: $P = (0.97, 0.01, 0.01, 0.01)$. Which has higher entropy?",
-      options: [
-        "Distribution B — it has one dominant outcome, so more information content",
-        "Distribution A — it is uniform, so maximum uncertainty",
-        "They have equal entropy because both are over 4 outcomes",
-        "Cannot determine without knowing what the outcomes represent"
-      ],
-      correct: 1,
+      options: ["Distribution B — it has one dominant outcome, so more information content", "They have equal entropy because both are over 4 outcomes", "Distribution A — it is uniform, so maximum uncertainty", "Cannot determine without knowing what the outcomes represent"],
+      correct: 2,
       explanation: "Distribution A is uniform over 4 outcomes, giving $H(A) = \\log_2 4 = 2$ bits — the maximum possible for 4 outcomes. Distribution B concentrates almost all mass on one outcome: $H(B) \\approx 0.97 \\cdot 0.044 + 3 \\cdot 0.01 \\cdot 6.64 \\approx 0.24$ bits. High concentration means low uncertainty, hence low entropy."
+    },
+    {
+      type: "mc",
+      question: "A coin flip has $P(\\text{heads}) = p$. At what value of $p$ is the entropy $H(X)$ maximized?",
+      options: ["$p = 0$ — certainty about the outcome maximizes information", "$p = 0.5$ — maximum uncertainty when both outcomes are equally likely", "$p = 1/e \\approx 0.37$ — this minimizes $-p \\log p$", "$p = 1$ — a guaranteed outcome carries the most information"],
+      correct: 1,
+      explanation: "For a Bernoulli variable, $H(X) = -p\\log p - (1-p)\\log(1-p)$. This is a concave function maximized at $p = 0.5$, where $H = 1$ bit. At $p = 0$ or $p = 1$, entropy is 0 — there is no uncertainty. The value $1/e$ minimizes (not maximizes) the function $-p\\log p$ for a single term, but entropy involves two terms that together peak at $p = 0.5$."
+    },
+    {
+      type: "mc",
+      question: "You have two language models. Model X assigns probability 0.8 to the correct next token on average. Model Y assigns probability 0.2. Roughly how do their per-token cross-entropies compare?",
+      options: ["Model X's cross-entropy is 4x lower (0.2 vs 0.8)", "Model X's cross-entropy is about $-\\ln(0.8) \\approx 0.22$ nats vs Model Y's $-\\ln(0.2) \\approx 1.61$ nats — a ~7x difference", "They have similar cross-entropy since both are far from perfect", "Model Y's cross-entropy is lower because it spreads probability more evenly"],
+      correct: 1,
+      explanation: "Cross-entropy involves $-\\log Q(w_{\\text{correct}})$. For Model X: $-\\ln(0.8) \\approx 0.22$ nats. For Model Y: $-\\ln(0.2) \\approx 1.61$ nats. The ratio is about 7x, not 4x, because cross-entropy is logarithmic in probability — small changes in probability near 1.0 matter less than small changes near 0. This is why the last few percentage points of accuracy are disproportionately hard to achieve in terms of loss reduction."
     },
     {
       type: "info",
@@ -47,6 +56,13 @@ export const entropyEasy = {
       explanation: "By definition: $H(P, Q) = H(P) + \\text{KL}(P \\| Q)$, so $H(P, Q) - H(P) = \\text{KL}(P \\| Q)$. This is the *forward* KL — the penalty your model pays for deviating from the true distribution. It is always $\\geq 0$, with equality iff $Q = P$. This is why cross-entropy loss is a sound training objective: minimizing it drives $Q$ toward $P$."
     },
     {
+      type: "mc",
+      question: "Is cross-entropy symmetric? That is, does $H(P, Q) = H(Q, P)$ in general?",
+      options: ["Yes — cross-entropy is a distance metric so it must be symmetric", "No — $H(P, Q) = H(P) + \\text{KL}(P \\| Q)$ while $H(Q, P) = H(Q) + \\text{KL}(Q \\| P)$, and these differ when $P \\neq Q$", "Yes — since $\\sum_x P(x) \\log Q(x) = \\sum_x Q(x) \\log P(x)$ by the symmetry of multiplication", "It depends on whether $P$ and $Q$ have the same support"],
+      correct: 1,
+      explanation: "Cross-entropy is NOT symmetric. $H(P, Q) = H(P) + \\text{KL}(P \\| Q)$ and $H(Q, P) = H(Q) + \\text{KL}(Q \\| P)$. Both KL divergence and entropy differ between $P$ and $Q$ in general, so the two cross-entropies differ. This is why it matters which distribution is 'true' and which is the 'model' in the training loss — we minimize $H(P_{\\text{data}}, Q_\\theta)$, not $H(Q_\\theta, P_{\\text{data}})$."
+    },
+    {
       type: "info",
       title: "Conditional Entropy: The Irreducible Floor",
       content: "**Conditional entropy** $H(X \\mid Y)$ measures how uncertain $X$ remains after observing $Y$:\n\n$$H(X \\mid Y) = -\\sum_{x, y} P(x, y) \\log P(x \\mid y) = \\mathbb{E}_{(X,Y)}[-\\log P(X \\mid Y)]$$\n\nFor language models, the crucial quantity is $H(W_t \\mid W_{<t})$ — the entropy of the next token given all preceding context. This is the **intrinsic unpredictability of language** at position $t$.\n\nA perfect model $Q^* = P$ achieves training loss:\n\n$$H(P_{\\text{data}}, Q^*) = H(P_{\\text{data}}) = \\mathbb{E}[-\\log P(W_t \\mid W_{<t})]$$\n\nNo model can do better than this, no matter how large or well-trained. This quantity is the **Bayes-optimal loss** — the irreducible noise floor. It is nonzero because language is genuinely stochastic: given a context, multiple valid continuations exist.\n\nThe chain rule of entropy decomposes sequence entropy: $H(W_1, \\ldots, W_T) = \\sum_{t=1}^T H(W_t \\mid W_{<t})$. Each token's conditional entropy contributes to the total."
@@ -54,13 +70,8 @@ export const entropyEasy = {
     {
       type: "mc",
       question: "A language model's per-token training loss can never go below which quantity?",
-      options: [
-        "Zero — a sufficiently large model could memorize every sequence",
-        "$H(W_t \\mid W_{<t})$, the conditional entropy of the next token given context",
-        "$H(W_t)$, the marginal entropy of the token distribution",
-        "$\\log K$ where $K$ is the vocabulary size"
-      ],
-      correct: 1,
+      options: ["Zero — a sufficiently large model could memorize every sequence", "$\\log K$ where $K$ is the vocabulary size", "$H(W_t)$, the marginal entropy of the token distribution", "$H(W_t \\mid W_{<t})$, the conditional entropy of the next token given context"],
+      correct: 3,
       explanation: "The minimum achievable cross-entropy is $H(P_{\\text{data}}, Q^*) = H(P_{\\text{data}})$, which equals $\\mathbb{E}[H(W_t \\mid W_{<t})]$ averaged over positions. This is the conditional entropy of language itself — the irreducible uncertainty given perfect context modeling. Even memorizing the training set doesn't help: the Bayes-optimal predictor must spread probability across all valid continuations, not just the one that appeared in the corpus."
     },
     {
@@ -71,14 +82,16 @@ export const entropyEasy = {
     {
       type: "mc",
       question: "Model A has perplexity 30 and Model B has perplexity 90. How much better is A than B in cross-entropy (bits)?",
-      options: [
-        "60 bits — the difference in perplexity",
-        "$\\log_2(90) - \\log_2(30) = \\log_2(3) \\approx 1.58$ bits",
-        "$\\log_2(90/30) = \\log_2(3) \\approx 1.58$ bits per token, but the models might have different vocabularies",
-        "Cannot compare without knowing the vocabulary size"
-      ],
-      correct: 1,
+      options: ["$\\log_2(90) - \\log_2(30) = \\log_2(3) \\approx 1.58$ bits", "60 bits — the difference in perplexity", "$\\log_2(90/30) = \\log_2(3) \\approx 1.58$ bits per token, but the models might have different vocabularies", "Cannot compare without knowing the vocabulary size"],
+      correct: 0,
       explanation: "Cross-entropy $= \\log_2(\\text{PPL})$, so the difference is $\\log_2(90) - \\log_2(30) = \\log_2(90/30) = \\log_2(3) \\approx 1.58$ bits per token. This means Model B wastes 1.58 extra bits per token compared to A. Note that perplexity ratios correspond to cross-entropy *differences* (because $\\log$ turns ratios into differences) — a 3x perplexity improvement always equals $\\log_2 3 \\approx 1.58$ bits, regardless of the absolute values."
+    },
+    {
+      type: "mc",
+      question: "A language model achieves a cross-entropy loss of 3.0 nats per token on a held-out set. What is the model's perplexity?",
+      options: ["$3.0$", "$2^3 = 8$", "$e^3 \\approx 20.1$", "$\\ln(3) \\approx 1.1$"],
+      correct: 2,
+      explanation: "When cross-entropy is measured in nats (using $\\ln$), perplexity is $e^{\\text{loss}}$, so $e^{3.0} \\approx 20.1$. If the loss were in bits (using $\\log_2$), perplexity would be $2^{\\text{loss}}$. The choice of log base determines the exponentiation base. In most deep learning frameworks, the loss is in nats (natural log), so $e$ is the correct base."
     },
     {
       type: "info",
@@ -88,13 +101,8 @@ export const entropyEasy = {
     {
       type: "mc",
       question: "A uniform model over a 50,000-token vocabulary assigns $P(w) = 1/50000$ for every token regardless of context. What is its perplexity?",
-      options: [
-        "$\\log_2(50000) \\approx 15.6$",
-        "$50000$",
-        "$\\sqrt{50000} \\approx 224$",
-        "$50000^2 = 2.5 \\times 10^9$"
-      ],
-      correct: 1,
+      options: ["$\\log_2(50000) \\approx 15.6$", "$\\sqrt{50000} \\approx 224$", "$50000$", "$50000^2 = 2.5 \\times 10^9$"],
+      correct: 2,
       explanation: "Cross-entropy of a uniform model is $-\\sum_w P(w) \\log(1/50000) = \\log(50000)$. So $\\text{PPL} = e^{\\log 50000} = 50000$. The uniform model's perplexity equals the vocabulary size — it is equivalent to rolling a 50,000-sided die. This is the worst possible perplexity for this vocabulary, confirming the interpretation of perplexity as \"effective vocabulary size.\""
     },
     {
@@ -133,13 +141,8 @@ export const entropyMedium = {
     {
       type: "mc",
       question: "If $X$ and $Y$ are independent, what is $I(X; Y)$?",
-      options: [
-        "$H(X) + H(Y)$ — their total uncertainty",
-        "$H(X) \\cdot H(Y)$",
-        "$0$, because $H(X \\mid Y) = H(X)$ when $X \\perp Y$",
-        "$-\\infty$, because the log-ratio in KL is undefined"
-      ],
-      correct: 2,
+      options: ["$H(X) + H(Y)$ — their total uncertainty", "$H(X) \\cdot H(Y)$", "$-\\infty$, because the log-ratio in KL is undefined", "$0$, because $H(X \\mid Y) = H(X)$ when $X \\perp Y$"],
+      correct: 3,
       explanation: "When $X \\perp Y$: $P(X, Y) = P(X)P(Y)$, so the KL divergence $\\text{KL}(P(X,Y) \\| P(X)P(Y)) = 0$. Equivalently, $H(X \\mid Y) = H(X)$ — observing $Y$ doesn't reduce uncertainty about $X$ — so $I(X;Y) = H(X) - H(X) = 0$. Independence means zero shared information."
     },
     {
@@ -150,14 +153,23 @@ export const entropyMedium = {
     {
       type: "mc",
       question: "A representation $Z = f(X)$ is a deterministic function of $X$. Can $I(X; Z)$ be zero?",
-      options: [
-        "No — a deterministic function always preserves some information",
-        "Yes — if $Z$ is a constant function (maps all inputs to the same value), then $I(X; Z) = 0$",
-        "Yes — if $f$ is a non-invertible hash function, MI is always zero",
-        "It depends on the dimensionality of $Z$ relative to $X$"
-      ],
-      correct: 1,
+      options: ["Yes — if $Z$ is a constant function (maps all inputs to the same value), then $I(X; Z) = 0$", "No — a deterministic function always preserves some information", "Yes — if $f$ is a non-invertible hash function, MI is always zero", "It depends on the dimensionality of $Z$ relative to $X$"],
+      correct: 0,
       explanation: "$I(X; Z) = 0$ requires $X \\perp Z$, meaning $Z$ carries no information about $X$. For a deterministic $Z = f(X)$, this happens only if $f$ is constant — $Z$ takes the same value regardless of input. Any non-constant deterministic function has $I(X; Z) > 0$, because knowing $Z$ eliminates at least some uncertainty about $X$. A hash function that maps different inputs to different outputs would actually have high MI, even though it's not invertible."
+    },
+    {
+      type: "mc",
+      question: "Two random variables $X$ and $Y$ have correlation $\\rho = 0$ but are clearly dependent (e.g., $Y = X^2$ where $X \\sim \\text{Uniform}(-1, 1)$). What is $I(X; Y)$?",
+      options: ["$I(X; Y) = 0$ because zero correlation implies independence", "$I(X; Y) = 0$ because MI equals the square of correlation", "$I(X; Y) > 0$ — MI detects all dependencies including nonlinear ones, unlike correlation which only measures linear relationships", "$I(X; Y) < 0$ — the nonlinear relationship introduces negative information"],
+      correct: 2,
+      explanation: "MI is zero if and only if $X$ and $Y$ are independent. Zero correlation only rules out *linear* dependence. If $Y = X^2$ and $X$ is symmetric around 0, then $\\text{Corr}(X, Y) = 0$ but $Y$ is completely determined by $X$, so $I(X; Y) = H(Y) > 0$. This is a key advantage of MI over correlation: it captures arbitrary statistical dependencies, making it a more principled measure for representation learning."
+    },
+    {
+      type: "mc",
+      question: "In the information bottleneck framework, you want to find a representation $Z$ of input $X$ that maximizes $I(Z; Y) - \\beta \\cdot I(Z; X)$ for task label $Y$. What happens as $\\beta \\to 0$?",
+      options: ["The representation becomes maximally compressed (constant $Z$)", "The representation retains all input information — $Z$ becomes a copy of $X$ with no compression", "The representation becomes random noise", "The optimization becomes infeasible"],
+      correct: 1,
+      explanation: "As $\\beta \\to 0$, the compression penalty $\\beta \\cdot I(Z; X)$ vanishes, so the objective reduces to maximizing $I(Z; Y)$ alone. The optimal solution retains all information from $X$ (no compression) to maximize task-relevant information. As $\\beta$ increases, the compression penalty becomes stronger, forcing $Z$ to discard task-irrelevant details from $X$. This is the information bottleneck tradeoff: $\\beta$ controls the compression-relevance balance."
     },
     {
       type: "info",
@@ -167,13 +179,8 @@ export const entropyMedium = {
     {
       type: "mc",
       question: "Layer 3 of a network has $I(X; h_3) = 5$ bits. What can you say about $I(X; h_5)$ for layer 5?",
-      options: [
-        "$I(X; h_5) = 5$ bits — information is conserved across layers",
-        "$I(X; h_5) \\leq 5$ bits — the data processing inequality prevents information from increasing",
-        "$I(X; h_5) \\geq 5$ bits — deeper layers learn richer representations",
-        "Nothing — MI between non-adjacent layers is not constrained by DPI"
-      ],
-      correct: 1,
+      options: ["$I(X; h_5) = 5$ bits — information is conserved across layers", "$I(X; h_5) \\geq 5$ bits — deeper layers learn richer representations", "$I(X; h_5) \\leq 5$ bits — the data processing inequality prevents information from increasing", "Nothing — MI between non-adjacent layers is not constrained by DPI"],
+      correct: 2,
       explanation: "Since $X \\to h_3 \\to h_4 \\to h_5$ is a Markov chain, DPI gives $I(X; h_5) \\leq I(X; h_3) = 5$ bits. Each additional layer can only preserve or lose information about the input. The *useful* information $I(Y; h_5)$ might be concentrated and refined, but the *total* input information $I(X; h_5)$ cannot exceed what layer 3 retained."
     },
     {
@@ -201,13 +208,8 @@ export const entropyMedium = {
     {
       type: "mc",
       question: "In CLIP training with batch size $N = 1024$, what is the maximum mutual information $I(\\text{image}; \\text{text})$ that the InfoNCE loss can estimate?",
-      options: [
-        "$1024$ bits",
-        "$\\sqrt{1024} = 32$ bits",
-        "$\\log_2(1024) = 10$ bits",
-        "$1024 \\cdot \\log_2(1024) = 10240$ bits"
-      ],
-      correct: 2,
+      options: ["$1024$ bits", "$\\sqrt{1024} = 32$ bits", "$1024 \\cdot \\log_2(1024) = 10240$ bits", "$\\log_2(1024) = 10$ bits"],
+      correct: 3,
       explanation: "The InfoNCE bound is $I(X; Y) \\geq \\log N - \\mathcal{L}$. Even when the loss is driven to zero, the bound saturates at $\\log N$. With $N = 1024$: $\\log_2(1024) = 10$ bits. If the true MI exceeds 10 bits, the InfoNCE loss with this batch size simply cannot distinguish — the bound is too loose. This is why CLIP uses batch sizes of 32K+: $\\log_2(32768) = 15$ bits, allowing the model to capture finer-grained correspondences."
     },
     {
@@ -218,13 +220,8 @@ export const entropyMedium = {
     {
       type: "mc",
       question: "Why is estimating MI between a 768-dimensional representation and its input fundamentally hard?",
-      options: [
-        "768 dimensions is too many for any neural network to process",
-        "MI is not well-defined for continuous random variables",
-        "Reliable MI estimation requires sample complexity that grows exponentially with the true MI value",
-        "The representation must be discrete for MI to be computable"
-      ],
-      correct: 2,
+      options: ["Reliable MI estimation requires sample complexity that grows exponentially with the true MI value", "MI is not well-defined for continuous random variables", "768 dimensions is too many for any neural network to process", "The representation must be discrete for MI to be computable"],
+      correct: 0,
       explanation: "MI is well-defined for continuous variables (as a KL divergence between densities), but *estimating* it reliably is the problem. The McAllester-Statos impossibility result shows that any estimator providing a high-confidence lower bound needs exponentially many samples in the true MI. A 768-dim representation can have very high MI with its input (potentially hundreds of bits for a deterministic encoder), making reliable estimation require astronomical sample sizes. This is why empirical \"information plane\" analyses of deep networks should be interpreted with caution."
     }
   ]
@@ -273,6 +270,13 @@ export const entropyHard = {
       explanation: "The optimal gap is $\\log\\frac{(1-\\alpha)K}{\\alpha} = \\log\\frac{0.9 \\times 50000}{0.1} = \\log(450000) \\approx 13.0$ (using natural log). Without label smoothing, this gap would be $+\\infty$. With $\\alpha = 0.1$, it is a large but finite number. The logits stabilize rather than growing without bound, leading to better-conditioned gradients in the final layers."
     },
     {
+      type: "mc",
+      question: "You increase the label smoothing parameter from $\\alpha = 0.1$ to $\\alpha = 0.3$. How does this change the optimal logit gap?",
+      options: ["The gap increases — stronger smoothing requires more confident predictions", "The gap stays the same — $\\alpha$ only affects the loss magnitude, not the optimal logits", "The gap decreases — stronger smoothing means the target is closer to uniform, so optimal logits are less extreme", "The gap becomes negative — the model should be more confident in wrong answers"],
+      correct: 2,
+      explanation: "The optimal logit gap is $\\log\\frac{(1-\\alpha)K}{\\alpha}$. Increasing $\\alpha$ from 0.1 to 0.3 means the numerator decreases ($0.7K$ vs $0.9K$) and the denominator increases ($0.3$ vs $0.1$), so the gap shrinks substantially. At $\\alpha = 0.3$: $\\log(0.7 \\times 50000 / 0.3) \\approx \\log(116667) \\approx 11.7$, vs $\\approx 13.0$ at $\\alpha = 0.1$. Stronger smoothing pulls the optimal output closer to uniform (smaller logit gaps)."
+    },
+    {
       type: "info",
       title: "Calibration: When Confidence Matches Accuracy",
       content: "A model is **calibrated** if its confidence estimates match its actual accuracy:\n\n$$P(\\text{correct} \\mid \\text{confidence} = p) = p$$\n\nIf a calibrated model says \"90% confident\" on 1000 predictions, approximately 900 should be correct.\n\nCross-entropy is a **proper scoring rule**: the expected loss is uniquely minimized when $Q = P_{\\text{true}}$. This means a model trained to global optimum on infinite data with cross-entropy loss would be perfectly calibrated.\n\nBut in practice, three factors break calibration:\n\n**1. Finite data**: The model overfits, learning to be confident on training examples without proportional accuracy on new data.\n\n**2. Overparameterization**: Modern networks can fit the training data with room to spare, and the excess capacity drives predictions toward extreme confidence.\n\n**3. Batch normalization and weight decay**: These interact with softmax in subtle ways that shift the confidence distribution.\n\nThe result: modern neural networks are systematically **overconfident** — their predicted probabilities exceed their actual accuracy. Guo et al. (2017) demonstrated this across architectures: deeper and wider networks are more miscalibrated despite being more accurate."
@@ -280,14 +284,16 @@ export const entropyHard = {
     {
       type: "mc",
       question: "A model outputs \"90% confident\" on 100 predictions. Of these, 72 are correct. Is the model well-calibrated, overconfident, or underconfident?",
-      options: [
-        "Well-calibrated — 72% is close enough to 90%",
-        "Underconfident — it should have said higher confidence since some might be right by chance",
-        "Overconfident — it claimed 90% confidence but only achieved 72% accuracy on those predictions",
-        "Cannot determine — calibration requires looking at all confidence levels"
-      ],
-      correct: 2,
+      options: ["Well-calibrated — 72% is close enough to 90%", "Underconfident — it should have said higher confidence since some might be right by chance", "Cannot determine — calibration requires looking at all confidence levels", "Overconfident — it claimed 90% confidence but only achieved 72% accuracy on those predictions"],
+      correct: 3,
       explanation: "The model said \"90% confident\" but only 72/100 = 72% were correct. It is **overconfident**: its stated confidence (90%) significantly exceeds its actual accuracy (72%) for this confidence bin. The **expected calibration error** (ECE) would flag this as a large deviation. A well-calibrated model at 90% confidence should get approximately 90 out of 100 correct. This overconfidence is the norm for modern deep networks and motivates post-hoc calibration techniques."
+    },
+    {
+      type: "mc",
+      question: "Why are modern deep networks typically overconfident rather than underconfident, even when well-trained with cross-entropy loss?",
+      options: ["Cross-entropy loss penalizes underconfidence more heavily than overconfidence", "Overparameterized models can perfectly fit training data, then the softmax concentrates mass as logit magnitudes grow during training — finite data cannot prevent this", "Batch normalization ensures outputs sum to more than 1.0", "The softmax function is inherently biased toward extreme probabilities regardless of logit values"],
+      correct: 1,
+      explanation: "Cross-entropy is a proper scoring rule, so at the infinite-data optimum the model would be calibrated. But in practice, overparameterized networks fit training data perfectly and then continue pushing logits apart (increasing $\\|z\\|$), which concentrates the softmax output toward a point mass. Without enough data to penalize this on held-out examples during training, overconfidence grows unchecked. This is exacerbated by architectural choices (e.g., residual connections allow logit magnitudes to grow freely) and training heuristics like weight decay that insufficiently regularize the logit scale."
     },
     {
       type: "info",
@@ -297,13 +303,8 @@ export const entropyHard = {
     {
       type: "mc",
       question: "Post-hoc temperature scaling with $T > 1$ does what to a trained model's predictions?",
-      options: [
-        "Changes which class is predicted (different $\\arg\\max$), improving accuracy",
-        "Makes predictions less confident (higher entropy) without changing which class is predicted",
-        "Makes predictions more confident (lower entropy), fixing underconfidence",
-        "Retrains the final layer to improve calibration"
-      ],
-      correct: 1,
+      options: ["Makes predictions less confident (higher entropy) without changing which class is predicted", "Changes which class is predicted (different $\\arg\\max$), improving accuracy", "Makes predictions more confident (lower entropy), fixing underconfidence", "Retrains the final layer to improve calibration"],
+      correct: 0,
       explanation: "Dividing logits by $T > 1$ compresses them toward zero, making the softmax output more uniform — higher entropy, lower confidence. Since dividing all logits by the same positive constant preserves their ordering, the $\\arg\\max$ is unchanged: accuracy is identical. Only the *confidence* of the prediction changes. This is why temperature scaling is so appealing: it fixes calibration (confidence matches accuracy) with zero cost to accuracy and only one parameter to tune."
     },
     {

--- a/src/modules/info-theory-f-divergences.js
+++ b/src/modules/info-theory-f-divergences.js
@@ -18,13 +18,8 @@ export const easyModule = {
     {
       type: "mc",
       question: "Which of the following is a known limitation of KL divergence that motivates looking for alternatives?",
-      options: [
-        "It requires both distributions to be discrete",
-        "It is asymmetric: $\\text{KL}(P \\| Q) \\neq \\text{KL}(Q \\| P)$",
-        "It is always bounded between 0 and 1",
-        "It cannot handle continuous distributions"
-      ],
-      correct: 1,
+      options: ["It requires both distributions to be discrete", "It cannot handle continuous distributions", "It is always bounded between 0 and 1", "It is asymmetric: $\\text{KL}(P \\| Q) \\neq \\text{KL}(Q \\| P)$"],
+      correct: 3,
       explanation: "KL divergence is **asymmetric** — swapping the arguments gives a fundamentally different quantity. This asymmetry has deep practical consequences: $\\text{KL}(P \\| Q)$ and $\\text{KL}(Q \\| P)$ penalize different types of mismatch, leading to different model behaviors."
     },
     {
@@ -35,13 +30,8 @@ export const easyModule = {
     {
       type: "mc",
       question: "A target distribution $P$ is bimodal with two well-separated peaks. You fit $Q$ by minimizing **forward KL** $\\text{KL}(P \\| Q)$. What behavior do you expect?",
-      options: [
-        "$Q$ locks onto one peak and ignores the other",
-        "$Q$ spreads to cover both peaks, possibly placing mass between them",
-        "$Q$ assigns uniform probability everywhere",
-        "$Q$ exactly matches $P$"
-      ],
-      correct: 1,
+      options: ["$Q$ spreads to cover both peaks, possibly placing mass between them", "$Q$ locks onto one peak and ignores the other", "$Q$ assigns uniform probability everywhere", "$Q$ exactly matches $P$"],
+      correct: 0,
       explanation: "Forward KL is **mode-covering**: $Q$ must assign probability wherever $P$ has mass (otherwise $\\log P/Q \\to \\infty$). For a bimodal $P$, $Q$ will cover both modes — but if $Q$ is a unimodal family (e.g., a single Gaussian), it may place significant mass in the valley between the peaks. This is the classic failure mode of variational inference with forward KL."
     },
     {
@@ -86,13 +76,8 @@ export const easyModule = {
     {
       type: "mc",
       question: "During language model training with cross-entropy loss (= forward KL minimization), the training data $P$ has support on certain token sequences. If $Q$ (your model) assigns near-zero probability to a sequence that $P$ covers, what happens?",
-      options: [
-        "The KL divergence stays bounded and training proceeds smoothly",
-        "The gradient signal for that sequence vanishes",
-        "The loss for that sequence becomes very large, creating a strong gradient signal",
-        "The model ignores that sequence and focuses on higher-probability ones"
-      ],
-      correct: 2,
+      options: ["The KL divergence stays bounded and training proceeds smoothly", "The gradient signal for that sequence vanishes", "The model ignores that sequence and focuses on higher-probability ones", "The loss for that sequence becomes very large, creating a strong gradient signal"],
+      correct: 3,
       explanation: "Since $\\text{KL}(P \\| Q) = \\sum P(x) \\log(P(x)/Q(x))$, when $Q(x) \\to 0$ for some $x$ where $P(x) > 0$, the term $\\log(P/Q) \\to \\infty$. This creates a large loss and strong gradient, forcing the model to assign *some* probability to every sequence in the training data. This is forward KL's mode-covering property at work — it's also why language models sometimes hallucinate: they've been forced to cover the full support of $P$, including rare patterns."
     },
     {
@@ -119,13 +104,8 @@ export const mediumModule = {
     {
       type: "mc",
       question: "The chi-squared divergence is $\\chi^2(P \\| Q) = \\mathbb{E}_Q[(P/Q)^2] - 1$. Recall that $\\text{Var}[X] = \\mathbb{E}[X^2] - (\\mathbb{E}[X])^2$. What is $\\mathbb{E}_Q[P(x)/Q(x)]$?",
-      options: [
-        "$0$",
-        "$1$",
-        "It depends on $P$ and $Q$",
-        "$\\text{KL}(P \\| Q)$"
-      ],
-      correct: 1,
+      options: ["$1$", "$0$", "It depends on $P$ and $Q$", "$\\text{KL}(P \\| Q)$"],
+      correct: 0,
       explanation: "$\\mathbb{E}_Q[P/Q] = \\sum_x Q(x) \\cdot \\frac{P(x)}{Q(x)} = \\sum_x P(x) = 1$. The importance weight $P/Q$ always has expectation 1 under $Q$. This is the fundamental property that makes importance sampling work — and it means $\\chi^2(P \\| Q) = \\mathbb{E}_Q[(P/Q)^2] - 1 = \\text{Var}_Q[P/Q]$."
     },
     {
@@ -170,13 +150,8 @@ export const mediumModule = {
     {
       type: "mc",
       question: "If $P$ and $Q$ have completely disjoint support (no overlap at all), what is $\\text{JS}(P \\| Q)$?",
-      options: [
-        "$0$",
-        "$\\log 2$",
-        "$\\infty$",
-        "Undefined"
-      ],
-      correct: 1,
+      options: ["$0$", "$\\infty$", "$\\log 2$", "Undefined"],
+      correct: 2,
       explanation: "When $P$ and $Q$ don't overlap: $M = (P+Q)/2$ has support everywhere either does. Then $\\text{KL}(P \\| M) = \\sum P \\log \\frac{P}{P/2} = \\sum P \\log 2 = \\log 2$, and similarly $\\text{KL}(Q \\| M) = \\log 2$. So $\\text{JS} = \\frac{1}{2}\\log 2 + \\frac{1}{2}\\log 2 = \\log 2$. JS saturates at its maximum — it tells you the distributions are maximally different, but **the gradient of this constant is zero**. This is the vanishing gradient problem that motivated Wasserstein GANs."
     },
     {
@@ -187,13 +162,8 @@ export const mediumModule = {
     {
       type: "mc",
       question: "Early in GAN training, the generator produces low-quality samples far from the data distribution. The discriminator easily distinguishes real from fake (near-perfect classification). What happens to the JS divergence gradient?",
-      options: [
-        "The gradient is very large, providing a strong learning signal",
-        "The gradient is moderate and training proceeds normally",
-        "The gradient nearly vanishes because JS saturates at $\\log 2$",
-        "The gradient oscillates unpredictably"
-      ],
-      correct: 2,
+      options: ["The gradient is very large, providing a strong learning signal", "The gradient is moderate and training proceeds normally", "The gradient oscillates unpredictably", "The gradient nearly vanishes because JS saturates at $\\log 2$"],
+      correct: 3,
       explanation: "When the discriminator is near-perfect, $P$ and $Q_G$ are effectively non-overlapping. JS saturates at its maximum $\\log 2$, and $\\nabla_G \\text{JS} \\approx 0$. The generator receives almost no gradient signal. This is the **GAN training instability** that led to alternatives: Wasserstein GAN uses Earth Mover's distance (not an f-divergence) which provides gradients even for non-overlapping distributions."
     },
     {
@@ -204,13 +174,8 @@ export const mediumModule = {
     {
       type: "mc",
       question: "A representation $Z = f(X)$ is a deterministic function of input $X$. If $I(X; Z) = 0$, what can you conclude about $Z$?",
-      options: [
-        "$Z$ perfectly encodes all information in $X$",
-        "$Z$ is independent of $X$ — it carries no information about the input",
-        "$Z$ encodes only task-relevant information",
-        "Nothing — MI can be zero even for useful representations"
-      ],
-      correct: 1,
+      options: ["$Z$ is independent of $X$ — it carries no information about the input", "$Z$ perfectly encodes all information in $X$", "$Z$ encodes only task-relevant information", "Nothing — MI can be zero even for useful representations"],
+      correct: 0,
       explanation: "$I(X; Z) = 0$ means $P(X, Z) = P(X)P(Z)$, i.e., $X$ and $Z$ are independent. The representation carries **no information** about the input — it's useless. High MI means $Z$ is informative about $X$; low MI means $Z$ has discarded information. The information bottleneck asks: what's the minimum MI $I(X; Z)$ you can get away with while still predicting the target $Y$ well?"
     }
   ]
@@ -249,13 +214,8 @@ export const hardModule = {
     {
       type: "mc",
       question: "In the variational bound $D_f(P \\| Q) \\geq \\sup_T\\{\\mathbb{E}_P[T] - \\mathbb{E}_Q[f^*(T)]\\}$, the function $T$ is optimized to tighten the bound. In a GAN, what plays the role of $T$?",
-      options: [
-        "The generator network",
-        "The discriminator network",
-        "The loss function",
-        "The latent noise vector"
-      ],
-      correct: 1,
+      options: ["The generator network", "The loss function", "The discriminator network", "The latent noise vector"],
+      correct: 2,
       explanation: "The **discriminator** maximizes the variational bound — it's the function $T$ that distinguishes real from generated data. The generator then minimizes the resulting (approximate) f-divergence. This is the adversarial game: the discriminator tightens the lower bound on the divergence, and the generator minimizes it."
     },
     {
@@ -266,13 +226,8 @@ export const hardModule = {
     {
       type: "mc",
       question: "Least-Squares GAN (LSGAN) replaces the log-loss with squared error: $\\min_G \\max_D\\; \\mathbb{E}_P[(D(x)-1)^2] + \\mathbb{E}_{Q_G}[D(x)^2]$. Based on the f-GAN framework, which f-divergence does LSGAN approximately minimize?",
-      options: [
-        "KL divergence",
-        "Jensen-Shannon divergence",
-        "Pearson chi-squared divergence",
-        "Total variation distance"
-      ],
-      correct: 2,
+      options: ["KL divergence", "Jensen-Shannon divergence", "Total variation distance", "Pearson chi-squared divergence"],
+      correct: 3,
       explanation: "LSGAN's squared-error objective corresponds to the **Pearson chi-squared divergence** ($f(t) = (t-1)^2$). The conjugate of $(t-1)^2$ is $f^*(u) = u + u^2/4$, which gives a quadratic (least-squares) discriminator loss. This was shown by Mao et al. (2017) and provides a theoretical justification for why LSGAN training is often more stable than the original — chi-squared has nicer gradient properties near saturation."
     },
     {
@@ -300,13 +255,8 @@ export const hardModule = {
     {
       type: "mc",
       question: "In both the information bottleneck and RLHF, $\\beta$ controls a trade-off. In the IB, increasing $\\beta$ makes the model retain more task-relevant information. In RLHF, increasing $\\beta$ makes the policy:",
-      options: [
-        "Chase higher rewards more aggressively, diverging further from $\\pi_{\\text{ref}}$",
-        "Stay closer to $\\pi_{\\text{ref}}$, sacrificing potential reward",
-        "Have no effect — $\\beta$ only matters in the IB setting",
-        "Increase the entropy of the policy distribution"
-      ],
-      correct: 1,
+      options: ["Stay closer to $\\pi_{\\text{ref}}$, sacrificing potential reward", "Chase higher rewards more aggressively, diverging further from $\\pi_{\\text{ref}}$", "Have no effect — $\\beta$ only matters in the IB setting", "Increase the entropy of the policy distribution"],
+      correct: 0,
       explanation: "In the RLHF objective $\\max \\mathbb{E}[R] - \\beta \\cdot \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, a larger $\\beta$ increases the penalty for deviating from $\\pi_{\\text{ref}}$. The policy stays closer to the reference model and sacrifices potential reward for safety/coherence. This is exactly analogous to the IB: higher $\\beta$ → stronger constraint → more conservative behavior. The Pareto frontier traced by varying $\\beta$ is called the **rate-distortion curve** in information theory."
     }
   ]

--- a/src/modules/linear-algebra.js
+++ b/src/modules/linear-algebra.js
@@ -19,85 +19,50 @@ export const easyModule = {
     {
       type: "mc",
       question: "A function $f: \\mathbb{R}^n \\to \\mathbb{R}^m$ has a Jacobian matrix $J$. What is the shape of $J$?",
-      options: [
-        "$n \\times n$",
-        "$m \\times n$",
-        "$n \\times m$",
-        "$m \\times m$"
-      ],
-      correct: 1,
+      options: ["$m \\times n$", "$n \\times n$", "$n \\times m$", "$m \\times m$"],
+      correct: 0,
       explanation: "The Jacobian $J \\in \\mathbb{R}^{m \\times n}$ has entry $J_{ij} = \\partial f_i / \\partial x_j$. Each row corresponds to one output dimension, each column to one input dimension. When $m = 1$ (scalar output), this reduces to the familiar gradient $\\nabla f \\in \\mathbb{R}^{1 \\times n}$ (a row vector)."
     },
     {
       type: "mc",
       question: "A real symmetric matrix $A$ has eigendecomposition $A = Q \\Lambda Q^\\top$. Which statement is **always** true?",
-      options: [
-        "The columns of $Q$ are orthonormal and the diagonal entries of $\\Lambda$ are real",
-        "The columns of $Q$ are orthonormal and the diagonal entries of $\\Lambda$ are positive",
-        "All eigenvalues are distinct",
-        "$A$ must be positive definite"
-      ],
-      correct: 0,
+      options: ["The columns of $Q$ are orthonormal and the diagonal entries of $\\Lambda$ are positive", "The columns of $Q$ are orthonormal and the diagonal entries of $\\Lambda$ are real", "All eigenvalues are distinct", "$A$ must be positive definite"],
+      correct: 1,
       explanation: "By the **Spectral Theorem**, every real symmetric matrix has real eigenvalues and an orthonormal eigenbasis — so $Q$ is orthogonal ($Q^\\top Q = I$) and $\\Lambda$ is real diagonal. Eigenvalues need not be positive or distinct; positive-definiteness is an additional condition requiring all $\\lambda_i > 0$."
     },
     {
       type: "mc",
       question: "Matrix $A \\in \\mathbb{R}^{m \\times n}$ (with $m \\geq n$) has SVD $A = U \\Sigma V^\\top$. What are the shapes of $U$, $\\Sigma$, and $V$?",
-      options: [
-        "$U \\in \\mathbb{R}^{m \\times m},\\ \\Sigma \\in \\mathbb{R}^{m \\times n},\\ V \\in \\mathbb{R}^{n \\times n}$",
-        "$U \\in \\mathbb{R}^{m \\times n},\\ \\Sigma \\in \\mathbb{R}^{n \\times n},\\ V \\in \\mathbb{R}^{n \\times n}$",
-        "$U \\in \\mathbb{R}^{m \\times m},\\ \\Sigma \\in \\mathbb{R}^{n \\times n},\\ V \\in \\mathbb{R}^{n \\times m}$",
-        "$U \\in \\mathbb{R}^{n \\times n},\\ \\Sigma \\in \\mathbb{R}^{n \\times m},\\ V \\in \\mathbb{R}^{m \\times m}$"
-      ],
-      correct: 0,
+      options: ["$U \\in \\mathbb{R}^{m \\times m},\\ \\Sigma \\in \\mathbb{R}^{n \\times n},\\ V \\in \\mathbb{R}^{n \\times m}$", "$U \\in \\mathbb{R}^{m \\times n},\\ \\Sigma \\in \\mathbb{R}^{n \\times n},\\ V \\in \\mathbb{R}^{n \\times n}$", "$U \\in \\mathbb{R}^{m \\times m},\\ \\Sigma \\in \\mathbb{R}^{m \\times n},\\ V \\in \\mathbb{R}^{n \\times n}$", "$U \\in \\mathbb{R}^{n \\times n},\\ \\Sigma \\in \\mathbb{R}^{n \\times m},\\ V \\in \\mathbb{R}^{m \\times m}$"],
+      correct: 2,
       explanation: "Full SVD: $U \\in \\mathbb{R}^{m \\times m}$ (left singular vectors), $\\Sigma \\in \\mathbb{R}^{m \\times n}$ (diagonal, with $n$ singular values on the diagonal), $V \\in \\mathbb{R}^{n \\times n}$ (right singular vectors). Both $U$ and $V$ are orthogonal matrices. The 'thin' or 'economy' SVD keeps only $n$ columns of $U$, making $\\Sigma$ square $n \\times n$ — common in practice."
     },
     {
       type: "mc",
       question: "What does `torch.einsum('ij,jk->ik', A, B)` compute?",
-      options: [
-        "Element-wise product of $A$ and $B$",
-        "Matrix product $AB$",
-        "Outer product of $A$ and $B$",
-        "Trace of $AB$"
-      ],
-      correct: 1,
+      options: ["Element-wise product of $A$ and $B$", "Trace of $AB$", "Outer product of $A$ and $B$", "Matrix product $AB$"],
+      correct: 3,
       explanation: "The index $j$ appears on both inputs but not in the output, so it is summed over: $\\sum_j A_{ij} B_{jk} = (AB)_{ik}$. This is exactly matrix multiplication. Einsum notation makes the contraction axis explicit — `ij,jk->ik` is the canonical matrix multiply pattern."
     },
     {
       type: "mc",
       question: "A matrix $A$ is **positive semi-definite (PSD)** if and only if:",
-      options: [
-        "All entries of $A$ are non-negative",
-        "$x^\\top A x \\geq 0$ for all $x \\in \\mathbb{R}^n$",
-        "$A$ is symmetric and invertible",
-        "$A$ has a non-negative determinant"
-      ],
-      correct: 1,
+      options: ["$x^\\top A x \\geq 0$ for all $x \\in \\mathbb{R}^n$", "All entries of $A$ are non-negative", "$A$ is symmetric and invertible", "$A$ has a non-negative determinant"],
+      correct: 0,
       explanation: "$A$ is PSD iff $x^\\top A x \\geq 0$ for all $x$ — this is the definition. Equivalently (for symmetric $A$), all eigenvalues are $\\geq 0$. Hessians of convex functions are PSD; this is why checking eigenvalues of the Hessian tells you about convexity. Non-negative entries is a much weaker (and unrelated) condition."
     },
     {
       type: "mc",
       question: "The **spectral norm** $\\|A\\|_2$ of a matrix equals:",
-      options: [
-        "The sum of all singular values",
-        "The square root of the sum of squared entries",
-        "The largest singular value $\\sigma_1$",
-        "The largest absolute eigenvalue"
-      ],
-      correct: 2,
+      options: ["The sum of all singular values", "The largest singular value $\\sigma_1$", "The square root of the sum of squared entries", "The largest absolute eigenvalue"],
+      correct: 1,
       explanation: "$\\|A\\|_2 = \\sigma_1$, the largest singular value. It equals $\\max_{\\|x\\|=1} \\|Ax\\|$, i.e., how much $A$ stretches a unit vector at most. This is the operationally important norm for stability analysis — gradient explosion occurs when products of weight matrices have spectral norms $\\gg 1$. (The sum of singular values is the nuclear norm; the Frobenius norm is the square root of sum of squares.)"
     },
     {
       type: "mc",
       question: "Which einsum string computes a **batched matrix multiply** $C_{b} = A_{b} B_{b}$ for a batch of matrices?",
-      options: [
-        "`'ij,jk->ik'`",
-        "`'bij,bjk->bik'`",
-        "`'bi,bj->bij'`",
-        "`'bij,bkj->bik'`"
-      ],
-      correct: 1,
+      options: ["`'ij,jk->ik'`", "`'bi,bj->bij'`", "`'bij,bjk->bik'`", "`'bij,bkj->bik'`"],
+      correct: 2,
       explanation: "`'bij,bjk->bik'`: index $b$ appears in all three tensors so it is kept (not summed); $j$ is summed over as the shared inner dimension. The result is $C_{bik} = \\sum_j A_{bij} B_{bjk}$ — independently multiplying the $b$-th matrix pair. This is what PyTorch's `torch.bmm` does under the hood."
     }
   ]
@@ -119,25 +84,15 @@ export const mediumModule = {
     {
       type: "mc",
       question: "For a linear layer $z = Wx$ with $W \\in \\mathbb{R}^{m \\times n}$, $x \\in \\mathbb{R}^n$, scalar loss $L$. The upstream gradient is $\\delta = \\nabla_z L \\in \\mathbb{R}^m$. What is $\\nabla_W L$?",
-      options: [
-        "$\\delta^\\top x$",
-        "$\\delta x^\\top$",
-        "$x \\delta^\\top$",
-        "$W^\\top \\delta$"
-      ],
-      correct: 1,
+      options: ["$\\delta^\\top x$", "$W^\\top \\delta$", "$x \\delta^\\top$", "$\\delta x^\\top$"],
+      correct: 3,
       explanation: "$\\nabla_W L = \\delta x^\\top \\in \\mathbb{R}^{m \\times n}$. This is an outer product: the gradient with respect to each weight $W_{ij}$ is $\\delta_i x_j$, since $\\partial z_i / \\partial W_{ij} = x_j$. This outer-product structure explains why gradient updates are low-rank (rank 1 per sample, rank $\\leq$ batch size for a mini-batch) — the foundation of why LoRA works."
     },
     {
       type: "mc",
       question: "The **Eckart-Young theorem** says: among all rank-$k$ matrices, $\\hat{A}_k = \\sum_{i=1}^k \\sigma_i u_i v_i^\\top$ minimizes which quantity?",
-      options: [
-        "Only the spectral norm $\\|A - \\hat{A}_k\\|_2$",
-        "Only the Frobenius norm $\\|A - \\hat{A}_k\\|_F$",
-        "Both the spectral norm and the Frobenius norm",
-        "The nuclear norm $\\|A - \\hat{A}_k\\|_*$"
-      ],
-      correct: 2,
+      options: ["Both the spectral norm and the Frobenius norm", "Only the Frobenius norm $\\|A - \\hat{A}_k\\|_F$", "Only the spectral norm $\\|A - \\hat{A}_k\\|_2$", "The nuclear norm $\\|A - \\hat{A}_k\\|_*$"],
+      correct: 0,
       explanation: "Eckart-Young holds for **both** the spectral norm and the Frobenius norm — the rank-$k$ truncated SVD is simultaneously optimal under both. The residual errors are $\\|A - \\hat{A}_k\\|_2 = \\sigma_{k+1}$ and $\\|A - \\hat{A}_k\\|_F = \\sqrt{\\sum_{i>k} \\sigma_i^2}$. This robustness to choice of norm makes SVD the gold standard for low-rank approximation."
     },
     {
@@ -155,37 +110,22 @@ export const mediumModule = {
     {
       type: "mc",
       question: "Computing the eigendecomposition $A = Q \\Lambda Q^\\top$ gives a fast way to compute $A^k$ for large integer $k$. What is $A^k$?",
-      options: [
-        "$Q \\Lambda^k Q^\\top$",
-        "$Q^k \\Lambda Q^{\\top k}$",
-        "$Q \\Lambda Q^\\top + k(Q \\Lambda Q^\\top)$",
-        "$k \\cdot Q \\Lambda Q^\\top$"
-      ],
-      correct: 0,
+      options: ["$Q \\Lambda Q^\\top + k(Q \\Lambda Q^\\top)$", "$Q^k \\Lambda Q^{\\top k}$", "$Q \\Lambda^k Q^\\top$", "$k \\cdot Q \\Lambda Q^\\top$"],
+      correct: 2,
       explanation: "$A^k = (Q \\Lambda Q^\\top)^k = Q \\Lambda^k Q^\\top$, since $Q^\\top Q = I$ collapses all the middle factors. This makes matrix powers cheap: just raise the diagonal entries to the $k$-th power. The same trick gives $\\exp(A) = Q \\exp(\\Lambda) Q^\\top$ and $A^{-1} = Q \\Lambda^{-1} Q^\\top$ (when $A$ is invertible). This is the basis for efficient computation in Hessian-based optimizers."
     },
     {
       type: "mc",
       question: "The Hessian $H = \\nabla^2 L$ of a loss function is always symmetric. At a local minimum, what can you say about $H$?",
-      options: [
-        "$H$ must be the identity matrix",
-        "$H$ must be positive definite (all eigenvalues $> 0$)",
-        "$H$ must be positive semi-definite (all eigenvalues $\\geq 0$)",
-        "$H$ can have any eigenvalue signs"
-      ],
-      correct: 2,
+      options: ["$H$ must be the identity matrix", "$H$ must be positive definite (all eigenvalues $> 0$)", "$H$ can have any eigenvalue signs", "$H$ must be positive semi-definite (all eigenvalues $\\geq 0$)"],
+      correct: 3,
       explanation: "The second-order **necessary** condition at a local minimum is $H \\succeq 0$ (PSD — all eigenvalues $\\geq 0$). Positive definiteness ($H \\succ 0$) is the **sufficient** condition that *confirms* a minimum, but it is not required — local minima with zero eigenvalues (flat directions) are common and valid. In neural network training, Hessians at minima routinely have many near-zero eigenvalues. The key distinction: if any eigenvalue is **negative**, the point is a saddle, not a minimum; if all are $\\geq 0$, it can be a minimum."
     },
     {
       type: "mc",
       question: "What does `torch.einsum('bhij,bhjd->bhid', attn_weights, V)` compute in a multi-head attention layer? (Indices: $b$=batch, $h$=head, $i$=query position, $j$=key position, $d$=head dim)",
-      options: [
-        "The dot-product attention scores $QK^\\top / \\sqrt{d}$",
-        "The weighted sum of values: for each query position $i$, sum values $V$ weighted by attention over positions $j$",
-        "The outer product of queries and keys",
-        "Layer normalization across the head dimension"
-      ],
-      correct: 1,
+      options: ["The weighted sum of values: for each query position $i$, sum values $V$ weighted by attention over positions $j$", "The dot-product attention scores $QK^\\top / \\sqrt{d}$", "The outer product of queries and keys", "Layer normalization across the head dimension"],
+      correct: 0,
       explanation: "Index $j$ is summed over (it appears in both inputs but not the output), giving $\\text{output}_{bhid} = \\sum_j \\text{attn}_{bhij} \\cdot V_{bhjd}$. This is exactly the attention output: for each batch $b$, head $h$, and query position $i$, compute a weighted sum of the value vectors $V_{bhjd}$ across all key/value positions $j$, with weights given by the (softmaxed) attention scores."
     }
   ]
@@ -219,49 +159,29 @@ export const hardModule = {
     {
       type: "mc",
       question: "You want to compress a trained weight matrix $W \\in \\mathbb{R}^{4096 \\times 4096}$ by keeping only its top-$r$ singular values. After inspecting the singular value spectrum, you find $\\sigma_1 = 850$, $\\sigma_2 = 832$, ..., $\\sigma_{50} = 810$, $\\sigma_{51} = 12$, $\\sigma_{52} = 11.5$, .... What does this suggest about an appropriate $r$?",
-      options: [
-        "$r = 4096$ (keep everything — the spectrum is too dense)",
-        "$r \\approx 50$ (there is a sharp spectral gap at rank 50)",
-        "$r = 1$ (the first singular value dominates)",
-        "$r$ cannot be determined without knowing the task loss"
-      ],
-      correct: 1,
+      options: ["$r = 4096$ (keep everything — the spectrum is too dense)", "$r = 1$ (the first singular value dominates)", "$r \\approx 50$ (there is a sharp spectral gap at rank 50)", "$r$ cannot be determined without knowing the task loss"],
+      correct: 2,
       explanation: "The **spectral gap** between $\\sigma_{50} \\approx 810$ and $\\sigma_{51} \\approx 12$ (a factor of ~67×) is a strong signal. The top 50 singular vectors capture structured information; the rest are noise-level. Setting $r = 50$ keeps almost all the signal while compressing storage from $4096^2 \\approx 16.8$M parameters to $2 \\times 50 \\times 4096 = 409.6$K parameters — a ~41× reduction. This spectral-gap criterion is the practical heuristic behind SVD-based model compression."
     },
     {
       type: "mc",
       question: "**Spectral normalization** divides each weight matrix by its spectral norm: $\\hat{W} = W / \\sigma_1(W)$. This ensures $\\|\\hat{W}\\|_2 = 1$. Why does this stabilize training?",
-      options: [
-        "It makes the weight matrices orthogonal",
-        "It ensures the Jacobian of each layer is an isometry",
-        "It bounds the Lipschitz constant of each linear layer to 1, preventing gradient explosion",
-        "It makes the loss landscape convex"
-      ],
-      correct: 2,
+      options: ["It makes the weight matrices orthogonal", "It ensures the Jacobian of each layer is an isometry", "It makes the loss landscape convex", "It bounds the Lipschitz constant of each linear layer to 1, preventing gradient explosion"],
+      correct: 3,
       explanation: "For a linear map $x \\mapsto Wx$, the Lipschitz constant is exactly $\\|W\\|_2 = \\sigma_1(W)$. After spectral normalization, $\\|\\hat{W}x - \\hat{W}y\\|_2 \\leq \\|x - y\\|_2$ for all $x, y$ (1-Lipschitz). In a deep network, the global Lipschitz constant is at most the product of per-layer Lipschitz constants — spectral normalization keeps each factor $\\leq 1$, preventing gradient explosion through deep chains of linear layers."
     },
     {
       type: "mc",
       question: "The gradient of the loss $L$ with respect to the input $x$ of a linear layer $z = Wx$ is:",
-      options: [
-        "$\\nabla_x L = \\nabla_z L \\cdot W$",
-        "$\\nabla_x L = W^\\top \\nabla_z L$",
-        "$\\nabla_x L = W \\nabla_z L$",
-        "$\\nabla_x L = \\nabla_z L \\cdot W^\\top$"
-      ],
-      correct: 1,
+      options: ["$\\nabla_x L = W^\\top \\nabla_z L$", "$\\nabla_x L = \\nabla_z L \\cdot W$", "$\\nabla_x L = W \\nabla_z L$", "$\\nabla_x L = \\nabla_z L \\cdot W^\\top$"],
+      correct: 0,
       explanation: "By the chain rule, $(\\nabla_x L)_j = \\sum_i (\\nabla_z L)_i \\frac{\\partial z_i}{\\partial x_j} = \\sum_i (\\nabla_z L)_i W_{ij}$. In matrix form this is $W^\\top (\\nabla_z L)$. The transpose of $W$ appears naturally because backprop reverses the direction of information flow — the Jacobian of $z = Wx$ w.r.t. $x$ is $W$, and its transpose appears in the vector-Jacobian product. This is why every backward pass through a linear layer is another matrix multiply with the transposed weight."
     },
     {
       type: "mc",
       question: "Scaled dot-product attention computes $\\text{Attention}(Q, K, V) = \\text{softmax}\\!\\left(\\frac{QK^\\top}{\\sqrt{d_k}}\\right) V$. Using einsum notation with indices $b$ (batch), $h$ (head), $i$ (query pos), $j$ (key pos), $d$ (head dim): which sequence of einsum calls correctly computes the attention output?",
-      options: [
-        "`scores = einsum('bhid,bhjd->bhij', Q, K)` then `out = einsum('bhij,bhjd->bhid', softmax(scores/√d), V)`",
-        "`scores = einsum('bhid,bhid->bhi', Q, K)` then `out = einsum('bhi,bhid->bhid', softmax(scores/√d), V)`",
-        "`scores = einsum('bhid,bhjd->bhid', Q, K)` then `out = einsum('bhij,bhjd->bij', softmax(scores/√d), V)`",
-        "`scores = einsum('bhij,bhjd->bhid', Q, K)` then `out = einsum('bhid,bhjd->bhij', softmax(scores/√d), V)`"
-      ],
-      correct: 0,
+      options: ["`scores = einsum('bhid,bhid->bhi', Q, K)` then `out = einsum('bhi,bhid->bhid', softmax(scores/√d), V)`", "`scores = einsum('bhid,bhjd->bhij', Q, K)` then `out = einsum('bhij,bhjd->bhid', softmax(scores/√d), V)`", "`scores = einsum('bhid,bhjd->bhid', Q, K)` then `out = einsum('bhij,bhjd->bij', softmax(scores/√d), V)`", "`scores = einsum('bhij,bhjd->bhid', Q, K)` then `out = einsum('bhid,bhjd->bhij', softmax(scores/√d), V)`"],
+      correct: 1,
       explanation: "Step 1: `'bhid,bhjd->bhij'` — $d$ is summed (dot product over head dim between each query $i$ and key $j$), giving attention logits of shape $(b, h, i, j)$. Step 2: `'bhij,bhjd->bhid'` — $j$ is summed (weighted sum of values over key positions), giving output of shape $(b, h, i, d)$. The full attention pattern is: contract over $d$ to get scores, softmax, then contract over $j$ to aggregate values."
     },
     {

--- a/src/modules/prob-assessment-applied.js
+++ b/src/modules/prob-assessment-applied.js
@@ -18,25 +18,15 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "During LLM pre-training, the loss is $-\\frac{1}{T} \\sum_{t=1}^{T} \\log P_\\theta(w_t \\mid w_{<t})$. As training progresses, this loss decreases but eventually plateaus. The **irreducible** component of this loss corresponds to:",
-      options: [
-        "The numerical precision of float16 arithmetic",
-        "The **entropy of natural language** $H(W_t \\mid W_{<t})$ — the inherent unpredictability that no model can eliminate because language itself is stochastic",
-        "The size of the vocabulary",
-        "The number of parameters in the model"
-      ],
-      correct: 1,
+      options: ["The numerical precision of float16 arithmetic", "The size of the vocabulary", "The **entropy of natural language** $H(W_t \\mid W_{<t})$ — the inherent unpredictability that no model can eliminate because language itself is stochastic", "The number of parameters in the model"],
+      correct: 2,
       explanation: "Cross-entropy loss $= H(P) + \\text{KL}(P \\| Q_\\theta)$. Even a perfect model ($Q = P$) achieves loss $H(P)$, the conditional entropy of the next token. This is the irreducible noise in language — given perfect context, many continuations are still plausible. The gap between the model's loss and $H(P)$ is the KL divergence, which measures model imperfection. Scaling laws describe how this KL component decreases with compute."
     },
     {
       type: "mc",
       question: "When you increase the **temperature** $\\tau$ in sampling ($P(w) \\propto \\exp(z_w / \\tau)$ where $z_w$ are logits), you are:",
-      options: [
-        "Changing the model's parameters",
-        "Interpolating between the model's learned distribution ($\\tau = 1$) and uniform ($\\tau \\to \\infty$), which increases entropy and diversity. At $\\tau \\to 0$, you get argmax (greedy) decoding",
-        "Applying dropout at inference time",
-        "Changing the loss function"
-      ],
-      correct: 1,
+      options: ["Interpolating between the model's learned distribution ($\\tau = 1$) and uniform ($\\tau \\to \\infty$), which increases entropy and diversity. At $\\tau \\to 0$, you get argmax (greedy) decoding", "Changing the model's parameters", "Applying dropout at inference time", "Changing the loss function"],
+      correct: 0,
       explanation: "Dividing logits by $\\tau > 1$ flattens the distribution (higher entropy, more random). Dividing by $\\tau < 1$ sharpens it (lower entropy, more deterministic). At $\\tau \\to 0$, all mass concentrates on the highest-logit token (argmax). At $\\tau \\to \\infty$, the distribution approaches uniform over the vocabulary. Temperature is a post-hoc entropy control that doesn't change the model — it's a monotonic transformation of the entropy of the output distribution."
     },
     {
@@ -54,37 +44,22 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "A model trained on code achieves cross-entropy 0.5 nats/token on Python but 1.8 nats/token on Haskell. Assuming equal vocabulary, the **perplexity ratio** tells us:",
-      options: [
-        "Python is a better language than Haskell",
-        "The model has learned far more predictable structure in Python — perplexity is $e^{0.5} \\approx 1.65$ for Python vs $e^{1.8} \\approx 6.05$ for Haskell, meaning the model is ~3.7× more uncertain per token on Haskell",
-        "The Haskell tokenizer is broken",
-        "The Python test set is smaller"
-      ],
-      correct: 1,
+      options: ["Python is a better language than Haskell", "The Python test set is smaller", "The Haskell tokenizer is broken", "The model has learned far more predictable structure in Python — perplexity is $e^{0.5} \\approx 1.65$ for Python vs $e^{1.8} \\approx 6.05$ for Haskell, meaning the model is ~3.7× more uncertain per token on Haskell"],
+      correct: 3,
       explanation: "Perplexity $= e^{H(P,Q)}$. Lower cross-entropy → lower perplexity → more predictable. The ratio $e^{1.8}/e^{0.5} = e^{1.3} \\approx 3.67$ means the model's uncertainty per token is 3.7× higher on Haskell. This could reflect: less Haskell in training data, Haskell's inherently different structure, or poor tokenization. The information-theoretic view lets you decompose the loss into data entropy + model deficiency."
     },
     {
       type: "mc",
       question: "**Reward hacking** in RLHF occurs when the policy finds outputs that score high reward but are low-quality. From an information-theoretic perspective, this happens because:",
-      options: [
-        "The reward model has high entropy",
-        "The reward model is a learned approximation — as $\\pi$ moves far from $\\pi_{\\text{ref}}$ (high KL), it enters out-of-distribution regions where the reward model's predictions are unreliable, effectively exploiting the reward model's epistemic uncertainty",
-        "The KL penalty is too large",
-        "The vocabulary is too small"
-      ],
-      correct: 1,
+      options: ["The reward model has high entropy", "The KL penalty is too large", "The reward model is a learned approximation — as $\\pi$ moves far from $\\pi_{\\text{ref}}$ (high KL), it enters out-of-distribution regions where the reward model's predictions are unreliable, effectively exploiting the reward model's epistemic uncertainty", "The vocabulary is too small"],
+      correct: 2,
       explanation: "The reward model $r_\\phi$ was trained on data from $\\pi_{\\text{ref}}$. When $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is large, $\\pi$ generates text unlike anything the reward model saw during training. The reward model's predictions become meaningless — it may assign high scores to adversarial outputs. This is why the KL penalty is crucial: it keeps $\\pi$ in the region where $r_\\phi$ is calibrated. This is a distributional shift problem quantified by KL divergence."
     },
     {
       type: "mc",
       question: "During fine-tuning, you notice the model's **token-level entropy** $H(P_\\theta(\\cdot \\mid x))$ dropping rapidly. The attention entropy (entropy of attention weights) is also collapsing. This likely indicates:",
-      options: [
-        "The model is learning perfectly",
-        "The model is **overfitting and losing diversity** — it's becoming overconfident on training patterns, potentially memorizing rather than generalizing. Entropy collapse in attention means it's attending to fewer positions, losing contextual flexibility",
-        "The learning rate is too low",
-        "The model needs a larger vocabulary"
-      ],
-      correct: 1,
+      options: ["The model is **overfitting and losing diversity** — it's becoming overconfident on training patterns, potentially memorizing rather than generalizing. Entropy collapse in attention means it's attending to fewer positions, losing contextual flexibility", "The model is learning perfectly", "The learning rate is too low", "The model needs a larger vocabulary"],
+      correct: 0,
       explanation: "Entropy collapse is a warning sign: the model assigns near-deterministic predictions and attends to very few positions. Low output entropy means the model \"thinks\" it's very certain — but on new inputs, this overconfidence leads to poor calibration and repetitive/degenerate outputs. Monitoring entropy during training is an information-theoretic diagnostic: healthy training should reduce entropy gradually (learning structure) without collapsing it (losing flexibility)."
     },
     {
@@ -102,25 +77,15 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "In the **information bottleneck** framework, a representation $Z$ of input $X$ is optimized to maximize $I(Z; Y)$ (task-relevant information) while minimizing $I(Z; X)$ (total information retained). In the context of LLM representations, this means:",
-      options: [
-        "Layers should memorize all input details",
-        "Good representations should **compress away irrelevant details of the input** while retaining information needed for prediction — the $\\beta$ parameter controls this trade-off, analogous to the KL penalty in RLHF",
-        "All layers should have the same mutual information with the input",
-        "The output should be independent of the input"
-      ],
-      correct: 1,
+      options: ["Layers should memorize all input details", "The output should be independent of the input", "All layers should have the same mutual information with the input", "Good representations should **compress away irrelevant details of the input** while retaining information needed for prediction — the $\\beta$ parameter controls this trade-off, analogous to the KL penalty in RLHF"],
+      correct: 3,
       explanation: "The IB objective $\\max_{p(z|x)} I(Z; Y) - \\beta I(Z; X)$ formalizes the compression/prediction trade-off. Small $\\beta$ keeps all information (overfitting); large $\\beta$ compresses aggressively (underfitting). This framework connects to: dropout (random compression), bottleneck layers (architectural compression), and the KL penalty in RLHF (behavioral compression). The parallel to $\\max \\mathbb{E}[r] - \\beta \\text{KL}$ is exact in structure."
     },
     {
       type: "mc",
       question: "When computing $\\log P(y \\mid x)$ for a long sequence $y = (y_1, \\dots, y_T)$, numerical issues arise because the log-probability is a sum of $T$ negative terms that can become very negative. The standard solution is:",
-      options: [
-        "Clipping the log-probabilities to a minimum value",
-        "Working in **log-space throughout** — using the log-sum-exp trick for normalization and accumulating log-probabilities additively, which is numerically stable and avoids underflow from multiplying many small probabilities",
-        "Using float64 instead of float32",
-        "Truncating sequences to a maximum length"
-      ],
-      correct: 1,
+      options: ["Clipping the log-probabilities to a minimum value", "Using float64 instead of float32", "Working in **log-space throughout** — using the log-sum-exp trick for normalization and accumulating log-probabilities additively, which is numerically stable and avoids underflow from multiplying many small probabilities", "Truncating sequences to a maximum length"],
+      correct: 2,
       explanation: "Direct computation of $P(y|x) = \\prod_t P(y_t | y_{<t}, x)$ would underflow to zero for long sequences (multiplying many numbers < 1). Instead, we compute $\\log P(y|x) = \\sum_t \\log P(y_t | y_{<t}, x)$, keeping everything in log-space. The log-sum-exp trick $\\log \\sum_i e^{a_i} = A + \\log \\sum_i e^{a_i - A}$ (where $A = \\max_i a_i$) handles the softmax normalization. This is a universal pattern: always work in log-probability space."
     }
   ]

--- a/src/modules/prob-assessment-bayesian.js
+++ b/src/modules/prob-assessment-bayesian.js
@@ -18,13 +18,8 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "Bayes' theorem states $P(\\theta \\mid \\mathcal{D}) = \\frac{P(\\mathcal{D} \\mid \\theta) P(\\theta)}{P(\\mathcal{D})}$. The denominator $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ is called the **evidence** or **marginal likelihood**. Why is it typically intractable?",
-      options: [
-        "Because $P(\\mathcal{D} \\mid \\theta)$ is unknown",
-        "Because the integral is over the entire parameter space, which is high-dimensional for neural networks — making it impossible to evaluate analytically or numerically",
-        "Because the prior $P(\\theta)$ is always improper",
-        "Because the data $\\mathcal{D}$ is too large"
-      ],
-      correct: 1,
+      options: ["Because $P(\\mathcal{D} \\mid \\theta)$ is unknown", "Because the data $\\mathcal{D}$ is too large", "Because the prior $P(\\theta)$ is always improper", "Because the integral is over the entire parameter space, which is high-dimensional for neural networks — making it impossible to evaluate analytically or numerically"],
+      correct: 3,
       explanation: "For a neural network with millions of parameters, $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ requires integrating over a million-dimensional space. This integral has no closed form (the likelihood is a complex nonlinear function of $\\theta$) and is too high-dimensional for numerical quadrature. This intractability motivates both MCMC (sampling) and variational inference (optimization) as approximation strategies."
     },
     {
@@ -42,37 +37,22 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "The **ELBO** (Evidence Lower Bound) is $\\mathcal{L}(q) = \\mathbb{E}_q[\\log P(\\mathcal{D} \\mid \\theta)] - \\text{KL}(q(\\theta) \\| P(\\theta))$. Why is it called a \"lower bound\"?",
-      options: [
-        "Because it lower-bounds the KL divergence",
-        "Because $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q \\| P(\\theta \\mid \\mathcal{D})) \\geq \\mathcal{L}(q)$, since KL $\\geq 0$ — so the ELBO lower-bounds the log-evidence",
-        "Because the expected log-likelihood is always negative",
-        "Because the prior term is always a penalty"
-      ],
-      correct: 1,
+      options: ["Because $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q \\| P(\\theta \\mid \\mathcal{D})) \\geq \\mathcal{L}(q)$, since KL $\\geq 0$ — so the ELBO lower-bounds the log-evidence", "Because it lower-bounds the KL divergence", "Because the expected log-likelihood is always negative", "Because the prior term is always a penalty"],
+      correct: 0,
       explanation: "We can decompose: $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q(\\theta) \\| P(\\theta \\mid \\mathcal{D}))$. Since KL is always $\\geq 0$, we get $\\log P(\\mathcal{D}) \\geq \\mathcal{L}(q)$. Maximizing the ELBO simultaneously (1) tightens the bound on the evidence, and (2) minimizes $\\text{KL}(q \\| P(\\theta \\mid \\mathcal{D}))$, making $q$ a better posterior approximation. The ELBO equals the evidence when $q$ equals the true posterior."
     },
     {
       type: "mc",
       question: "In the VAE (Variational Autoencoder), the ELBO for a single datapoint is $\\mathcal{L}(x) = \\mathbb{E}_{q(z|x)}[\\log p(x \\mid z)] - \\text{KL}(q(z \\mid x) \\| p(z))$. The two terms correspond to:",
-      options: [
-        "Accuracy and speed",
-        "**Reconstruction** (how well can we decode $z$ back to $x$) and **regularization** (how close is the encoder's posterior to the prior)",
-        "Training loss and validation loss",
-        "Bias and variance of the model"
-      ],
-      correct: 1,
+      options: ["Accuracy and speed", "Training loss and validation loss", "**Reconstruction** (how well can we decode $z$ back to $x$) and **regularization** (how close is the encoder's posterior to the prior)", "Bias and variance of the model"],
+      correct: 2,
       explanation: "The first term $\\mathbb{E}_{q(z|x)}[\\log p(x|z)]$ encourages accurate reconstruction — $z$ must contain enough information to reproduce $x$. The second term $\\text{KL}(q(z|x) \\| p(z))$ regularizes the latent space, pushing $q(z|x)$ toward the prior $p(z) = \\mathcal{N}(0, I)$. The tension between these creates a learned compression: encode enough to reconstruct, but stay close to a simple prior."
     },
     {
       type: "mc",
       question: "The **reparameterization trick** in VAEs writes $z = \\mu(x) + \\sigma(x) \\odot \\epsilon$ where $\\epsilon \\sim \\mathcal{N}(0, I)$. Why is this needed?",
-      options: [
-        "To make the latent space continuous",
-        "To move the stochasticity outside the computational graph, enabling backpropagation through the sampling operation via the deterministic path $\\mu(x)$ and $\\sigma(x)$",
-        "To ensure $z$ follows a Gaussian distribution",
-        "To reduce the dimensionality of $z$"
-      ],
-      correct: 1,
+      options: ["To make the latent space continuous", "To reduce the dimensionality of $z$", "To ensure $z$ follows a Gaussian distribution", "To move the stochasticity outside the computational graph, enabling backpropagation through the sampling operation via the deterministic path $\\mu(x)$ and $\\sigma(x)$"],
+      correct: 3,
       explanation: "You can't backpropagate through a random sampling operation $z \\sim q(z|x)$. The reparameterization trick rewrites this as a deterministic function of learned parameters ($\\mu, \\sigma$) plus fixed noise ($\\epsilon$). Now gradients flow through $\\mu$ and $\\sigma$ to the encoder. This same idea (making gradients flow through stochastic operations) appears in policy gradient methods and Gumbel-softmax for discrete distributions."
     },
     {
@@ -102,25 +82,15 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "**Bayesian model comparison** uses the evidence $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta, M) P(\\theta \\mid M) d\\theta$ to compare models $M_1$ and $M_2$ via the Bayes factor $\\frac{P(\\mathcal{D} \\mid M_1)}{P(\\mathcal{D} \\mid M_2)}$. How does this naturally implement Occam's razor?",
-      options: [
-        "It penalizes models with more parameters through an explicit penalty term",
-        "Complex models spread their prior mass over many possible datasets, so they assign lower prior probability to any specific dataset — the evidence automatically balances fit and complexity",
-        "It uses cross-validation internally",
-        "It selects the model with the highest likelihood on the training data"
-      ],
-      correct: 1,
+      options: ["It penalizes models with more parameters through an explicit penalty term", "It uses cross-validation internally", "Complex models spread their prior mass over many possible datasets, so they assign lower prior probability to any specific dataset — the evidence automatically balances fit and complexity", "It selects the model with the highest likelihood on the training data"],
+      correct: 2,
       explanation: "A complex model can fit many possible datasets but must spread its prior predictive probability $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ thinly over all of them. A simple model concentrates its probability on fewer datasets but assigns higher probability to those. The evidence thus naturally penalizes unnecessary complexity — no regularization parameter needed. This is called the \"Bayesian Occam's razor.\""
     },
     {
       type: "mc",
       question: "**Amortized inference** (as in VAEs) trains an encoder $q_\\phi(z \\mid x)$ to approximate the posterior for any $x$, rather than optimizing $q$ separately for each $x$. The key advantage is:",
-      options: [
-        "It guarantees exact posterior inference",
-        "After training, inference for a new $x$ is a single forward pass through the encoder — no iterative optimization needed. This trades per-datapoint optimality for speed",
-        "It eliminates the need for the ELBO",
-        "It makes the posterior always Gaussian"
-      ],
-      correct: 1,
+      options: ["It guarantees exact posterior inference", "It makes the posterior always Gaussian", "It eliminates the need for the ELBO", "After training, inference for a new $x$ is a single forward pass through the encoder — no iterative optimization needed. This trades per-datapoint optimality for speed"],
+      correct: 3,
       explanation: "Traditional VI optimizes $q(z)$ separately per datapoint (expensive). Amortized inference learns a single function $q_\\phi(z|x)$ (the encoder) that maps any $x$ to an approximate posterior in one forward pass. The trade-off: the \"amortization gap\" — the shared encoder may not be as good as per-datapoint optimization. But the speedup (one pass vs. iterative optimization) makes it practical for large datasets."
     }
   ]

--- a/src/modules/prob-assessment-concentration.js
+++ b/src/modules/prob-assessment-concentration.js
@@ -18,13 +18,8 @@ export const concentrationAssessment = {
     {
       type: "mc",
       question: "**Markov's inequality** states that for a non-negative random variable $X$ and $a > 0$: $P(X \\geq a) \\leq \\frac{\\mathbb{E}[X]}{a}$. This bound is:",
-      options: [
-        "Tight for all distributions",
-        "Very loose in general (it only uses the mean), but important because it requires minimal assumptions — just non-negativity",
-        "Only valid for Gaussian distributions",
-        "Tighter than Chebyshev's inequality"
-      ],
-      correct: 1,
+      options: ["Very loose in general (it only uses the mean), but important because it requires minimal assumptions — just non-negativity", "Tight for all distributions", "Only valid for Gaussian distributions", "Tighter than Chebyshev's inequality"],
+      correct: 0,
       explanation: "Markov's inequality is the weakest but most general bound — it only requires $X \\geq 0$ and finite mean. It's rarely used directly because it's very loose, but it's the foundation from which all stronger bounds are derived (Chebyshev applies Markov to $(X - \\mu)^2$, Chernoff applies Markov to $e^{tX}$). Its value is conceptual: it shows that heavy-tailed behavior is constrained by the mean."
     },
     {
@@ -54,49 +49,29 @@ export const concentrationAssessment = {
     {
       type: "mc",
       question: "A random variable $X$ is **sub-Gaussian** with parameter $\\sigma$ if $\\mathbb{E}[e^{t(X - \\mu)}] \\leq e^{\\sigma^2 t^2 / 2}$ for all $t$. Why is the sub-Gaussian property important in deep learning?",
-      options: [
-        "All neural network weights are sub-Gaussian",
-        "It implies exponential tail concentration $P(|X - \\mu| \\geq t) \\leq 2e^{-t^2/(2\\sigma^2)}$, which applies to bounded random variables, Gaussian variables, and sums thereof — covering most quantities we care about in training and evaluation",
-        "It guarantees convergence of SGD",
-        "It means the distribution is exactly Gaussian"
-      ],
-      correct: 1,
+      options: ["All neural network weights are sub-Gaussian", "It guarantees convergence of SGD", "It implies exponential tail concentration $P(|X - \\mu| \\geq t) \\leq 2e^{-t^2/(2\\sigma^2)}$, which applies to bounded random variables, Gaussian variables, and sums thereof — covering most quantities we care about in training and evaluation", "It means the distribution is exactly Gaussian"],
+      correct: 2,
       explanation: "Sub-Gaussianity is a tail condition: the tails decay at least as fast as a Gaussian with variance $\\sigma^2$. Bounded variables ($[a,b]$) are sub-Gaussian with $\\sigma = (b-a)/2$, and sums of sub-Gaussians are sub-Gaussian. This covers sample means, bounded losses, and many gradient estimators. The tail bound gives sharp concentration — the foundation for PAC-Bayes bounds, uniform convergence, and confidence intervals."
     },
     {
       type: "mc",
       question: "In SGD, the gradient estimate $g = \\nabla L(x_i; \\theta)$ for a random mini-batch is an unbiased estimator of $\\nabla L(\\theta)$. The **variance** of this estimate relates to concentration via:",
-      options: [
-        "Higher variance means faster convergence due to exploration",
-        "Gradient variance $\\text{Var}(g)$ scales as $\\sigma^2_g / B$ for batch size $B$ — doubling batch size halves the variance but also halves the number of parameter updates per epoch",
-        "Variance is irrelevant because SGD converges regardless",
-        "Variance only matters for the final few iterations"
-      ],
-      correct: 1,
+      options: ["Higher variance means faster convergence due to exploration", "Variance only matters for the final few iterations", "Variance is irrelevant because SGD converges regardless", "Gradient variance $\\text{Var}(g)$ scales as $\\sigma^2_g / B$ for batch size $B$ — doubling batch size halves the variance but also halves the number of parameter updates per epoch"],
+      correct: 3,
       explanation: "The mini-batch gradient is a sample mean, so $\\text{Var}(\\bar{g}_B) = \\sigma^2_g / B$. This means larger batches give more concentrated (less noisy) gradient estimates. But the total computation is $B \\times \\text{updates}$, and doubling $B$ halves updates per epoch. The \"critical batch size\" is where further increases in $B$ no longer improve wall-clock convergence — below this, gradient noise is too high; above it, you're wasting compute on variance reduction that doesn't help."
     },
     {
       type: "mc",
       question: "**McDiarmid's inequality** generalizes Hoeffding to functions of independent variables: if changing any one input $x_i$ changes $f(x_1, \\ldots, x_n)$ by at most $c_i$, then $P(f - \\mathbb{E}[f] \\geq t) \\leq \\exp\\left(-\\frac{2t^2}{\\sum_i c_i^2}\\right)$. This is useful in ML for bounding:",
-      options: [
-        "The training loss only",
-        "The **generalization gap** — since train/test metrics are functions of i.i.d. data points, and changing one datapoint has bounded effect (bounded differences), McDiarmid gives exponential concentration of empirical risk around its expectation",
-        "The norm of the weight matrix",
-        "The number of epochs needed"
-      ],
-      correct: 1,
+      options: ["The **generalization gap** — since train/test metrics are functions of i.i.d. data points, and changing one datapoint has bounded effect (bounded differences), McDiarmid gives exponential concentration of empirical risk around its expectation", "The training loss only", "The norm of the weight matrix", "The number of epochs needed"],
+      correct: 0,
       explanation: "The empirical risk $\\hat{R} = \\frac{1}{n} \\sum_i L(f(x_i), y_i)$ is a function of $n$ i.i.d. data points. Changing one point changes $\\hat{R}$ by at most $c_i = M/n$ (if the loss is bounded by $M$). McDiarmid gives $P(|\\hat{R} - R| \\geq t) \\leq 2e^{-2nt^2/M^2}$. This is a key ingredient in VC theory and PAC learning bounds."
     },
     {
       type: "mc",
       question: "The **Chernoff bound** technique optimizes over the parameter in the moment generating function: $P(X \\geq a) \\leq \\min_{t > 0} e^{-ta} \\mathbb{E}[e^{tX}]$. This gives the **tightest exponential bound** because:",
-      options: [
-        "It uses all moments of the distribution simultaneously (through the MGF), not just the mean or variance — the optimization over $t$ selects the tightest exponential rate for each specific tail probability",
-        "It only requires the mean",
-        "It works for any distribution including heavy-tailed ones",
-        "It is always tighter than the exact probability"
-      ],
-      correct: 0,
+      options: ["It only requires the mean", "It uses all moments of the distribution simultaneously (through the MGF), not just the mean or variance — the optimization over $t$ selects the tightest exponential rate for each specific tail probability", "It works for any distribution including heavy-tailed ones", "It is always tighter than the exact probability"],
+      correct: 1,
       explanation: "The Chernoff method applies Markov's inequality to $e^{tX}$ for any $t > 0$, then optimizes over $t$. Since $\\mathbb{E}[e^{tX}]$ encodes all moments (via Taylor expansion: $\\sum_k t^k \\mathbb{E}[X^k]/k!$), the optimization over $t$ extracts the best exponential bound the moment information can provide. For sub-Gaussian and sub-exponential variables, this gives sharp rates. It fails for truly heavy-tailed distributions where the MGF doesn't exist."
     },
     {

--- a/src/modules/prob-assessment-divergences.js
+++ b/src/modules/prob-assessment-divergences.js
@@ -30,37 +30,22 @@ export const divergencesAssessment = {
     {
       type: "mc",
       question: "In RLHF, the objective is $\\max_\\pi \\mathbb{E}_{\\pi}[r(x)] - \\beta \\, \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$. The KL term $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is **forward KL** from $\\pi$ to $\\pi_{\\text{ref}}$. What behavior does this penalty enforce?",
-      options: [
-        "It forces $\\pi$ to match a single mode of $\\pi_{\\text{ref}}$",
-        "Wherever $\\pi$ places probability mass, $\\pi_{\\text{ref}}$ must also have mass — preventing $\\pi$ from generating text that $\\pi_{\\text{ref}}$ considers highly unlikely",
-        "It ensures $\\pi_{\\text{ref}}$ covers all modes of $\\pi$",
-        "It minimizes the entropy of $\\pi$"
-      ],
-      correct: 1,
+      options: ["Wherever $\\pi$ places probability mass, $\\pi_{\\text{ref}}$ must also have mass — preventing $\\pi$ from generating text that $\\pi_{\\text{ref}}$ considers highly unlikely", "It forces $\\pi$ to match a single mode of $\\pi_{\\text{ref}}$", "It ensures $\\pi_{\\text{ref}}$ covers all modes of $\\pi$", "It minimizes the entropy of $\\pi$"],
+      correct: 0,
       explanation: "$\\text{KL}(\\pi \\| \\pi_{\\text{ref}}) = \\mathbb{E}_\\pi[\\log \\pi / \\pi_{\\text{ref}}]$ — the expectation is under $\\pi$. If $\\pi(x) > 0$ but $\\pi_{\\text{ref}}(x) \\approx 0$, the ratio explodes. So $\\pi$ is penalized for putting mass where the reference doesn't. This prevents \"reward hacking\" — generating text that scores high reward but is completely unlike natural text."
     },
     {
       type: "mc",
       question: "The **Jensen-Shannon divergence** $\\text{JS}(P \\| Q) = \\frac{1}{2}\\text{KL}(P \\| M) + \\frac{1}{2}\\text{KL}(Q \\| M)$ where $M = \\frac{1}{2}(P + Q)$ has which advantages over KL?",
-      options: [
-        "It is always larger than KL divergence",
-        "It is symmetric, bounded ($0 \\leq \\text{JS} \\leq \\log 2$), and well-defined even when supports don't fully overlap",
-        "It is easier to compute than KL",
-        "It converges faster during training"
-      ],
-      correct: 1,
+      options: ["It is always larger than KL divergence", "It is easier to compute than KL", "It is symmetric, bounded ($0 \\leq \\text{JS} \\leq \\log 2$), and well-defined even when supports don't fully overlap", "It converges faster during training"],
+      correct: 2,
       explanation: "JS divergence is symmetric ($\\text{JS}(P\\|Q) = \\text{JS}(Q\\|P)$), bounded by $\\log 2$, and always finite even when $P$ and $Q$ have disjoint support (because $M$ covers both). Its square root is a true metric. The original GAN objective minimizes JS divergence, but the bounded/finite property actually causes problems (vanishing gradients when $P$ and $Q$ are far apart)."
     },
     {
       type: "mc",
       question: "**Reverse KL** $\\text{KL}(Q \\| P)$ is called \"mode-seeking\" because when fitting $Q$ to a multimodal $P$:",
-      options: [
-        "$Q$ covers all modes of $P$ uniformly",
-        "$Q$ tends to concentrate on a single mode of $P$, fitting it precisely while ignoring others",
-        "$Q$ places mass only between modes",
-        "$Q$ becomes uniform regardless of $P$"
-      ],
-      correct: 1,
+      options: ["$Q$ covers all modes of $P$ uniformly", "$Q$ becomes uniform regardless of $P$", "$Q$ places mass only between modes", "$Q$ tends to concentrate on a single mode of $P$, fitting it precisely while ignoring others"],
+      correct: 3,
       explanation: "In reverse KL, the expectation is under $Q$: $\\mathbb{E}_Q[\\log Q/P]$. If $Q$ places mass where $P(x) \\approx 0$, $\\log(Q/P) \\to \\infty$, so $Q$ avoids regions where $P$ is small. But $Q$ pays no penalty for *ignoring* modes of $P$ (since it doesn't sample there). So $Q$ \"seeks\" a single mode and fits it tightly. This is the behavior of variational inference with reverse KL."
     },
     {
@@ -78,49 +63,29 @@ export const divergencesAssessment = {
     {
       type: "mc",
       question: "The **total variation distance** $\\text{TV}(P, Q) = \\frac{1}{2} \\sum_x |P(x) - Q(x)|$ relates to KL divergence through **Pinsker's inequality**:",
-      options: [
-        "$\\text{TV}(P, Q) \\leq \\text{KL}(P \\| Q)$",
-        "$\\text{TV}(P, Q) \\leq \\sqrt{\\frac{1}{2} \\text{KL}(P \\| Q)}$",
-        "$\\text{KL}(P \\| Q) \\leq \\text{TV}(P, Q)$",
-        "$\\text{TV}(P, Q) = \\text{KL}(P \\| Q)$ always"
-      ],
-      correct: 1,
+      options: ["$\\text{TV}(P, Q) \\leq \\sqrt{\\frac{1}{2} \\text{KL}(P \\| Q)}$", "$\\text{TV}(P, Q) \\leq \\text{KL}(P \\| Q)$", "$\\text{KL}(P \\| Q) \\leq \\text{TV}(P, Q)$", "$\\text{TV}(P, Q) = \\text{KL}(P \\| Q)$ always"],
+      correct: 0,
       explanation: "Pinsker's inequality: $\\text{TV}(P, Q) \\leq \\sqrt{\\frac{1}{2} \\text{KL}(P \\| Q)}$. This means small KL implies small TV, but not vice versa — TV can be small while KL is large (when the ratio $P/Q$ is extreme in regions with small mass). This inequality is fundamental in PAC-Bayes bounds and differential privacy proofs."
     },
     {
       type: "mc",
       question: "When two distributions $P$ and $Q$ have **disjoint supports** (no overlap), what happens to KL divergence, JS divergence, and total variation?",
-      options: [
-        "All three are zero",
-        "KL is undefined ($\\infty$), JS = $\\log 2$ (finite), TV = 1 (maximum)",
-        "All three are infinite",
-        "KL is finite, JS is infinite, TV = 0"
-      ],
-      correct: 1,
+      options: ["All three are zero", "All three are infinite", "KL is undefined ($\\infty$), JS = $\\log 2$ (finite), TV = 1 (maximum)", "KL is finite, JS is infinite, TV = 0"],
+      correct: 2,
       explanation: "With disjoint supports: KL is $+\\infty$ (dividing by zero in the log-ratio), JS is $\\log 2$ (its maximum, finite value), and TV is 1 (its maximum). This is why JS is preferred in some contexts — it gracefully handles non-overlapping distributions. However, this bounded behavior means JS gradients vanish when distributions are far apart, which was the original GAN training problem solved by Wasserstein distance."
     },
     {
       type: "mc",
       question: "The **f-divergence** framework defines $D_f(P \\| Q) = \\mathbb{E}_Q[f(P(x)/Q(x))]$ for convex $f$ with $f(1) = 0$. The **variational representation** $D_f(P \\| Q) = \\sup_T \\{\\mathbb{E}_P[T(x)] - \\mathbb{E}_Q[f^*(T(x))]\\}$ (where $f^*$ is the Fenchel conjugate) is important because:",
-      options: [
-        "It allows exact computation of any f-divergence",
-        "It converts divergence estimation into an optimization problem that a neural network (discriminator/critic) can solve — this is the foundation of f-GANs",
-        "It proves all f-divergences are equal",
-        "It eliminates the need for density ratio estimation"
-      ],
-      correct: 1,
+      options: ["It allows exact computation of any f-divergence", "It eliminates the need for density ratio estimation", "It proves all f-divergences are equal", "It converts divergence estimation into an optimization problem that a neural network (discriminator/critic) can solve — this is the foundation of f-GANs"],
+      correct: 3,
       explanation: "The variational representation turns f-divergence computation into a supremum over functions $T$ — which a neural network can approximate. The original GAN uses this for JS divergence (where $T$ is the discriminator), and f-GANs generalize this to arbitrary f-divergences. This is a powerful trick: you never need to know the density ratio explicitly; instead, you train a network to estimate it."
     },
     {
       type: "mc",
       question: "In DPO (Direct Preference Optimization), the loss involves $\\log \\frac{\\pi_\\theta(y_w \\mid x)}{\\pi_{\\text{ref}}(y_w \\mid x)} - \\log \\frac{\\pi_\\theta(y_l \\mid x)}{\\pi_{\\text{ref}}(y_l \\mid x)}$ where $y_w$ is preferred over $y_l$. The log-ratios $\\log \\frac{\\pi_\\theta}{\\pi_{\\text{ref}}}$ are called **implicit rewards**. This formulation implicitly uses which divergence concept?",
-      options: [
-        "The density ratio $\\pi_\\theta / \\pi_{\\text{ref}}$ that appears in KL divergence — DPO reparameterizes the RLHF objective's KL-constrained optimization into a supervised loss using the closed-form solution involving log-ratios",
-        "Jensen-Shannon divergence between preferred and dispreferred completions",
-        "Total variation distance between old and new policies",
-        "Wasserstein distance in token space"
-      ],
-      correct: 0,
+      options: ["Jensen-Shannon divergence between preferred and dispreferred completions", "The density ratio $\\pi_\\theta / \\pi_{\\text{ref}}$ that appears in KL divergence — DPO reparameterizes the RLHF objective's KL-constrained optimization into a supervised loss using the closed-form solution involving log-ratios", "Total variation distance between old and new policies", "Wasserstein distance in token space"],
+      correct: 1,
       explanation: "DPO derives from the RLHF objective $\\max_\\pi \\mathbb{E}[r(x)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, whose closed-form solution is $\\pi^*(y \\mid x) \\propto \\pi_{\\text{ref}}(y \\mid x) \\exp(r(y,x)/\\beta)$. Rearranging gives $r(y,x) = \\beta \\log \\frac{\\pi^*(y \\mid x)}{\\pi_{\\text{ref}}(y \\mid x)} + \\text{const}$. DPO substitutes this into the Bradley-Terry preference model, yielding a supervised loss that implicitly optimizes the KL-constrained objective."
     }
   ]

--- a/src/modules/prob-assessment-entropy.js
+++ b/src/modules/prob-assessment-entropy.js
@@ -18,37 +18,22 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "The **entropy** $H(X) = -\\sum_x p(x) \\log p(x)$ of a discrete random variable is maximized when:",
-      options: [
-        "The distribution is concentrated on a single outcome (deterministic)",
-        "The distribution is uniform over all outcomes",
-        "The distribution is Gaussian",
-        "The distribution has the largest possible support"
-      ],
-      correct: 1,
+      options: ["The distribution is concentrated on a single outcome (deterministic)", "The distribution has the largest possible support", "The distribution is Gaussian", "The distribution is uniform over all outcomes"],
+      correct: 3,
       explanation: "For a discrete variable with $K$ outcomes, entropy is maximized at $H = \\log K$ when $p(x) = 1/K$ (uniform). Any deviation from uniform reduces entropy. Intuitively, entropy measures uncertainty — maximum uncertainty means every outcome is equally likely. This is why temperature scaling in LLMs (which pushes the distribution toward uniform) increases entropy and diversity of outputs."
     },
     {
       type: "mc",
       question: "The **cross-entropy** $H(P, Q) = -\\mathbb{E}_P[\\log Q(x)]$ between the data distribution $P$ and model $Q$ relates to KL divergence and entropy as:",
-      options: [
-        "$H(P, Q) = H(P) - \\text{KL}(P \\| Q)$",
-        "$H(P, Q) = H(P) + \\text{KL}(P \\| Q)$",
-        "$H(P, Q) = \\text{KL}(P \\| Q) - H(P)$",
-        "$H(P, Q) = H(Q) + \\text{KL}(Q \\| P)$"
-      ],
-      correct: 1,
+      options: ["$H(P, Q) = H(P) - \\text{KL}(P \\| Q)$", "$H(P, Q) = \\text{KL}(P \\| Q) - H(P)$", "$H(P, Q) = H(P) + \\text{KL}(P \\| Q)$", "$H(P, Q) = H(Q) + \\text{KL}(Q \\| P)$"],
+      correct: 2,
       explanation: "$H(P, Q) = H(P) + \\text{KL}(P \\| Q)$. Since $H(P)$ is fixed (it depends only on the data), minimizing cross-entropy is equivalent to minimizing $\\text{KL}(P \\| Q)$. This is why cross-entropy loss works — it drives the model $Q$ toward the data distribution $P$ in the KL sense."
     },
     {
       type: "mc",
       question: "**Perplexity** of a language model on data $P$ is defined as $\\text{PPL} = 2^{H(P,Q)}$ (or $e^{H(P,Q)}$ in nats). A model with perplexity 50 on a vocabulary of 50,000 tokens means:",
-      options: [
-        "The model gets 50% of predictions correct",
-        "On average, the model is as uncertain as choosing uniformly among 50 equally likely tokens at each step",
-        "The model uses 50 bits per token",
-        "The vocabulary can be reduced to 50 tokens without loss"
-      ],
-      correct: 1,
+      options: ["On average, the model is as uncertain as choosing uniformly among 50 equally likely tokens at each step", "The model gets 50% of predictions correct", "The model uses 50 bits per token", "The vocabulary can be reduced to 50 tokens without loss"],
+      correct: 0,
       explanation: "Perplexity is the exponential of cross-entropy. A perplexity of 50 means the model's uncertainty is equivalent to choosing uniformly from 50 options. Lower perplexity = more confident = better model. A uniform model over 50K tokens would have perplexity 50,000. Getting from 50,000 to 50 represents learning enormous amounts of structure."
     },
     {
@@ -66,37 +51,22 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "**Conditional entropy** $H(X \\mid Y) = \\mathbb{E}_Y[H(X \\mid Y = y)]$. In the context of language modeling, $H(W_t \\mid W_{<t})$ represents:",
-      options: [
-        "The entropy of the vocabulary distribution",
-        "The average uncertainty about the next token given the context — the irreducible per-token loss for a perfect model",
-        "The probability of the most likely next token",
-        "The number of possible next tokens"
-      ],
-      correct: 1,
+      options: ["The entropy of the vocabulary distribution", "The number of possible next tokens", "The probability of the most likely next token", "The average uncertainty about the next token given the context — the irreducible per-token loss for a perfect model"],
+      correct: 3,
       explanation: "$H(W_t \\mid W_{<t})$ is the conditional entropy of the next token given all previous tokens. For a *perfect* model $Q = P$, the cross-entropy equals $H(P) = H(W_t \\mid W_{<t})$ — this is the irreducible uncertainty. No model can beat this bound. The gap between a model's cross-entropy and this quantity is exactly $\\text{KL}(P \\| Q)$."
     },
     {
       type: "mc",
       question: "The **data processing inequality** states that for a Markov chain $X \\to Y \\to Z$, we have $I(X; Z) \\leq I(X; Y)$. What does this imply for neural network representations?",
-      options: [
-        "Deeper layers always lose information about the input",
-        "Each layer can only preserve or lose information about the input — never create new information about it",
-        "The final layer has zero mutual information with the input",
-        "All layers must have equal mutual information with the input"
-      ],
-      correct: 1,
+      options: ["Deeper layers always lose information about the input", "The final layer has zero mutual information with the input", "Each layer can only preserve or lose information about the input — never create new information about it", "All layers must have equal mutual information with the input"],
+      correct: 2,
       explanation: "The data processing inequality says information can only be lost, never gained, through processing. If $X \\to \\text{layer}_1 \\to \\text{layer}_2$, then $I(X; \\text{layer}_2) \\leq I(X; \\text{layer}_1)$. This is the theoretical foundation of the **information bottleneck** view: good representations compress away irrelevant information while retaining information relevant to the task."
     },
     {
       type: "mc",
       question: "The **chain rule of mutual information** states $I(X; Y, Z) = I(X; Y) + I(X; Z \\mid Y)$. If a context window includes both recent tokens $Y$ and distant tokens $Z$, and $I(X; Z \\mid Y) \\approx 0$, this means:",
-      options: [
-        "Distant tokens are more important than recent tokens",
-        "Distant tokens provide no additional information about the next token beyond what recent tokens already provide",
-        "The model should ignore all context",
-        "Recent and distant tokens are independent of each other"
-      ],
-      correct: 1,
+      options: ["Distant tokens provide no additional information about the next token beyond what recent tokens already provide", "Distant tokens are more important than recent tokens", "The model should ignore all context", "Recent and distant tokens are independent of each other"],
+      correct: 0,
       explanation: "$I(X; Z \\mid Y) \\approx 0$ means that once you condition on recent context $Y$, distant context $Z$ adds negligible information about next token $X$. This does NOT mean $Z$ is independent of $Y$ — just that $Z$'s predictive value is already captured by $Y$. This relates to why many practical tasks work well with limited context, and why efficient attention methods that prioritize local context can work."
     },
     {
@@ -114,14 +84,44 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "When fine-tuning with **label smoothing** (mixing the hard target with a uniform distribution), the effective target becomes $P'(y) = (1 - \\alpha) \\cdot \\mathbf{1}[y = y^*] + \\alpha / K$. How does this affect the cross-entropy loss landscape?",
-      options: [
-        "It has no effect on training dynamics",
-        "It prevents the model from driving logits to $\\pm \\infty$ — the optimal logit gap becomes finite, acting as implicit regularization on confidence",
-        "It makes the model converge to a uniform distribution",
-        "It increases the entropy of the model to match the entropy of the smoothed labels"
-      ],
-      correct: 1,
+      options: ["It has no effect on training dynamics", "It increases the entropy of the model to match the entropy of the smoothed labels", "It makes the model converge to a uniform distribution", "It prevents the model from driving logits to $\\pm \\infty$ — the optimal logit gap becomes finite, acting as implicit regularization on confidence"],
+      correct: 3,
       explanation: "Without label smoothing, the optimal logits are $+\\infty$ for the correct class and $-\\infty$ for others. Label smoothing caps the optimal logit gap at a finite value (proportional to $\\log((1-\\alpha)K/\\alpha)$), preventing overconfident predictions. This acts as entropy regularization — the model's output entropy stays bounded away from zero, improving calibration and generalization."
+    },
+    {
+      type: "mc",
+      question: "A model's training cross-entropy loss converges to 2.5 nats per token but validation loss plateaus at 3.2 nats. What is the most informative interpretation?",
+      options: ["The model is underfitting — it needs more parameters to reduce training loss further", "The gap of 0.7 nats between train and val represents overfitting: the model memorizes training patterns that don't generalize, wasting capacity on spurious correlations", "The true entropy rate of the language is exactly 2.5 nats", "The validation set is from a different language or domain"],
+      correct: 1,
+      explanation: "The train-val gap (0.7 nats) indicates the model has memorized training-specific patterns. Training loss reflects both genuine language structure and training-set-specific memorization; the difference (generalization gap) quantifies the latter. The true entropy rate $H(P)$ is at most the validation loss (3.2 nats), since $H(P, Q_{\\text{val}}) = H(P) + \\text{KL}(P \\| Q)$ and KL is non-negative. The training loss can go below $H(P)$ precisely because of memorization."
+    },
+    {
+      type: "mc",
+      question: "You apply temperature scaling with $T = 2.0$ to a model's logits during inference. If the original top-1 probability was 0.95, approximately what will it become?",
+      options: ["$0.95 / 2 = 0.475$ — probabilities scale linearly with temperature", "Still close to 0.95 — temperature only affects low-probability tokens", "Significantly reduced (roughly $0.95^{1/2} \\approx 0.87$ to $0.90$, depending on logit structure) — dividing logits by 2 compresses them toward zero, spreading mass to other tokens", "Exactly $0.5$ — doubling temperature always halves the top probability"],
+      correct: 2,
+      explanation: "Temperature scaling divides logits by $T$ before softmax. If the top logit was much larger than others (giving 0.95), dividing by 2 halves the logit gap, spreading probability to other tokens. The exact new probability depends on the logit distribution, but for a sharply peaked distribution going from $T=1$ to $T=2$ typically reduces the top probability noticeably. The relationship is NOT linear in $T$ — it goes through the softmax nonlinearity."
+    },
+    {
+      type: "mc",
+      question: "In contrastive learning (e.g., SimCLR), why does using a very small batch size (e.g., 32) limit performance even with longer training?",
+      options: ["Small batches cause gradient noise that prevents convergence", "The InfoNCE bound on MI is $\\log N$ where $N$ is batch size — a batch of 32 can estimate at most $\\log_2(32) = 5$ bits of MI, regardless of training duration", "Small batches cause mode collapse in the representation space", "Small batches violate the i.i.d. assumption required for contrastive learning"],
+      correct: 1,
+      explanation: "The InfoNCE loss provides a lower bound: $I(X;Y) \\geq \\log N - \\mathcal{L}$. Even if the loss reaches 0, you can only estimate $\\log N$ bits of MI. With batch size 32: $\\log_2(32) = 5$ bits maximum. If the true MI between views is much higher, this ceiling prevents the model from learning fine-grained distinctions. This is why CLIP uses batch sizes of 32K+ ($\\log_2(32768) \\approx 15$ bits) — it raises the MI ceiling, enabling richer representations."
+    },
+    {
+      type: "mc",
+      question: "For a Markov chain $X \\to Y \\to Z$, when does $I(X; Z) = I(X; Y)$ (equality in the data processing inequality)?",
+      options: ["When $Z$ is a higher-dimensional version of $Y$ (e.g., zero-padding)", "When $Z$ is a sufficient statistic of $Y$ for $X$ — meaning $X \\to Z \\to Y$ is also a valid Markov chain, so no information about $X$ is lost", "Equality never holds — processing always loses some information", "Only when $Y = Z$ (the identity mapping)"],
+      correct: 1,
+      explanation: "DPI gives equality when $Z$ retains all information that $Y$ has about $X$, formally when $Z$ is a sufficient statistic of $Y$ for $X$. This means $P(X \\mid Y) = P(X \\mid Z)$ — knowing $Z$ is just as good as knowing $Y$ for predicting $X$. An invertible transformation $Z = g(Y)$ trivially satisfies this (since $Y$ can be recovered from $Z$), but sufficiency is the general condition. Identity is sufficient but not necessary."
+    },
+    {
+      type: "mc",
+      question: "A language model trained on English text achieves perplexity 8.0. Shannon estimated English entropy at ~1.3 bits/char, and BPE tokens average ~4 chars. How does this model compare to the theoretical limit?",
+      options: ["The model has nearly reached the entropy limit — $\\log_2(8) = 3$ bits/token vs theoretical ~$4 \\times 1.3 = 5.2$ bits/token, actually beating it because the tokenizer absorbs spelling redundancy", "The model is far above the limit — perplexity 8 is very high", "The comparison is invalid because Shannon's estimate is per character, not per token", "The model exactly matches the entropy limit"],
+      correct: 0,
+      explanation: "At perplexity 8: cross-entropy $= \\log_2(8) = 3$ bits/token. Shannon's character-level entropy rate (~1.3 bits/char) times ~4 chars/token gives ~5.2 bits/token as a crude token-level estimate. But BPE tokenization already encodes spelling patterns (absorbing ~1-2 bits/char of redundancy), so the effective per-token entropy limit is lower than 5.2 bits. The model at 3 bits/token is performing well, suggesting it captures most of the remaining (post-tokenization) statistical structure."
     }
   ]
 };

--- a/src/modules/prob-assessment-exponential-family.js
+++ b/src/modules/prob-assessment-exponential-family.js
@@ -18,25 +18,15 @@ export const exponentialFamilyAssessment = {
     {
       type: "mc",
       question: "An exponential family distribution has the form $p(x \\mid \\theta) = h(x) \\exp(\\eta(\\theta)^\\top T(x) - A(\\theta))$. What role does $A(\\theta)$ (the log-partition function) play?",
-      options: [
-        "It defines the prior distribution over $\\theta$",
-        "It is a normalization constant ensuring the distribution sums/integrates to 1",
-        "It computes the mode of the distribution",
-        "It measures the divergence between the model and the true distribution"
-      ],
-      correct: 1,
+      options: ["It defines the prior distribution over $\\theta$", "It computes the mode of the distribution", "It is a normalization constant ensuring the distribution sums/integrates to 1", "It measures the divergence between the model and the true distribution"],
+      correct: 2,
       explanation: "$A(\\theta) = \\log \\int h(x) \\exp(\\eta(\\theta)^\\top T(x))\\, dx$ is the log-partition function. It ensures normalization. Crucially, its derivatives give the moments: $\\nabla_\\eta A = \\mathbb{E}[T(x)]$ and $\\nabla^2_\\eta A = \\text{Cov}[T(x)]$. This means the log-partition function encodes everything about the distribution's moments."
     },
     {
       type: "mc",
       question: "The softmax output layer of an LLM defines a **categorical distribution** over tokens. In exponential family form, the natural parameters $\\eta_i$ correspond to:",
-      options: [
-        "The token embeddings",
-        "The logits (pre-softmax scores)",
-        "The softmax probabilities themselves",
-        "The attention weights"
-      ],
-      correct: 1,
+      options: ["The token embeddings", "The attention weights", "The softmax probabilities themselves", "The logits (pre-softmax scores)"],
+      correct: 3,
       explanation: "The categorical distribution in exponential family form is $P(w = i) = \\exp(\\eta_i - A(\\eta))$ where $A(\\eta) = \\log \\sum_j \\exp(\\eta_j)$ (the log-sum-exp). The logits **are** the natural parameters. This is why working in logit space (rather than probability space) is natural for optimization — gradients in the natural parameterization have nice properties."
     },
     {
@@ -78,37 +68,22 @@ export const exponentialFamilyAssessment = {
     {
       type: "mc",
       question: "The **Fisher information matrix** $\\mathcal{I}(\\theta) = \\mathbb{E}\\left[\\nabla \\log p(x \\mid \\theta) \\nabla \\log p(x \\mid \\theta)^\\top\\right]$ plays what role in MLE?",
-      options: [
-        "It determines the learning rate for SGD",
-        "It gives the asymptotic covariance of the MLE: $\\hat{\\theta}_{\\text{MLE}} \\sim \\mathcal{N}(\\theta, \\mathcal{I}(\\theta)^{-1}/n)$ as $n \\to \\infty$",
-        "It measures the distance between the model and the data",
-        "It equals the Hessian of the log-prior"
-      ],
-      correct: 1,
+      options: ["It gives the asymptotic covariance of the MLE: $\\hat{\\theta}_{\\text{MLE}} \\sim \\mathcal{N}(\\theta, \\mathcal{I}(\\theta)^{-1}/n)$ as $n \\to \\infty$", "It determines the learning rate for SGD", "It measures the distance between the model and the data", "It equals the Hessian of the log-prior"],
+      correct: 0,
       explanation: "The Cramér-Rao bound says no unbiased estimator can have variance lower than $\\mathcal{I}(\\theta)^{-1}/n$, and the MLE achieves this bound asymptotically. The Fisher matrix also defines the **natural gradient** $\\mathcal{I}^{-1} \\nabla \\ell$ — a direction that accounts for the geometry of the parameter space. This connects to Adam (which approximates diagonal Fisher) and to natural gradient methods in RL."
     },
     {
       type: "mc",
       question: "In practice, we train LLMs by minimizing cross-entropy on finite data. MLE is known to **overfit** without regularization. From a Bayesian perspective, L2 regularization ($\\lambda \\|\\theta\\|^2$) corresponds to:",
-      options: [
-        "A uniform prior over $\\theta$",
-        "A Gaussian prior $\\theta \\sim \\mathcal{N}(0, \\frac{1}{2\\lambda} I)$ — making the loss a MAP estimate",
-        "A Laplace prior over $\\theta$",
-        "Minimizing the Fisher information"
-      ],
-      correct: 1,
+      options: ["A uniform prior over $\\theta$", "A Laplace prior over $\\theta$", "A Gaussian prior $\\theta \\sim \\mathcal{N}(0, \\frac{1}{2\\lambda} I)$ — making the loss a MAP estimate", "Minimizing the Fisher information"],
+      correct: 2,
       explanation: "Adding $\\lambda \\|\\theta\\|^2$ to the NLL gives $-\\log p(x \\mid \\theta) + \\lambda \\|\\theta\\|^2 = -\\log p(x \\mid \\theta) - \\log p(\\theta) + \\text{const}$ where $p(\\theta) \\propto \\exp(-\\lambda \\|\\theta\\|^2)$ is a Gaussian. This makes the solution a **MAP** (maximum a posteriori) estimate rather than pure MLE. L1 regularization corresponds to a Laplace prior and promotes sparsity."
     },
     {
       type: "mc",
       question: "When computing the MLE for a mixture model $p(x) = \\sum_k \\pi_k p_k(x \\mid \\theta_k)$, the log-likelihood has a log-sum that makes direct optimization hard. What standard algorithm addresses this?",
-      options: [
-        "Gradient descent on the log-likelihood directly",
-        "The EM (Expectation-Maximization) algorithm, which alternates between computing posterior cluster assignments (E-step) and updating parameters (M-step)",
-        "Gibbs sampling from the posterior",
-        "Grid search over all parameter values"
-      ],
-      correct: 1,
+      options: ["Gradient descent on the log-likelihood directly", "Grid search over all parameter values", "Gibbs sampling from the posterior", "The EM (Expectation-Maximization) algorithm, which alternates between computing posterior cluster assignments (E-step) and updating parameters (M-step)"],
+      correct: 3,
       explanation: "EM handles the intractable log-sum by introducing latent variables $z$ (cluster assignments). The E-step computes $q(z) = P(z \\mid x, \\theta^{\\text{old}})$, and the M-step maximizes $\\mathbb{E}_q[\\log p(x, z \\mid \\theta)]$. Each iteration is guaranteed to increase the log-likelihood. EM is a special case of variational inference where the E-step is exact."
     }
   ]

--- a/src/modules/prob-assessment-foundations.js
+++ b/src/modules/prob-assessment-foundations.js
@@ -18,25 +18,15 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "A language model assigns probability $P(w_t \\mid w_{<t})$ to each token. By the chain rule of probability, the joint probability of a sequence $w_1, \\dots, w_T$ is:",
-      options: [
-        "$\\sum_{t=1}^{T} P(w_t \\mid w_{<t})$",
-        "$\\prod_{t=1}^{T} P(w_t \\mid w_{<t})$",
-        "$\\frac{1}{T} \\sum_{t=1}^{T} P(w_t \\mid w_{<t})$",
-        "$\\max_{t} P(w_t \\mid w_{<t})$"
-      ],
-      correct: 1,
+      options: ["$\\sum_{t=1}^{T} P(w_t \\mid w_{<t})$", "$\\frac{1}{T} \\sum_{t=1}^{T} P(w_t \\mid w_{<t})$", "$\\prod_{t=1}^{T} P(w_t \\mid w_{<t})$", "$\\max_{t} P(w_t \\mid w_{<t})$"],
+      correct: 2,
       explanation: "The chain rule of probability says $P(w_1, \\dots, w_T) = \\prod_{t=1}^{T} P(w_t \\mid w_1, \\dots, w_{t-1})$. This is the foundational factorization that autoregressive language models exploit — they model each conditional factor in the product."
     },
     {
       type: "mc",
       question: "You have a classifier with 95% true positive rate ($P(\\text{pos} \\mid \\text{spam}) = 0.95$) and 3% false positive rate ($P(\\text{pos} \\mid \\text{ham}) = 0.03$). If only 1% of emails are spam ($P(\\text{spam}) = 0.01$), what is $P(\\text{spam} \\mid \\text{pos})$ approximately?",
-      options: [
-        "About 95% — the classifier is very accurate",
-        "About 50% — it's a coin flip",
-        "About 24% — the low base rate dominates",
-        "About 1% — the prior barely changes"
-      ],
-      correct: 2,
+      options: ["About 95% — the classifier is very accurate", "About 50% — it's a coin flip", "About 1% — the prior barely changes", "About 24% — the low base rate dominates"],
+      correct: 3,
       explanation: "By Bayes' theorem: $P(\\text{spam} \\mid \\text{pos}) = \\frac{0.95 \\times 0.01}{0.95 \\times 0.01 + 0.03 \\times 0.99} = \\frac{0.0095}{0.0095 + 0.0297} \\approx 0.242$. This is the base rate fallacy — even with a good classifier, a low prior dramatically reduces the posterior. This is critical intuition for understanding how priors interact with likelihoods."
     },
     {
@@ -54,25 +44,15 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "In a language model's output layer, the **softmax** function converts logits $z_i$ to probabilities. Which distribution does this define over the vocabulary?",
-      options: [
-        "A Bernoulli distribution",
-        "A multinomial (categorical) distribution",
-        "A Poisson distribution",
-        "A Dirichlet distribution"
-      ],
-      correct: 1,
+      options: ["A multinomial (categorical) distribution", "A Bernoulli distribution", "A Poisson distribution", "A Dirichlet distribution"],
+      correct: 0,
       explanation: "Softmax produces a **categorical distribution** over the vocabulary: $P(w = i) = \\frac{e^{z_i}}{\\sum_j e^{z_j}}$. Each token gets a probability, probabilities sum to 1, and we sample one token. When we sample multiple tokens with replacement, the counts follow a multinomial. The Dirichlet would be a distribution *over* such probability vectors, not a single draw."
     },
     {
       type: "mc",
       question: "The **law of total expectation** states $\\mathbb{E}[X] = \\mathbb{E}[\\mathbb{E}[X \\mid Y]]$. In the context of language modeling, if $X$ is the log-probability of a sequence and $Y$ is the topic, this means:",
-      options: [
-        "The overall log-probability equals the best topic-conditional log-probability",
-        "The overall expected log-probability is the topic-weighted average of per-topic expected log-probabilities",
-        "The log-probability is independent of the topic",
-        "You must know the topic to compute the log-probability"
-      ],
-      correct: 1,
+      options: ["The overall log-probability equals the best topic-conditional log-probability", "The log-probability is independent of the topic", "The overall expected log-probability is the topic-weighted average of per-topic expected log-probabilities", "You must know the topic to compute the log-probability"],
+      correct: 2,
       explanation: "The law of total expectation says you can decompose an unconditional expectation by first conditioning on $Y$, computing the conditional expectation, then averaging over $Y$. Here: $\\mathbb{E}[\\log P] = \\sum_{\\text{topic}} P(\\text{topic}) \\cdot \\mathbb{E}[\\log P \\mid \\text{topic}]$. This is fundamental to understanding mixture models and how perplexity varies across data subsets."
     },
     {
@@ -90,13 +70,8 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "The **law of total probability** says $P(A) = \\sum_i P(A \\mid B_i) P(B_i)$ for a partition $\\{B_i\\}$. When marginalizing over latent variable $z$ in a latent variable model, we compute:",
-      options: [
-        "$P(x) = \\max_z P(x \\mid z) P(z)$",
-        "$P(x) = \\sum_z P(x \\mid z) P(z)$ (or $\\int$ for continuous $z$)",
-        "$P(x) = P(x \\mid z^*) $ where $z^* = \\arg\\max P(z)$",
-        "$P(x) = \\sum_z P(z \\mid x) P(x)$"
-      ],
-      correct: 1,
+      options: ["$P(x) = \\max_z P(x \\mid z) P(z)$", "$P(x) = \\sum_z P(z \\mid x) P(x)$", "$P(x) = P(x \\mid z^*) $ where $z^* = \\arg\\max P(z)$", "$P(x) = \\sum_z P(x \\mid z) P(z)$ (or $\\int$ for continuous $z$)"],
+      correct: 3,
       explanation: "Marginalization is exactly the law of total probability applied to a latent variable: $P(x) = \\sum_z P(x, z) = \\sum_z P(x \\mid z) P(z)$. This integral is often intractable, which is why we need variational inference (ELBO) or sampling methods. The max version gives the MAP estimate, not the marginal."
     },
     {

--- a/src/modules/prob-assessment-sampling.js
+++ b/src/modules/prob-assessment-sampling.js
@@ -18,25 +18,15 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Monte Carlo estimation** approximates $\\mathbb{E}_P[f(x)] \\approx \\frac{1}{N} \\sum_{i=1}^N f(x_i)$ where $x_i \\sim P$. The variance of this estimator decreases as:",
-      options: [
-        "$O(1/N^2)$",
-        "$O(1/N)$ — halving the variance requires doubling the samples, regardless of dimension",
-        "$O(1/\\sqrt{N})$",
-        "$O(e^{-N})$ — exponentially fast"
-      ],
-      correct: 1,
+      options: ["$O(1/N)$ — halving the variance requires doubling the samples, regardless of dimension", "$O(1/N^2)$", "$O(1/\\sqrt{N})$", "$O(e^{-N})$ — exponentially fast"],
+      correct: 0,
       explanation: "By the CLT, the variance of the sample mean is $\\text{Var}[f(X)] / N$, so it decreases as $O(1/N)$. The standard error decreases as $O(1/\\sqrt{N})$. Crucially, this rate is **dimension-independent** — this is why Monte Carlo methods scale to high dimensions where grid-based methods fail exponentially. This $O(1/N)$ rate drives many design choices in how many samples to use."
     },
     {
       type: "mc",
       question: "**Importance sampling** estimates $\\mathbb{E}_P[f(x)]$ using samples from a different distribution $Q$ via $\\mathbb{E}_P[f(x)] = \\mathbb{E}_Q\\left[f(x) \\frac{P(x)}{Q(x)}\\right]$. The ratio $w(x) = P(x)/Q(x)$ is called the importance weight. When can this go badly wrong?",
-      options: [
-        "When $P$ and $Q$ are identical distributions",
-        "When $Q$ has lighter tails than $P$ — the weights $P(x)/Q(x)$ can become enormous in the tails, causing high variance and unstable estimates",
-        "When $f(x)$ is a constant function",
-        "When $N$ is very large"
-      ],
-      correct: 1,
+      options: ["When $P$ and $Q$ are identical distributions", "When $f(x)$ is a constant function", "When $Q$ has lighter tails than $P$ — the weights $P(x)/Q(x)$ can become enormous in the tails, causing high variance and unstable estimates", "When $N$ is very large"],
+      correct: 2,
       explanation: "If $Q$ has lighter tails than $P$, then in regions where $P(x) \\gg Q(x)$, the weight $P(x)/Q(x)$ explodes. A few samples may dominate the entire estimate, giving high variance. This is the \"weight degeneracy\" problem. In off-policy RL, this manifests when the learned policy differs significantly from the behavior policy — importance weights become degenerate, which is why PPO clips them."
     },
     {
@@ -54,37 +44,22 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Top-k sampling** from an LLM restricts sampling to the $k$ highest-probability tokens and redistributes probability mass. From a sampling theory perspective, this is equivalent to:",
-      options: [
-        "Importance sampling with a uniform proposal",
-        "Sampling from a truncated version of the original distribution — renormalizing the top-k probabilities",
-        "Rejection sampling where we reject low-probability tokens",
-        "Gibbs sampling over the vocabulary"
-      ],
-      correct: 1,
+      options: ["Importance sampling with a uniform proposal", "Gibbs sampling over the vocabulary", "Rejection sampling where we reject low-probability tokens", "Sampling from a truncated version of the original distribution — renormalizing the top-k probabilities"],
+      correct: 3,
       explanation: "Top-k sets $P(w) = 0$ for all tokens outside the top $k$, then renormalizes: $P'(w) = P(w) / \\sum_{w' \\in \\text{top-k}} P(w')$ for $w \\in \\text{top-k}$. This is distribution truncation. Nucleus (top-p) sampling is similar but adaptive — it truncates at the smallest set whose cumulative probability exceeds $p$, making it more robust to varying entropy across positions."
     },
     {
       type: "mc",
       question: "**MCMC** (Markov Chain Monte Carlo) methods construct a Markov chain whose stationary distribution is the target $P$. The **Metropolis-Hastings** acceptance probability $\\alpha = \\min\\left(1, \\frac{P(x') Q(x|x')}{P(x) Q(x'|x)}\\right)$ ensures:",
-      options: [
-        "That the chain converges in finite time",
-        "**Detailed balance**: the chain is reversible with respect to $P$, guaranteeing $P$ is the stationary distribution",
-        "That all states are visited equally often",
-        "That the proposal $Q$ matches $P$ exactly"
-      ],
-      correct: 1,
+      options: ["**Detailed balance**: the chain is reversible with respect to $P$, guaranteeing $P$ is the stationary distribution", "That the chain converges in finite time", "That all states are visited equally often", "That the proposal $Q$ matches $P$ exactly"],
+      correct: 0,
       explanation: "The acceptance ratio enforces detailed balance: $P(x) T(x'|x) = P(x') T(x|x')$ where $T$ is the transition kernel. Detailed balance implies $P$ is stationary (but is stronger — it also implies reversibility). Note that we only need the ratio $P(x')/P(x)$, so we don't need to know the normalizing constant of $P$ — this is why MCMC works for Bayesian posteriors where the evidence is intractable."
     },
     {
       type: "mc",
       question: "The **Gumbel-max trick** provides exact samples from a categorical distribution: $\\arg\\max_i (\\log p_i + G_i)$ where $G_i \\sim \\text{Gumbel}(0, 1)$ are i.i.d. The **Gumbel-Softmax** relaxation replaces argmax with softmax to make this:",
-      options: [
-        "More numerically stable",
-        "Differentiable — enabling gradient-based optimization through discrete sampling operations using a continuous relaxation with temperature $\\tau$",
-        "Faster to compute",
-        "Exact rather than approximate"
-      ],
-      correct: 1,
+      options: ["More numerically stable", "Faster to compute", "Differentiable — enabling gradient-based optimization through discrete sampling operations using a continuous relaxation with temperature $\\tau$", "Exact rather than approximate"],
+      correct: 2,
       explanation: "The argmax is non-differentiable, blocking backpropagation. Gumbel-Softmax replaces it with $\\text{softmax}((\\log p_i + G_i)/\\tau)$, which is differentiable and approaches a one-hot vector as $\\tau \\to 0$. This enables end-to-end training of models with discrete choices (e.g., hard attention, discrete latent variables). The temperature $\\tau$ controls the bias-variance trade-off: low $\\tau$ is more accurate but higher variance."
     },
     {
@@ -102,25 +77,15 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Rejection sampling** draws $x \\sim Q$, then accepts with probability $\\frac{P(x)}{M \\cdot Q(x)}$ where $M \\geq \\sup_x \\frac{P(x)}{Q(x)}$. In high dimensions, this method:",
-      options: [
-        "Becomes more efficient due to the law of large numbers",
-        "Becomes exponentially inefficient — the acceptance rate drops exponentially with dimension because $M$ must be exponentially large to bound $P/Q$ everywhere",
-        "Works exactly the same as in low dimensions",
-        "Is replaced by importance sampling, which has the same problem"
-      ],
-      correct: 1,
+      options: ["Becomes more efficient due to the law of large numbers", "Is replaced by importance sampling, which has the same problem", "Works exactly the same as in low dimensions", "Becomes exponentially inefficient — the acceptance rate drops exponentially with dimension because $M$ must be exponentially large to bound $P/Q$ everywhere"],
+      correct: 3,
       explanation: "In $d$ dimensions, the acceptance rate $1/M$ typically decays as $e^{-\\Theta(d)}$ because the proposal $Q$ must cover the tails of $P$ in all dimensions simultaneously. This is the \"curse of dimensionality\" for rejection sampling. MCMC avoids this by not requiring a global bound — it only needs local moves. This is why rejection sampling is practical only in low dimensions, while MCMC and variational methods scale to millions of parameters."
     },
     {
       type: "mc",
       question: "**Speculative decoding** uses a small draft model to generate $k$ candidate tokens, then verifies them against the large target model in parallel. The verification uses a form of:",
-      options: [
-        "Beam search with pruning",
-        "Rejection sampling — each draft token is accepted with probability $\\min(1, P_{\\text{target}}(w_t) / P_{\\text{draft}}(w_t))$, and on rejection, we resample from a corrected distribution, ensuring the final output distribution exactly matches the target model",
-        "Importance sampling with the draft model as the proposal",
-        "Gibbs sampling alternating between draft and target"
-      ],
-      correct: 1,
+      options: ["Rejection sampling — each draft token is accepted with probability $\\min(1, P_{\\text{target}}(w_t) / P_{\\text{draft}}(w_t))$, and on rejection, we resample from a corrected distribution, ensuring the final output distribution exactly matches the target model", "Beam search with pruning", "Importance sampling with the draft model as the proposal", "Gibbs sampling alternating between draft and target"],
+      correct: 0,
       explanation: "Speculative decoding is mathematically exact: the output distribution matches what the target model would produce with standard autoregressive sampling. The trick is that acceptance probability $\\min(1, P_{\\text{target}}/P_{\\text{draft}})$ is high when the draft model is good, so most tokens are accepted without running the large model sequentially. On rejection, sampling from the residual $(P_{\\text{target}} - P_{\\text{draft}})_+$ corrects for the draft model's errors."
     }
   ]

--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -1,0 +1,99 @@
+/**
+ * Seeded shuffle utilities for randomizing quiz questions and options.
+ * Ensures each attempt presents questions and options in a different order,
+ * preventing pattern-matching and memorization of button sequences.
+ */
+
+// Linear congruential PRNG (same as used in WarmupView)
+export function createRng(seed) {
+  let s = Math.abs(seed) % 2147483647 || 1;
+  return () => {
+    s = (s * 16807) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+// Fisher-Yates shuffle using seeded RNG
+export function shuffleArray(arr, rng) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * Shuffle a MC step's options and remap the correct index.
+ * Returns a new step object with shuffled options and updated correct index.
+ */
+export function shuffleMcStep(step, seed) {
+  if (step.type !== 'mc') return step;
+  const rng = createRng(seed);
+  const indices = step.options.map((_, i) => i);
+  const shuffled = shuffleArray(indices, rng);
+  return {
+    ...step,
+    options: shuffled.map(i => step.options[i]),
+    correct: shuffled.indexOf(step.correct),
+  };
+}
+
+/**
+ * Shuffle all MC steps in a module. For test modules, also shuffles question order.
+ * Info steps in learning modules stay in their original positions relative to MC steps.
+ * Returns a new steps array.
+ */
+export function shuffleModuleSteps(steps, moduleType, seed) {
+  const rng = createRng(seed);
+
+  // Shuffle option order for every MC step (unique sub-seed per step)
+  const optionRng = createRng(seed + 31337);
+  const withShuffledOptions = steps.map((step, i) => {
+    if (step.type !== 'mc') return step;
+    const stepSeed = Math.floor(optionRng() * 2147483646) + 1;
+    return shuffleMcStep(step, stepSeed);
+  });
+
+  // For test modules, shuffle the order of MC questions
+  // Keep any leading info/intro steps in place
+  if (moduleType === 'test') {
+    const leadingInfo = [];
+    const rest = [];
+    let pastIntro = false;
+    for (const step of withShuffledOptions) {
+      if (!pastIntro && step.type === 'info') {
+        leadingInfo.push(step);
+      } else {
+        pastIntro = true;
+        rest.push(step);
+      }
+    }
+    return [...leadingInfo, ...shuffleArray(rest, rng)];
+  }
+
+  return withShuffledOptions;
+}
+
+/**
+ * Generate or retrieve a per-attempt seed for a module.
+ * Stored in sessionStorage so it persists across re-renders but changes per session/retry.
+ */
+export function getAttemptSeed(moduleId) {
+  const key = `llm-curriculum-shuffle-${moduleId}`;
+  try {
+    const stored = sessionStorage.getItem(key);
+    if (stored) return Number(stored);
+  } catch {}
+  return resetAttemptSeed(moduleId);
+}
+
+/**
+ * Reset the attempt seed (called on Retry or new attempt).
+ */
+export function resetAttemptSeed(moduleId) {
+  const key = `llm-curriculum-shuffle-${moduleId}`;
+  const seed = Math.floor(Math.random() * 2147483646) + 1;
+  try { sessionStorage.setItem(key, String(seed)); } catch {}
+  return seed;
+}


### PR DESCRIPTION
- Add seeded shuffle utility (src/utils/shuffle.js) for deterministic
  per-attempt randomization of both question order and option order
- ModuleView: shuffle option positions on every MC question; shuffle
  question order for test modules; new seed on Retry
- WarmupView: shuffle option positions for each warmup question
- Redistribute correct answer positions across all 479 MC questions
  (was ~90% at position 1, now ~25% per position 0-3)
- Expand entropy/cross-entropy question pool: +8 new reasoning questions
  across easy/medium/hard learning modules, +5 new assessment questions

https://claude.ai/code/session_014CMtEQM22LyncRYPbPFBAm