### PR TITLE
Equalize distractor lengths across prob-assessment modules

### DIFF
--- a/src/modules/prob-assessment-applied.js
+++ b/src/modules/prob-assessment-applied.js
@@ -18,14 +18,14 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "During LLM pre-training, the loss is $-\\frac{1}{T} \\sum_{t=1}^{T} \\log P_\\theta(w_t \\mid w_{<t})$. As training progresses, this loss decreases but eventually plateaus. The **irreducible** component of this loss corresponds to:",
-      options: ["The numerical precision of float16 arithmetic", "The size of the vocabulary", "The **entropy of natural language** $H(W_t \\mid W_{<t})$ — the inherent unpredictability that no model can eliminate because language itself is stochastic", "The number of parameters in the model"],
+      options: ["The numerical precision limits of float16 arithmetic, which introduce quantization noise that prevents the loss from reaching its true minimum", "The total size of the vocabulary, which sets a lower bound on cross-entropy because the model must distribute probability across all possible tokens", "The **entropy of natural language** $H(W_t \\mid W_{<t})$ — the inherent unpredictability that no model can eliminate because language itself is stochastic", "The number of parameters in the model, which determines the expressiveness ceiling and therefore the minimum achievable loss value"],
       correct: 2,
       explanation: "Cross-entropy loss $= H(P) + \\text{KL}(P \\| Q_\\theta)$. Even a perfect model ($Q = P$) achieves loss $H(P)$, the conditional entropy of the next token. This is the irreducible noise in language — given perfect context, many continuations are still plausible. The gap between the model's loss and $H(P)$ is the KL divergence, which measures model imperfection. Scaling laws describe how this KL component decreases with compute."
     },
     {
       type: "mc",
       question: "When you increase the **temperature** $\\tau$ in sampling ($P(w) \\propto \\exp(z_w / \\tau)$ where $z_w$ are logits), you are:",
-      options: ["Interpolating between the model's learned distribution ($\\tau = 1$) and uniform ($\\tau \\to \\infty$), which increases entropy and diversity. At $\\tau \\to 0$, you get argmax (greedy) decoding", "Changing the model's parameters", "Applying dropout at inference time", "Changing the loss function"],
+      options: ["Interpolating between the model's learned distribution ($\\tau = 1$) and uniform ($\\tau \\to \\infty$), which increases entropy and diversity — at $\\tau \\to 0$ you get argmax (greedy) decoding", "Modifying the model's internal weight parameters by scaling the final layer's weight matrix, which permanently changes the learned token probability estimates", "Applying a form of inference-time dropout that randomly masks logits before the softmax, introducing controlled stochasticity into the generation process", "Changing the cross-entropy loss function used during the forward pass, which alters the gradient signal and causes the model to reweight its learned distributions"],
       correct: 0,
       explanation: "Dividing logits by $\\tau > 1$ flattens the distribution (higher entropy, more random). Dividing by $\\tau < 1$ sharpens it (lower entropy, more deterministic). At $\\tau \\to 0$, all mass concentrates on the highest-logit token (argmax). At $\\tau \\to \\infty$, the distribution approaches uniform over the vocabulary. Temperature is a post-hoc entropy control that doesn't change the model — it's a monotonic transformation of the entropy of the output distribution."
     },
@@ -33,10 +33,10 @@ export const appliedInfoTheoryAssessment = {
       type: "mc",
       question: "In RLHF, increasing the KL penalty coefficient $\\beta$ in $\\max_\\pi \\mathbb{E}[r(x)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ causes the optimal policy to:",
       options: [
-        "Maximize reward regardless of the reference policy",
+        "Maximize reward without any constraint from the reference policy, since larger $\\beta$ amplifies the reward signal relative to the penalty term",
         "Stay closer to $\\pi_{\\text{ref}}$, trading off reward for distributional similarity — in the limit $\\beta \\to \\infty$, $\\pi^* = \\pi_{\\text{ref}}$",
-        "Become a uniform distribution",
-        "Increase its entropy independently of $\\pi_{\\text{ref}}$"
+        "Converge toward a uniform distribution over all possible outputs, since the KL penalty increasingly dominates and favors maximum entropy",
+        "Increase its entropy independently of $\\pi_{\\text{ref}}$, producing more diverse outputs without regard for the reference distribution's shape"
       ],
       correct: 1,
       explanation: "The optimal policy is $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. As $\\beta \\to \\infty$, $\\exp(r/\\beta) \\to 1$, so $\\pi^* \\to \\pi_{\\text{ref}}$. As $\\beta \\to 0$, the reward dominates, and the policy concentrates on the highest-reward outputs regardless of naturalness. $\\beta$ controls the **rate-distortion trade-off**: how much \"distortion\" (reward sacrifice) you accept to stay within a certain \"rate\" (KL budget) from the reference."
@@ -44,21 +44,21 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "A model trained on code achieves cross-entropy 0.5 nats/token on Python but 1.8 nats/token on Haskell. Assuming equal vocabulary, the **perplexity ratio** tells us:",
-      options: ["Python is a better language than Haskell", "The Python test set is smaller", "The Haskell tokenizer is broken", "The model has learned far more predictable structure in Python — perplexity is $e^{0.5} \\approx 1.65$ for Python vs $e^{1.8} \\approx 6.05$ for Haskell, meaning the model is ~3.7× more uncertain per token on Haskell"],
+      options: ["Python is inherently a better-designed language than Haskell, which is why the model finds it fundamentally easier to predict and compress", "The Python test set contains fewer tokens overall, so the model achieves lower average cross-entropy simply due to the reduced evaluation sample size", "The Haskell tokenizer is producing suboptimal token boundaries, artificially inflating the per-token cross-entropy through poor segmentation choices", "The model has learned far more predictable structure in Python — perplexity is $e^{0.5} \\approx 1.65$ for Python vs $e^{1.8} \\approx 6.05$ for Haskell, meaning ~3.7× more uncertainty per token"],
       correct: 3,
       explanation: "Perplexity $= e^{H(P,Q)}$. Lower cross-entropy → lower perplexity → more predictable. The ratio $e^{1.8}/e^{0.5} = e^{1.3} \\approx 3.67$ means the model's uncertainty per token is 3.7× higher on Haskell. This could reflect: less Haskell in training data, Haskell's inherently different structure, or poor tokenization. The information-theoretic view lets you decompose the loss into data entropy + model deficiency."
     },
     {
       type: "mc",
       question: "**Reward hacking** in RLHF occurs when the policy finds outputs that score high reward but are low-quality. From an information-theoretic perspective, this happens because:",
-      options: ["The reward model has high entropy", "The KL penalty is too large", "The reward model is a learned approximation — as $\\pi$ moves far from $\\pi_{\\text{ref}}$ (high KL), it enters out-of-distribution regions where the reward model's predictions are unreliable, effectively exploiting the reward model's epistemic uncertainty", "The vocabulary is too small"],
+      options: ["The reward model has excessively high entropy in its output scores, assigning near-uniform reward across all possible outputs regardless of their actual quality", "The KL penalty coefficient is too large, forcing the policy to stay so close to the reference that it cannot explore the reward landscape meaningfully", "The reward model is a learned approximation — as $\\pi$ moves far from $\\pi_{\\text{ref}}$ (high KL), it enters out-of-distribution regions where the reward model's predictions are unreliable", "The vocabulary is too small to express the nuanced outputs the reward model expects, causing a systematic mismatch between generation capacity and reward criteria"],
       correct: 2,
       explanation: "The reward model $r_\\phi$ was trained on data from $\\pi_{\\text{ref}}$. When $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is large, $\\pi$ generates text unlike anything the reward model saw during training. The reward model's predictions become meaningless — it may assign high scores to adversarial outputs. This is why the KL penalty is crucial: it keeps $\\pi$ in the region where $r_\\phi$ is calibrated. This is a distributional shift problem quantified by KL divergence."
     },
     {
       type: "mc",
       question: "During fine-tuning, you notice the model's **token-level entropy** $H(P_\\theta(\\cdot \\mid x))$ dropping rapidly. The attention entropy (entropy of attention weights) is also collapsing. This likely indicates:",
-      options: ["The model is **overfitting and losing diversity** — it's becoming overconfident on training patterns, potentially memorizing rather than generalizing. Entropy collapse in attention means it's attending to fewer positions, losing contextual flexibility", "The model is learning perfectly", "The learning rate is too low", "The model needs a larger vocabulary"],
+      options: ["The model is **overfitting and losing diversity** — it's becoming overconfident on training patterns, potentially memorizing rather than generalizing, with attention collapsing onto fewer positions", "The model is learning perfectly and converging to the true data distribution, which naturally has lower entropy than the pretrained model's initial predictions", "The learning rate is set too low, causing the model to make only incremental updates that gradually concentrate probability mass without meaningful learning", "The model needs a substantially larger vocabulary to express the fine-tuning distribution, and the current vocabulary bottleneck is forcing artificial certainty"],
       correct: 0,
       explanation: "Entropy collapse is a warning sign: the model assigns near-deterministic predictions and attends to very few positions. Low output entropy means the model \"thinks\" it's very certain — but on new inputs, this overconfidence leads to poor calibration and repetitive/degenerate outputs. Monitoring entropy during training is an information-theoretic diagnostic: healthy training should reduce entropy gradually (learning structure) without collapsing it (losing flexibility)."
     },
@@ -66,10 +66,10 @@ export const appliedInfoTheoryAssessment = {
       type: "mc",
       question: "The **bits-per-byte** (BPB) metric normalizes perplexity across different tokenizers. If model A has perplexity 15.2 with a BPE tokenizer averaging 3.8 bytes/token, and model B has perplexity 8.1 with a character-level tokenizer (1 byte/token), which is better?",
       options: [
-        "Model B — it has lower perplexity",
-        "Must compare BPB: model A's BPB $= \\frac{\\log_2(15.2)}{3.8} \\approx 1.03$, model B's BPB $= \\frac{\\log_2(8.1)}{1.0} \\approx 3.02$. Model A is much better despite higher perplexity — it compresses information more efficiently per byte",
-        "Model A — it has a better tokenizer",
-        "They are equivalent"
+        "Model B — it has lower perplexity, which is the standard metric for language model quality regardless of tokenization differences",
+        "Must compare BPB: model A's BPB $= \\frac{\\log_2(15.2)}{3.8} \\approx 1.03$, model B's BPB $= \\frac{\\log_2(8.1)}{1.0} \\approx 3.02$ — model A compresses more efficiently per byte",
+        "Model A — it uses a better tokenizer with higher bytes-per-token, which inherently leads to more efficient compression of the input text",
+        "They are equivalent — the perplexity difference is exactly offset by the tokenizer granularity, so both models capture identical amounts of structure"
       ],
       correct: 1,
       explanation: "BPB = (bits per token) / (bytes per token) = $\\log_2(\\text{PPL}) / \\text{avg\\_bytes\\_per\\_token}$. Model A: $\\log_2(15.2)/3.8 \\approx 1.03$ BPB. Model B: $\\log_2(8.1)/1.0 \\approx 3.02$ BPB. Model A achieves much better compression per byte of text. Raw perplexity is misleading across tokenizers because a character-level model predicts many more (easier) tokens. BPB is the fair comparison metric."
@@ -77,14 +77,14 @@ export const appliedInfoTheoryAssessment = {
     {
       type: "mc",
       question: "In the **information bottleneck** framework, a representation $Z$ of input $X$ is optimized to maximize $I(Z; Y)$ (task-relevant information) while minimizing $I(Z; X)$ (total information retained). In the context of LLM representations, this means:",
-      options: ["Layers should memorize all input details", "The output should be independent of the input", "All layers should have the same mutual information with the input", "Good representations should **compress away irrelevant details of the input** while retaining information needed for prediction — the $\\beta$ parameter controls this trade-off, analogous to the KL penalty in RLHF"],
+      options: ["Layers should memorize all input details to preserve maximum information, since any compression risks discarding task-relevant features that cannot be recovered", "The output representation should be statistically independent of the input, retaining no mutual information with the original token embeddings", "All layers in the network should maintain exactly the same mutual information with the input, ensuring uniform information flow throughout the architecture", "Good representations should **compress away irrelevant details of the input** while retaining information needed for prediction — the $\\beta$ parameter controls this trade-off"],
       correct: 3,
       explanation: "The IB objective $\\max_{p(z|x)} I(Z; Y) - \\beta I(Z; X)$ formalizes the compression/prediction trade-off. Small $\\beta$ keeps all information (overfitting); large $\\beta$ compresses aggressively (underfitting). This framework connects to: dropout (random compression), bottleneck layers (architectural compression), and the KL penalty in RLHF (behavioral compression). The parallel to $\\max \\mathbb{E}[r] - \\beta \\text{KL}$ is exact in structure."
     },
     {
       type: "mc",
       question: "When computing $\\log P(y \\mid x)$ for a long sequence $y = (y_1, \\dots, y_T)$, numerical issues arise because the log-probability is a sum of $T$ negative terms that can become very negative. The standard solution is:",
-      options: ["Clipping the log-probabilities to a minimum value", "Using float64 instead of float32", "Working in **log-space throughout** — using the log-sum-exp trick for normalization and accumulating log-probabilities additively, which is numerically stable and avoids underflow from multiplying many small probabilities", "Truncating sequences to a maximum length"],
+      options: ["Clipping the log-probabilities to a minimum threshold value, preventing any single token from contributing more than a bounded amount to the total", "Using float64 instead of float32 for all intermediate computations, which provides sufficient dynamic range to avoid underflow in most practical cases", "Working in **log-space throughout** — using the log-sum-exp trick for normalization and accumulating log-probabilities additively, avoiding underflow from multiplying small values", "Truncating sequences to a fixed maximum length, ensuring the accumulated log-probability sum never exceeds the representable range of the floating-point format"],
       correct: 2,
       explanation: "Direct computation of $P(y|x) = \\prod_t P(y_t | y_{<t}, x)$ would underflow to zero for long sequences (multiplying many numbers < 1). Instead, we compute $\\log P(y|x) = \\sum_t \\log P(y_t | y_{<t}, x)$, keeping everything in log-space. The log-sum-exp trick $\\log \\sum_i e^{a_i} = A + \\log \\sum_i e^{a_i - A}$ (where $A = \\max_i a_i$) handles the softmax normalization. This is a universal pattern: always work in log-probability space."
     }

--- a/src/modules/prob-assessment-bayesian.js
+++ b/src/modules/prob-assessment-bayesian.js
@@ -18,7 +18,7 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "Bayes' theorem states $P(\\theta \\mid \\mathcal{D}) = \\frac{P(\\mathcal{D} \\mid \\theta) P(\\theta)}{P(\\mathcal{D})}$. The denominator $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ is called the **evidence** or **marginal likelihood**. Why is it typically intractable?",
-      options: ["Because $P(\\mathcal{D} \\mid \\theta)$ is unknown", "Because the data $\\mathcal{D}$ is too large", "Because the prior $P(\\theta)$ is always improper", "Because the integral is over the entire parameter space, which is high-dimensional for neural networks — making it impossible to evaluate analytically or numerically"],
+      options: ["Because $P(\\mathcal{D} \\mid \\theta)$ is generally unknown for complex models — the likelihood function cannot be evaluated pointwise without strong distributional assumptions about the data generating process", "Because the data $\\mathcal{D}$ is too large to fit in memory for modern datasets, making the sum over all datapoints computationally prohibitive regardless of the dimensionality of the parameter space", "Because the prior $P(\\theta)$ is always improper for neural network parameters, meaning the integral diverges to infinity regardless of the likelihood function or the architecture being used", "Because the integral is over the entire parameter space, which is high-dimensional for neural networks — making it impossible to evaluate analytically or via numerical quadrature methods"],
       correct: 3,
       explanation: "For a neural network with millions of parameters, $P(\\mathcal{D}) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ requires integrating over a million-dimensional space. This integral has no closed form (the likelihood is a complex nonlinear function of $\\theta$) and is too high-dimensional for numerical quadrature. This intractability motivates both MCMC (sampling) and variational inference (optimization) as approximation strategies."
     },
@@ -26,10 +26,10 @@ export const bayesianAssessment = {
       type: "mc",
       question: "In variational inference, we approximate the intractable posterior $P(\\theta \\mid \\mathcal{D})$ with a tractable distribution $q(\\theta)$ by minimizing $\\text{KL}(q(\\theta) \\| P(\\theta \\mid \\mathcal{D}))$. This is **reverse KL**. What consequence does this have?",
       options: [
-        "$q$ will cover all modes of the posterior (mode-covering)",
+        "$q$ will cover all modes of the posterior (mode-covering), spreading mass broadly to ensure no region of high posterior density is missed entirely",
         "$q$ will tend to concentrate on a single mode of the posterior (mode-seeking), potentially underestimating uncertainty",
-        "$q$ will exactly match the posterior",
-        "$q$ will be uniform over the parameter space"
+        "$q$ will exactly match the posterior when using a sufficiently flexible variational family, regardless of the optimization procedure used",
+        "$q$ will be uniform over the parameter space because the KL objective has no preference for any particular concentration of mass"
       ],
       correct: 1,
       explanation: "Reverse KL is mode-seeking: $q$ will lock onto one mode of the posterior and fit it tightly, ignoring other modes. This means variational inference systematically **underestimates** posterior uncertainty. For multimodal posteriors, $q$ may miss important modes. This is the fundamental trade-off of variational inference vs. MCMC (which can in principle explore all modes)."
@@ -37,21 +37,21 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "The **ELBO** (Evidence Lower Bound) is $\\mathcal{L}(q) = \\mathbb{E}_q[\\log P(\\mathcal{D} \\mid \\theta)] - \\text{KL}(q(\\theta) \\| P(\\theta))$. Why is it called a \"lower bound\"?",
-      options: ["Because $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q \\| P(\\theta \\mid \\mathcal{D})) \\geq \\mathcal{L}(q)$, since KL $\\geq 0$ — so the ELBO lower-bounds the log-evidence", "Because it lower-bounds the KL divergence", "Because the expected log-likelihood is always negative", "Because the prior term is always a penalty"],
+      options: ["Because $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q \\| P(\\theta \\mid \\mathcal{D})) \\geq \\mathcal{L}(q)$, since KL $\\geq 0$ — so the ELBO lower-bounds the log-evidence", "Because it provides a lower bound on the KL divergence between the variational posterior and the true posterior distribution at every optimization step", "Because the expected log-likelihood term is always negative for normalized probability distributions, which pulls the overall bound below the true log-evidence", "Because the KL prior penalty term strictly decreases the objective relative to maximum likelihood, acting as a one-sided regularizer that tightens the bound"],
       correct: 0,
       explanation: "We can decompose: $\\log P(\\mathcal{D}) = \\mathcal{L}(q) + \\text{KL}(q(\\theta) \\| P(\\theta \\mid \\mathcal{D}))$. Since KL is always $\\geq 0$, we get $\\log P(\\mathcal{D}) \\geq \\mathcal{L}(q)$. Maximizing the ELBO simultaneously (1) tightens the bound on the evidence, and (2) minimizes $\\text{KL}(q \\| P(\\theta \\mid \\mathcal{D}))$, making $q$ a better posterior approximation. The ELBO equals the evidence when $q$ equals the true posterior."
     },
     {
       type: "mc",
       question: "In the VAE (Variational Autoencoder), the ELBO for a single datapoint is $\\mathcal{L}(x) = \\mathbb{E}_{q(z|x)}[\\log p(x \\mid z)] - \\text{KL}(q(z \\mid x) \\| p(z))$. The two terms correspond to:",
-      options: ["Accuracy and speed", "Training loss and validation loss", "**Reconstruction** (how well can we decode $z$ back to $x$) and **regularization** (how close is the encoder's posterior to the prior)", "Bias and variance of the model"],
+      options: ["Accuracy of the decoder network and computational speed of the forward pass — balancing model fidelity against inference-time efficiency during generation", "Training loss on the current mini-batch and validation loss on held-out data — ensuring the model generalizes beyond its training distribution", "Reconstruction (how well can we decode $z$ back to $x$) and regularization (how close is the encoder's posterior to the prior $p(z)$)", "Bias of the latent representation and variance of the decoder outputs — controlling the bias-variance trade-off in the generative model"],
       correct: 2,
       explanation: "The first term $\\mathbb{E}_{q(z|x)}[\\log p(x|z)]$ encourages accurate reconstruction — $z$ must contain enough information to reproduce $x$. The second term $\\text{KL}(q(z|x) \\| p(z))$ regularizes the latent space, pushing $q(z|x)$ toward the prior $p(z) = \\mathcal{N}(0, I)$. The tension between these creates a learned compression: encode enough to reconstruct, but stay close to a simple prior."
     },
     {
       type: "mc",
       question: "The **reparameterization trick** in VAEs writes $z = \\mu(x) + \\sigma(x) \\odot \\epsilon$ where $\\epsilon \\sim \\mathcal{N}(0, I)$. Why is this needed?",
-      options: ["To make the latent space continuous", "To reduce the dimensionality of $z$", "To ensure $z$ follows a Gaussian distribution", "To move the stochasticity outside the computational graph, enabling backpropagation through the sampling operation via the deterministic path $\\mu(x)$ and $\\sigma(x)$"],
+      options: ["To make the latent space continuous and differentiable, since discrete latent variables would prevent the decoder network from producing smooth and coherent reconstructions of the input data", "To reduce the dimensionality of $z$ by projecting the encoder output into a lower-dimensional manifold that captures the most important axes of variation in the training data", "To ensure $z$ follows a Gaussian distribution at all layers of the network, which is required for the KL divergence term in the ELBO to have a tractable closed-form analytical solution", "To move the stochasticity outside the computational graph, enabling backpropagation through the sampling operation via the deterministic path through $\\mu(x)$ and $\\sigma(x)$"],
       correct: 3,
       explanation: "You can't backpropagate through a random sampling operation $z \\sim q(z|x)$. The reparameterization trick rewrites this as a deterministic function of learned parameters ($\\mu, \\sigma$) plus fixed noise ($\\epsilon$). Now gradients flow through $\\mu$ and $\\sigma$ to the encoder. This same idea (making gradients flow through stochastic operations) appears in policy gradient methods and Gumbel-softmax for discrete distributions."
     },
@@ -59,10 +59,10 @@ export const bayesianAssessment = {
       type: "mc",
       question: "**Mean-field variational inference** assumes the variational distribution factorizes: $q(\\theta) = \\prod_i q_i(\\theta_i)$. What does this independence assumption sacrifice?",
       options: [
-        "The ability to model the mean of each parameter",
-        "All correlations between parameters — it cannot capture posterior dependencies, often leading to underestimated uncertainty",
-        "The ability to compute the ELBO",
-        "Convergence guarantees"
+        "The ability to model the mean of each parameter accurately, since the factorized form biases individual marginal means toward the prior distribution values",
+        "All correlations between parameters — it cannot capture posterior dependencies, often leading to systematically underestimated uncertainty",
+        "The ability to compute the ELBO in closed form, requiring expensive Monte Carlo estimates for each gradient update step during the optimization process",
+        "Convergence guarantees for coordinate ascent optimization, meaning the algorithm may diverge or oscillate without extremely careful hyperparameter tuning"
       ],
       correct: 1,
       explanation: "Mean-field assumes all parameters are independent in the posterior, which is almost never true. In neural networks, weight correlations are rampant (e.g., a large weight in one layer affects optimal weights in the next). This means mean-field posteriors are overconfident — they give tight marginals that ignore how parameters co-vary. Despite this limitation, mean-field VI is widely used because it's tractable."
@@ -72,9 +72,9 @@ export const bayesianAssessment = {
       question: "The derivation of **DPO** (Direct Preference Optimization) starts from the KL-constrained RLHF objective and finds its closed-form optimal policy. The derivation critically uses:",
       options: [
         "The Lagrangian dual of the KL constraint, yielding $\\pi^*(y|x) \\propto \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$ — a Gibbs/Boltzmann distribution where the partition function acts as a value function",
-        "Monte Carlo sampling of the reward function",
-        "The gradient of the JS divergence",
-        "The central limit theorem applied to token probabilities"
+        "Monte Carlo sampling of the reward function across multiple rollouts to estimate expected reward and its gradient with respect to the current policy's trainable parameters",
+        "The gradient of the JS divergence between the policy and reference distributions, which provides a symmetric and bounded training signal for stable policy optimization updates",
+        "The central limit theorem applied to token-level log-probabilities, allowing the sequence-level reward to be approximated as a Gaussian over individual token contributions"
       ],
       correct: 0,
       explanation: "The RLHF objective $\\max_\\pi \\mathbb{E}[r] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ has the closed-form solution $\\pi^*(y|x) = \\frac{1}{Z(x)} \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$ where $Z(x) = \\sum_y \\pi_{\\text{ref}}(y|x) \\exp(r(y,x)/\\beta)$. This is derived by taking the functional derivative and solving. The key insight is rearranging to express $r$ in terms of $\\pi^*/\\pi_{\\text{ref}}$, then substituting into the Bradley-Terry preference model to eliminate the reward entirely."
@@ -82,14 +82,14 @@ export const bayesianAssessment = {
     {
       type: "mc",
       question: "**Bayesian model comparison** uses the evidence $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta, M) P(\\theta \\mid M) d\\theta$ to compare models $M_1$ and $M_2$ via the Bayes factor $\\frac{P(\\mathcal{D} \\mid M_1)}{P(\\mathcal{D} \\mid M_2)}$. How does this naturally implement Occam's razor?",
-      options: ["It penalizes models with more parameters through an explicit penalty term", "It uses cross-validation internally", "Complex models spread their prior mass over many possible datasets, so they assign lower prior probability to any specific dataset — the evidence automatically balances fit and complexity", "It selects the model with the highest likelihood on the training data"],
+      options: ["It penalizes models with more parameters through an explicit complexity term analogous to AIC or BIC, directly counting the effective number of free parameters in the model", "It uses internal cross-validation by marginalizing over parameter uncertainty, effectively averaging held-out prediction performance across all possible train-test data splits", "Complex models spread their prior mass over many possible datasets, so they assign lower prior probability to any specific dataset — the evidence automatically balances fit and complexity", "It selects the model with the highest likelihood on the training data, which inherently favors simpler models because they have fewer degrees of freedom available for overfitting"],
       correct: 2,
       explanation: "A complex model can fit many possible datasets but must spread its prior predictive probability $P(\\mathcal{D} \\mid M) = \\int P(\\mathcal{D} \\mid \\theta) P(\\theta) d\\theta$ thinly over all of them. A simple model concentrates its probability on fewer datasets but assigns higher probability to those. The evidence thus naturally penalizes unnecessary complexity — no regularization parameter needed. This is called the \"Bayesian Occam's razor.\""
     },
     {
       type: "mc",
       question: "**Amortized inference** (as in VAEs) trains an encoder $q_\\phi(z \\mid x)$ to approximate the posterior for any $x$, rather than optimizing $q$ separately for each $x$. The key advantage is:",
-      options: ["It guarantees exact posterior inference", "It makes the posterior always Gaussian", "It eliminates the need for the ELBO", "After training, inference for a new $x$ is a single forward pass through the encoder — no iterative optimization needed. This trades per-datapoint optimality for speed"],
+      options: ["It guarantees exact posterior inference by using a sufficiently expressive encoder architecture, eliminating the approximation gap entirely for any deep network model", "It constrains the posterior to always be Gaussian regardless of the true posterior shape, simplifying the KL computation in the ELBO to a closed-form analytical expression", "It eliminates the need for the ELBO objective entirely, allowing direct maximization of the marginal likelihood $\\log p(x)$ through the encoder's learned approximate posterior", "After training, inference for a new $x$ is a single forward pass through the encoder — no iterative optimization needed, trading per-datapoint optimality for speed"],
       correct: 3,
       explanation: "Traditional VI optimizes $q(z)$ separately per datapoint (expensive). Amortized inference learns a single function $q_\\phi(z|x)$ (the encoder) that maps any $x$ to an approximate posterior in one forward pass. The trade-off: the \"amortization gap\" — the shared encoder may not be as good as per-datapoint optimization. But the speedup (one pass vs. iterative optimization) makes it practical for large datasets."
     }

--- a/src/modules/prob-assessment-concentration.js
+++ b/src/modules/prob-assessment-concentration.js
@@ -18,7 +18,7 @@ export const concentrationAssessment = {
     {
       type: "mc",
       question: "**Markov's inequality** states that for a non-negative random variable $X$ and $a > 0$: $P(X \\geq a) \\leq \\frac{\\mathbb{E}[X]}{a}$. This bound is:",
-      options: ["Very loose in general (it only uses the mean), but important because it requires minimal assumptions — just non-negativity", "Tight for all distributions", "Only valid for Gaussian distributions", "Tighter than Chebyshev's inequality"],
+      options: ["Very loose in general (it only uses the mean), but important because it requires minimal assumptions — just non-negativity and a finite first moment", "Tight for all distributions with finite variance, since it leverages both the mean and the second moment to constrain the tail probability", "Only valid for Gaussian distributions or distributions that can be approximated by a Gaussian through the central limit theorem", "Tighter than Chebyshev's inequality because it avoids the squared term in the denominator that loosens higher-order moment bounds"],
       correct: 0,
       explanation: "Markov's inequality is the weakest but most general bound — it only requires $X \\geq 0$ and finite mean. It's rarely used directly because it's very loose, but it's the foundation from which all stronger bounds are derived (Chebyshev applies Markov to $(X - \\mu)^2$, Chernoff applies Markov to $e^{tX}$). Its value is conceptual: it shows that heavy-tailed behavior is constrained by the mean."
     },
@@ -26,10 +26,10 @@ export const concentrationAssessment = {
       type: "mc",
       question: "**Chebyshev's inequality** states $P(|X - \\mu| \\geq t) \\leq \\frac{\\sigma^2}{t^2}$. For a sample mean $\\bar{X}_n$ of $n$ i.i.d. variables with variance $\\sigma^2$, what does Chebyshev give for $P(|\\bar{X}_n - \\mu| \\geq \\epsilon)$?",
       options: [
-        "$\\frac{\\sigma^2}{\\epsilon^2}$ — independent of $n$",
-        "$\\frac{\\sigma^2}{n \\epsilon^2}$ — the bound tightens linearly with $n$, giving a $1/n$ convergence rate",
-        "$\\frac{\\sigma}{\\sqrt{n} \\epsilon}$",
-        "$e^{-n\\epsilon^2 / 2\\sigma^2}$"
+        "$\\frac{\\sigma^2}{\\epsilon^2}$ — independent of $n$, since the variance bound does not account for averaging effects across samples",
+        "$\\frac{\\sigma^2}{n \\epsilon^2}$ — the bound tightens linearly with $n$, giving a $1/n$ polynomial convergence rate for the sample mean",
+        "$\\frac{\\sigma}{\\sqrt{n} \\epsilon}$ — a square-root scaling that arises from applying the CLT approximation to the tail probability directly",
+        "$e^{-n\\epsilon^2 / 2\\sigma^2}$ — an exponential bound that follows from the sub-Gaussian property of bounded sample means"
       ],
       correct: 1,
       explanation: "$\\text{Var}(\\bar{X}_n) = \\sigma^2/n$, so Chebyshev gives $P(|\\bar{X}_n - \\mu| \\geq \\epsilon) \\leq \\sigma^2 / (n\\epsilon^2)$. This is a **polynomial** (not exponential) bound in $n$. To get $P \\leq \\delta$, you need $n \\geq \\sigma^2 / (\\epsilon^2 \\delta)$ — which can be impractically large. This motivates sub-Gaussian bounds that give exponential concentration."
@@ -38,10 +38,10 @@ export const concentrationAssessment = {
       type: "mc",
       question: "**Hoeffding's inequality** for i.i.d. bounded random variables $X_i \\in [a, b]$ states $P(|\\bar{X}_n - \\mu| \\geq t) \\leq 2\\exp\\left(-\\frac{2nt^2}{(b-a)^2}\\right)$. Compared to Chebyshev, this gives:",
       options: [
-        "A weaker bound that uses more assumptions",
-        "An **exponentially** decreasing tail bound in $n$ (vs. polynomial for Chebyshev) — the price is requiring bounded variables",
-        "The same rate but with a better constant",
-        "A bound that doesn't depend on the range $[a, b]$"
+        "A weaker bound that uses stronger assumptions — the boundedness requirement restricts applicability without improving the convergence rate over Chebyshev",
+        "An exponentially decreasing tail bound in $n$ (vs. polynomial for Chebyshev) — the price is requiring bounded variables rather than just finite variance",
+        "The same asymptotic rate as Chebyshev but with a tighter multiplicative constant, providing marginal improvement for moderate sample sizes only",
+        "A bound that does not depend on the range $[a, b]$ at all, since the exponential decay rate is determined entirely by the sample size and deviation"
       ],
       correct: 1,
       explanation: "Hoeffding gives $e^{-\\Theta(n)}$ decay vs. Chebyshev's $1/n$ decay. To achieve failure probability $\\delta$, Hoeffding needs $n = O(\\log(1/\\delta) / t^2)$ samples — logarithmic in $1/\\delta$ vs. Chebyshev's linear $O(1/\\delta)$. This exponential concentration is crucial in practice: it means evaluation metrics converge quickly and generalization bounds are meaningful."
@@ -49,28 +49,28 @@ export const concentrationAssessment = {
     {
       type: "mc",
       question: "A random variable $X$ is **sub-Gaussian** with parameter $\\sigma$ if $\\mathbb{E}[e^{t(X - \\mu)}] \\leq e^{\\sigma^2 t^2 / 2}$ for all $t$. Why is the sub-Gaussian property important in deep learning?",
-      options: ["All neural network weights are sub-Gaussian", "It guarantees convergence of SGD", "It implies exponential tail concentration $P(|X - \\mu| \\geq t) \\leq 2e^{-t^2/(2\\sigma^2)}$, which applies to bounded random variables, Gaussian variables, and sums thereof — covering most quantities we care about in training and evaluation", "It means the distribution is exactly Gaussian"],
+      options: ["All neural network weights are sub-Gaussian after standard initialization schemes, which guarantees that forward-pass activations remain bounded throughout training", "It guarantees convergence of SGD to a global minimum in non-convex landscapes, provided the gradient noise satisfies the sub-Gaussian tail condition at each step", "It implies exponential tail concentration $P(|X - \\mu| \\geq t) \\leq 2e^{-t^2/(2\\sigma^2)}$, which applies to bounded variables, Gaussians, and their sums — covering most training quantities", "It means the distribution is exactly Gaussian in its first two moments, allowing closed-form computation of expected loss and gradient variance during optimization"],
       correct: 2,
       explanation: "Sub-Gaussianity is a tail condition: the tails decay at least as fast as a Gaussian with variance $\\sigma^2$. Bounded variables ($[a,b]$) are sub-Gaussian with $\\sigma = (b-a)/2$, and sums of sub-Gaussians are sub-Gaussian. This covers sample means, bounded losses, and many gradient estimators. The tail bound gives sharp concentration — the foundation for PAC-Bayes bounds, uniform convergence, and confidence intervals."
     },
     {
       type: "mc",
       question: "In SGD, the gradient estimate $g = \\nabla L(x_i; \\theta)$ for a random mini-batch is an unbiased estimator of $\\nabla L(\\theta)$. The **variance** of this estimate relates to concentration via:",
-      options: ["Higher variance means faster convergence due to exploration", "Variance only matters for the final few iterations", "Variance is irrelevant because SGD converges regardless", "Gradient variance $\\text{Var}(g)$ scales as $\\sigma^2_g / B$ for batch size $B$ — doubling batch size halves the variance but also halves the number of parameter updates per epoch"],
+      options: ["Higher variance means faster convergence due to implicit exploration of the loss landscape, which helps SGD escape sharp local minima more effectively", "Variance only matters for the final few iterations of training when the model is near convergence and noise prevents settling into the exact optimum", "Variance is irrelevant to convergence because SGD's unbiasedness alone guarantees convergence regardless of second-moment properties of the gradient estimator", "Gradient variance $\\text{Var}(g)$ scales as $\\sigma^2_g / B$ for batch size $B$ — doubling the batch size halves the variance but also halves the parameter updates per epoch"],
       correct: 3,
       explanation: "The mini-batch gradient is a sample mean, so $\\text{Var}(\\bar{g}_B) = \\sigma^2_g / B$. This means larger batches give more concentrated (less noisy) gradient estimates. But the total computation is $B \\times \\text{updates}$, and doubling $B$ halves updates per epoch. The \"critical batch size\" is where further increases in $B$ no longer improve wall-clock convergence — below this, gradient noise is too high; above it, you're wasting compute on variance reduction that doesn't help."
     },
     {
       type: "mc",
       question: "**McDiarmid's inequality** generalizes Hoeffding to functions of independent variables: if changing any one input $x_i$ changes $f(x_1, \\ldots, x_n)$ by at most $c_i$, then $P(f - \\mathbb{E}[f] \\geq t) \\leq \\exp\\left(-\\frac{2t^2}{\\sum_i c_i^2}\\right)$. This is useful in ML for bounding:",
-      options: ["The **generalization gap** — since train/test metrics are functions of i.i.d. data points, and changing one datapoint has bounded effect (bounded differences), McDiarmid gives exponential concentration of empirical risk around its expectation", "The training loss only", "The norm of the weight matrix", "The number of epochs needed"],
+      options: ["The generalization gap — since train/test metrics are functions of i.i.d. data points, and changing one point has bounded effect, McDiarmid gives exponential concentration of empirical risk", "The training loss at each iteration, providing a deterministic upper bound on the per-step decrease that guarantees monotonic convergence of the optimization procedure", "The spectral norm of the weight matrix after each gradient update, which controls the Lipschitz constant of the network and thus its generalization capacity", "The number of epochs needed to reach a target accuracy, since the bounded-differences condition translates directly into a convergence rate for gradient descent"],
       correct: 0,
       explanation: "The empirical risk $\\hat{R} = \\frac{1}{n} \\sum_i L(f(x_i), y_i)$ is a function of $n$ i.i.d. data points. Changing one point changes $\\hat{R}$ by at most $c_i = M/n$ (if the loss is bounded by $M$). McDiarmid gives $P(|\\hat{R} - R| \\geq t) \\leq 2e^{-2nt^2/M^2}$. This is a key ingredient in VC theory and PAC learning bounds."
     },
     {
       type: "mc",
       question: "The **Chernoff bound** technique optimizes over the parameter in the moment generating function: $P(X \\geq a) \\leq \\min_{t > 0} e^{-ta} \\mathbb{E}[e^{tX}]$. This gives the **tightest exponential bound** because:",
-      options: ["It only requires the mean", "It uses all moments of the distribution simultaneously (through the MGF), not just the mean or variance — the optimization over $t$ selects the tightest exponential rate for each specific tail probability", "It works for any distribution including heavy-tailed ones", "It is always tighter than the exact probability"],
+      options: ["It only requires the mean of the distribution, making it the most broadly applicable bound that still achieves exponential decay in the tail probability", "It uses all moments of the distribution simultaneously (through the MGF), not just the mean or variance — the optimization over $t$ selects the tightest exponential rate", "It works for any distribution including heavy-tailed ones where the MGF may not exist, by truncating the moment generating function at a finite order", "It is always tighter than the exact probability because the exponential tilting introduces a bias that systematically underestimates the true tail mass"],
       correct: 1,
       explanation: "The Chernoff method applies Markov's inequality to $e^{tX}$ for any $t > 0$, then optimizes over $t$. Since $\\mathbb{E}[e^{tX}]$ encodes all moments (via Taylor expansion: $\\sum_k t^k \\mathbb{E}[X^k]/k!$), the optimization over $t$ extracts the best exponential bound the moment information can provide. For sub-Gaussian and sub-exponential variables, this gives sharp rates. It fails for truly heavy-tailed distributions where the MGF doesn't exist."
     },
@@ -78,10 +78,10 @@ export const concentrationAssessment = {
       type: "mc",
       question: "When evaluating an LLM on a benchmark with $n = 1000$ binary-scored questions, your model gets 72% accuracy. Using Hoeffding's inequality, a 95% confidence interval ($\\delta = 0.05$) for the true accuracy is approximately:",
       options: [
-        "$72\\% \\pm 0.1\\%$ — very precise with 1000 samples",
-        "$72\\% \\pm 2.7\\%$ — from $\\epsilon = \\sqrt{\\frac{\\log(2/\\delta)}{2n}} \\approx 0.027$ for bounded $[0,1]$ variables",
-        "$72\\% \\pm 10\\%$ — 1000 samples is not enough",
-        "$72\\% \\pm 1.4\\%$ — using the normal approximation"
+        "$72\\% \\pm 0.1\\%$ — extremely precise, since 1000 samples with exponential concentration yield a negligibly small confidence radius",
+        "$72\\% \\pm 2.7\\%$ — from $\\epsilon = \\sqrt{\\frac{\\log(2/\\delta)}{2n}} \\approx 0.027$ for bounded $[0,1]$ variables with Hoeffding's bound",
+        "$72\\% \\pm 10\\%$ — because 1000 samples is insufficient for meaningful concentration when the true accuracy is far from 50\\%",
+        "$72\\% \\pm 1.4\\%$ — using the normal approximation $1.96\\sqrt{p(1-p)/n}$ which gives a tighter interval than Hoeffding for binary outcomes"
       ],
       correct: 1,
       explanation: "Hoeffding gives $P(|\\hat{p} - p| \\geq \\epsilon) \\leq 2e^{-2n\\epsilon^2}$. Setting $2e^{-2(1000)\\epsilon^2} = 0.05$ gives $\\epsilon = \\sqrt{\\log(40)/2000} \\approx 0.043$, so about $\\pm 4.3\\%$. The tighter Clopper-Pearson or normal approximation ($\\pm 1.96\\sqrt{p(1-p)/n} \\approx \\pm 2.8\\%$) gives a narrower interval. The point: even 1000 samples leave meaningful uncertainty in benchmark scores, which is why comparing models that differ by 1-2% is statistically dubious."

--- a/src/modules/prob-assessment-divergences.js
+++ b/src/modules/prob-assessment-divergences.js
@@ -19,10 +19,10 @@ export const divergencesAssessment = {
       type: "mc",
       question: "The KL divergence $\\text{KL}(P \\| Q) = \\mathbb{E}_P\\left[\\log \\frac{P(x)}{Q(x)}\\right]$ is NOT a true metric because:",
       options: [
-        "It can be negative",
-        "It is asymmetric ($\\text{KL}(P\\|Q) \\neq \\text{KL}(Q\\|P)$) and does not satisfy the triangle inequality",
-        "It is always infinite",
-        "It is only defined for Gaussian distributions"
+        "It can be negative for certain pairs of distributions, violating the non-negativity requirement that all proper distance metrics must satisfy",
+        "It is asymmetric ($\\text{KL}(P\\|Q) \\neq \\text{KL}(Q\\|P)$) and does not satisfy the triangle inequality required of a true metric",
+        "It is always infinite when the distributions have continuous densities, making it undefined for the most common use cases in practice",
+        "It is only defined for Gaussian distributions or members of the exponential family, and cannot be computed for arbitrary density functions"
       ],
       correct: 1,
       explanation: "KL divergence fails two metric properties: (1) asymmetry — $\\text{KL}(P \\| Q) \\neq \\text{KL}(Q \\| P)$ in general, and (2) no triangle inequality. It IS non-negative ($\\text{KL} \\geq 0$ by Gibbs' inequality) and equals zero iff $P = Q$. Despite not being a metric, it's the natural measure arising from likelihood-based training."
@@ -30,21 +30,21 @@ export const divergencesAssessment = {
     {
       type: "mc",
       question: "In RLHF, the objective is $\\max_\\pi \\mathbb{E}_{\\pi}[r(x)] - \\beta \\, \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$. The KL term $\\text{KL}(\\pi \\| \\pi_{\\text{ref}})$ is **forward KL** from $\\pi$ to $\\pi_{\\text{ref}}$. What behavior does this penalty enforce?",
-      options: ["Wherever $\\pi$ places probability mass, $\\pi_{\\text{ref}}$ must also have mass — preventing $\\pi$ from generating text that $\\pi_{\\text{ref}}$ considers highly unlikely", "It forces $\\pi$ to match a single mode of $\\pi_{\\text{ref}}$", "It ensures $\\pi_{\\text{ref}}$ covers all modes of $\\pi$", "It minimizes the entropy of $\\pi$"],
+      options: ["Wherever $\\pi$ places probability mass, $\\pi_{\\text{ref}}$ must also have mass — preventing $\\pi$ from generating text that the reference considers highly unlikely", "It forces $\\pi$ to collapse onto a single mode of $\\pi_{\\text{ref}}$, ensuring the policy specializes in one style of response rather than hedging across many", "It ensures $\\pi_{\\text{ref}}$ covers all modes of $\\pi$ symmetrically, so the reference distribution's support is a strict superset of the policy's support", "It minimizes the entropy of $\\pi$ directly, pushing the policy toward deterministic outputs that maximize reward without regard to diversity of generations"],
       correct: 0,
       explanation: "$\\text{KL}(\\pi \\| \\pi_{\\text{ref}}) = \\mathbb{E}_\\pi[\\log \\pi / \\pi_{\\text{ref}}]$ — the expectation is under $\\pi$. If $\\pi(x) > 0$ but $\\pi_{\\text{ref}}(x) \\approx 0$, the ratio explodes. So $\\pi$ is penalized for putting mass where the reference doesn't. This prevents \"reward hacking\" — generating text that scores high reward but is completely unlike natural text."
     },
     {
       type: "mc",
       question: "The **Jensen-Shannon divergence** $\\text{JS}(P \\| Q) = \\frac{1}{2}\\text{KL}(P \\| M) + \\frac{1}{2}\\text{KL}(Q \\| M)$ where $M = \\frac{1}{2}(P + Q)$ has which advantages over KL?",
-      options: ["It is always larger than KL divergence", "It is easier to compute than KL", "It is symmetric, bounded ($0 \\leq \\text{JS} \\leq \\log 2$), and well-defined even when supports don't fully overlap", "It converges faster during training"],
+      options: ["It is always larger than KL divergence for any pair of distributions, providing a more conservative upper bound on distributional distance for hypothesis testing", "It is easier to compute than KL in closed form because the mixture $M$ cancels the log-ratio singularities, reducing to a simple sum of entropies", "It is symmetric, bounded ($0 \\leq \\text{JS} \\leq \\log 2$), and well-defined even when the supports of $P$ and $Q$ do not fully overlap", "It converges faster during training of generative models because its gradient has lower variance than KL, leading to more stable optimization dynamics"],
       correct: 2,
       explanation: "JS divergence is symmetric ($\\text{JS}(P\\|Q) = \\text{JS}(Q\\|P)$), bounded by $\\log 2$, and always finite even when $P$ and $Q$ have disjoint support (because $M$ covers both). Its square root is a true metric. The original GAN objective minimizes JS divergence, but the bounded/finite property actually causes problems (vanishing gradients when $P$ and $Q$ are far apart)."
     },
     {
       type: "mc",
       question: "**Reverse KL** $\\text{KL}(Q \\| P)$ is called \"mode-seeking\" because when fitting $Q$ to a multimodal $P$:",
-      options: ["$Q$ covers all modes of $P$ uniformly", "$Q$ becomes uniform regardless of $P$", "$Q$ places mass only between modes", "$Q$ tends to concentrate on a single mode of $P$, fitting it precisely while ignoring others"],
+      options: ["$Q$ covers all modes of $P$ uniformly by spreading mass to avoid missing any region where $P$ has significant probability density", "$Q$ becomes approximately uniform regardless of the shape of $P$, since the reverse direction penalizes any deviation from maximum entropy", "$Q$ places most of its mass between modes of $P$, concentrating on transition regions where the density gradient is steepest", "$Q$ tends to concentrate on a single mode of $P$, fitting it precisely while assigning negligible mass to all other modes"],
       correct: 3,
       explanation: "In reverse KL, the expectation is under $Q$: $\\mathbb{E}_Q[\\log Q/P]$. If $Q$ places mass where $P(x) \\approx 0$, $\\log(Q/P) \\to \\infty$, so $Q$ avoids regions where $P$ is small. But $Q$ pays no penalty for *ignoring* modes of $P$ (since it doesn't sample there). So $Q$ \"seeks\" a single mode and fits it tightly. This is the behavior of variational inference with reverse KL."
     },
@@ -52,10 +52,10 @@ export const divergencesAssessment = {
       type: "mc",
       question: "The **Rényi divergence** of order $\\alpha$ is $D_\\alpha(P \\| Q) = \\frac{1}{\\alpha - 1} \\log \\mathbb{E}_Q\\left[\\left(\\frac{P(x)}{Q(x)}\\right)^\\alpha\\right]$. As $\\alpha \\to 1$, it converges to:",
       options: [
-        "The total variation distance",
+        "The total variation distance between $P$ and $Q$",
         "The KL divergence $\\text{KL}(P \\| Q)$",
-        "The Hellinger distance",
-        "Zero for all distributions"
+        "The squared Hellinger distance $H^2(P, Q)$",
+        "Zero for all pairs of distributions"
       ],
       correct: 1,
       explanation: "Rényi divergence is a one-parameter family that includes KL as a special case at $\\alpha \\to 1$ (by L'Hôpital's rule). At $\\alpha = 1/2$ it relates to the Hellinger distance, and at $\\alpha \\to \\infty$ it becomes the max-divergence $\\log \\max_x P(x)/Q(x)$. Different $\\alpha$ values weight tail behavior differently, making Rényi divergences useful for robust training objectives."
@@ -70,21 +70,21 @@ export const divergencesAssessment = {
     {
       type: "mc",
       question: "When two distributions $P$ and $Q$ have **disjoint supports** (no overlap), what happens to KL divergence, JS divergence, and total variation?",
-      options: ["All three are zero", "All three are infinite", "KL is undefined ($\\infty$), JS = $\\log 2$ (finite), TV = 1 (maximum)", "KL is finite, JS is infinite, TV = 0"],
+      options: ["All three are zero because the distributions share no common events and thus cannot disagree on any probability assignment", "All three are infinite because disjoint supports cause every divergence measure to diverge, regardless of boundedness properties", "KL is undefined ($\\infty$), JS = $\\log 2$ (finite maximum), TV = 1 (its maximum) — each measure handles the singularity differently", "KL is finite and well-behaved, JS is infinite due to the mixture term, TV = 0 because non-overlapping distributions have zero pointwise difference"],
       correct: 2,
       explanation: "With disjoint supports: KL is $+\\infty$ (dividing by zero in the log-ratio), JS is $\\log 2$ (its maximum, finite value), and TV is 1 (its maximum). This is why JS is preferred in some contexts — it gracefully handles non-overlapping distributions. However, this bounded behavior means JS gradients vanish when distributions are far apart, which was the original GAN training problem solved by Wasserstein distance."
     },
     {
       type: "mc",
       question: "The **f-divergence** framework defines $D_f(P \\| Q) = \\mathbb{E}_Q[f(P(x)/Q(x))]$ for convex $f$ with $f(1) = 0$. The **variational representation** $D_f(P \\| Q) = \\sup_T \\{\\mathbb{E}_P[T(x)] - \\mathbb{E}_Q[f^*(T(x))]\\}$ (where $f^*$ is the Fenchel conjugate) is important because:",
-      options: ["It allows exact computation of any f-divergence", "It eliminates the need for density ratio estimation", "It proves all f-divergences are equal", "It converts divergence estimation into an optimization problem that a neural network (discriminator/critic) can solve — this is the foundation of f-GANs"],
+      options: ["It allows exact computation of any f-divergence in closed form without requiring knowledge of the density ratio, using only samples from both distributions", "It eliminates the need for density ratio estimation by replacing it with a moment-matching condition between the two distributions that can be verified analytically", "It proves all f-divergences are equivalent up to a monotone transformation, meaning minimizing one f-divergence simultaneously minimizes all others in the family", "It converts divergence estimation into an optimization problem that a neural network (discriminator/critic) can solve — this is the theoretical foundation of f-GANs"],
       correct: 3,
       explanation: "The variational representation turns f-divergence computation into a supremum over functions $T$ — which a neural network can approximate. The original GAN uses this for JS divergence (where $T$ is the discriminator), and f-GANs generalize this to arbitrary f-divergences. This is a powerful trick: you never need to know the density ratio explicitly; instead, you train a network to estimate it."
     },
     {
       type: "mc",
       question: "In DPO (Direct Preference Optimization), the loss involves $\\log \\frac{\\pi_\\theta(y_w \\mid x)}{\\pi_{\\text{ref}}(y_w \\mid x)} - \\log \\frac{\\pi_\\theta(y_l \\mid x)}{\\pi_{\\text{ref}}(y_l \\mid x)}$ where $y_w$ is preferred over $y_l$. The log-ratios $\\log \\frac{\\pi_\\theta}{\\pi_{\\text{ref}}}$ are called **implicit rewards**. This formulation implicitly uses which divergence concept?",
-      options: ["Jensen-Shannon divergence between preferred and dispreferred completions", "The density ratio $\\pi_\\theta / \\pi_{\\text{ref}}$ that appears in KL divergence — DPO reparameterizes the RLHF objective's KL-constrained optimization into a supervised loss using the closed-form solution involving log-ratios", "Total variation distance between old and new policies", "Wasserstein distance in token space"],
+      options: ["Jensen-Shannon divergence between preferred and dispreferred completion distributions, symmetrizing the reward signal to stabilize gradient updates during policy training", "The density ratio $\\pi_\\theta / \\pi_{\\text{ref}}$ that appears in KL divergence — DPO reparameterizes the KL-constrained RLHF objective into a supervised loss via the closed-form solution", "Total variation distance between the old and new policies, which bounds the maximum change in action probabilities and ensures conservative policy updates per step", "Wasserstein distance in token embedding space, measuring the minimum transport cost to move probability mass from the reference policy's outputs to the trained policy's"],
       correct: 1,
       explanation: "DPO derives from the RLHF objective $\\max_\\pi \\mathbb{E}[r(x)] - \\beta \\text{KL}(\\pi \\| \\pi_{\\text{ref}})$, whose closed-form solution is $\\pi^*(y \\mid x) \\propto \\pi_{\\text{ref}}(y \\mid x) \\exp(r(y,x)/\\beta)$. Rearranging gives $r(y,x) = \\beta \\log \\frac{\\pi^*(y \\mid x)}{\\pi_{\\text{ref}}(y \\mid x)} + \\text{const}$. DPO substitutes this into the Bradley-Terry preference model, yielding a supervised loss that implicitly optimizes the KL-constrained objective."
     }

--- a/src/modules/prob-assessment-entropy.js
+++ b/src/modules/prob-assessment-entropy.js
@@ -18,7 +18,7 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "The **entropy** $H(X) = -\\sum_x p(x) \\log p(x)$ of a discrete random variable is maximized when:",
-      options: ["The distribution is concentrated on a single outcome (deterministic)", "The distribution has the largest possible support", "The distribution is Gaussian", "The distribution is uniform over all outcomes"],
+      options: ["The distribution is concentrated on a single outcome, making the variable fully deterministic with zero uncertainty", "The distribution has the largest possible support, regardless of how probability mass is allocated across outcomes", "The distribution is Gaussian with mean zero and unit variance, the maximum entropy continuous distribution", "The distribution is uniform over all outcomes, assigning equal probability $1/K$ to each of the $K$ possibilities"],
       correct: 3,
       explanation: "For a discrete variable with $K$ outcomes, entropy is maximized at $H = \\log K$ when $p(x) = 1/K$ (uniform). Any deviation from uniform reduces entropy. Intuitively, entropy measures uncertainty — maximum uncertainty means every outcome is equally likely. This is why temperature scaling in LLMs (which pushes the distribution toward uniform) increases entropy and diversity of outputs."
     },
@@ -32,7 +32,7 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "**Perplexity** of a language model on data $P$ is defined as $\\text{PPL} = 2^{H(P,Q)}$ (or $e^{H(P,Q)}$ in nats). A model with perplexity 50 on a vocabulary of 50,000 tokens means:",
-      options: ["On average, the model is as uncertain as choosing uniformly among 50 equally likely tokens at each step", "The model gets 50% of predictions correct", "The model uses 50 bits per token", "The vocabulary can be reduced to 50 tokens without loss"],
+      options: ["On average, the model is as uncertain as choosing uniformly among 50 equally likely tokens at each position in the sequence", "The model correctly predicts exactly 50% of tokens in the sequence when evaluated using greedy argmax decoding", "The model requires approximately 50 bits of information to encode each token it encounters in the input sequence", "The effective vocabulary can be compressed down to just 50 tokens without any measurable loss of model performance"],
       correct: 0,
       explanation: "Perplexity is the exponential of cross-entropy. A perplexity of 50 means the model's uncertainty is equivalent to choosing uniformly from 50 options. Lower perplexity = more confident = better model. A uniform model over 50K tokens would have perplexity 50,000. Getting from 50,000 to 50 represents learning enormous amounts of structure."
     },
@@ -40,10 +40,10 @@ export const entropyAssessment = {
       type: "mc",
       question: "The **mutual information** $I(X; Y) = H(X) - H(X \\mid Y)$ measures the reduction in uncertainty about $X$ after observing $Y$. Which of the following is TRUE?",
       options: [
-        "$I(X; Y)$ can be negative when $Y$ adds confusion about $X$",
-        "$I(X; Y) = I(Y; X)$ — it is symmetric",
-        "$I(X; Y) = H(X) + H(Y)$ always",
-        "$I(X; Y) = 0$ implies $X$ and $Y$ are identically distributed"
+        "$I(X; Y)$ can be negative when $Y$ adds confusion about $X$, increasing overall uncertainty beyond the marginal entropy",
+        "$I(X; Y) = I(Y; X)$ — it is symmetric, meaning $X$ tells you as much about $Y$ as $Y$ tells you about $X$",
+        "$I(X; Y) = H(X) + H(Y)$ always, since mutual information combines the total uncertainty of both variables",
+        "$I(X; Y) = 0$ implies $X$ and $Y$ are identically distributed, meaning they share the same probability mass function"
       ],
       correct: 1,
       explanation: "$I(X; Y) = H(X) - H(X \\mid Y) = H(Y) - H(Y \\mid X) = I(Y; X)$. It's symmetric, non-negative (since conditioning cannot increase entropy on average), and equals zero if and only if $X$ and $Y$ are independent. Mutual information is the key quantity in the **information bottleneck** principle and in understanding what representations learn."
@@ -51,21 +51,21 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "**Conditional entropy** $H(X \\mid Y) = \\mathbb{E}_Y[H(X \\mid Y = y)]$. In the context of language modeling, $H(W_t \\mid W_{<t})$ represents:",
-      options: ["The entropy of the vocabulary distribution", "The number of possible next tokens", "The probability of the most likely next token", "The average uncertainty about the next token given the context — the irreducible per-token loss for a perfect model"],
+      options: ["The total entropy of the full vocabulary distribution, computed without conditioning on any preceding context tokens", "The cardinality of the set of possible next tokens that have nonzero probability under the language model", "The log-probability of the single most likely next token, which determines the greedy decoding selection", "The average uncertainty about the next token given the context — the irreducible per-token loss for a perfect model"],
       correct: 3,
       explanation: "$H(W_t \\mid W_{<t})$ is the conditional entropy of the next token given all previous tokens. For a *perfect* model $Q = P$, the cross-entropy equals $H(P) = H(W_t \\mid W_{<t})$ — this is the irreducible uncertainty. No model can beat this bound. The gap between a model's cross-entropy and this quantity is exactly $\\text{KL}(P \\| Q)$."
     },
     {
       type: "mc",
       question: "The **data processing inequality** states that for a Markov chain $X \\to Y \\to Z$, we have $I(X; Z) \\leq I(X; Y)$. What does this imply for neural network representations?",
-      options: ["Deeper layers always lose information about the input", "The final layer has zero mutual information with the input", "Each layer can only preserve or lose information about the input — never create new information about it", "All layers must have equal mutual information with the input"],
+      options: ["Deeper layers always lose a strictly positive amount of information about the input at every processing step", "The final layer retains zero mutual information with the input, having discarded everything during processing", "Each layer can only preserve or lose information about the input — never create new information about it", "All layers in the network must maintain exactly equal mutual information with the original input signal"],
       correct: 2,
       explanation: "The data processing inequality says information can only be lost, never gained, through processing. If $X \\to \\text{layer}_1 \\to \\text{layer}_2$, then $I(X; \\text{layer}_2) \\leq I(X; \\text{layer}_1)$. This is the theoretical foundation of the **information bottleneck** view: good representations compress away irrelevant information while retaining information relevant to the task."
     },
     {
       type: "mc",
       question: "The **chain rule of mutual information** states $I(X; Y, Z) = I(X; Y) + I(X; Z \\mid Y)$. If a context window includes both recent tokens $Y$ and distant tokens $Z$, and $I(X; Z \\mid Y) \\approx 0$, this means:",
-      options: ["Distant tokens provide no additional information about the next token beyond what recent tokens already provide", "Distant tokens are more important than recent tokens", "The model should ignore all context", "Recent and distant tokens are independent of each other"],
+      options: ["Distant tokens provide no additional information about the next token beyond what the recent context tokens already capture", "Distant tokens carry substantially more predictive information about the next token than the recent tokens do", "The model should discard all contextual information and rely only on the unconditional token frequency distribution", "Recent tokens and distant tokens are statistically independent of each other with zero mutual information between them"],
       correct: 0,
       explanation: "$I(X; Z \\mid Y) \\approx 0$ means that once you condition on recent context $Y$, distant context $Z$ adds negligible information about next token $X$. This does NOT mean $Z$ is independent of $Y$ — just that $Z$'s predictive value is already captured by $Y$. This relates to why many practical tasks work well with limited context, and why efficient attention methods that prioritize local context can work."
     },
@@ -73,10 +73,10 @@ export const entropyAssessment = {
       type: "mc",
       question: "The **entropy rate** of a stochastic process is $h = \\lim_{n \\to \\infty} \\frac{1}{n} H(X_1, \\dots, X_n)$. For English text, the entropy rate is estimated at roughly 1-1.5 bits per character. This means:",
       options: [
-        "English text is completely random",
+        "English text is effectively random with no exploitable statistical structure between consecutive characters",
         "Each character carries about 1-1.5 bits of information on average after accounting for all statistical patterns — English is highly redundant given its ~4.7-bit alphabet",
-        "You need 1-1.5 characters to encode each bit",
-        "A perfect language model would have perplexity between 1 and 1.5"
+        "You need approximately 1-1.5 characters of input context to encode each single bit of information content",
+        "A perfect language model operating at the entropy limit would achieve a perplexity score between 1.0 and 1.5"
       ],
       correct: 1,
       explanation: "With 26+ characters, a uniform distribution would give ~4.7 bits/char. The entropy rate of ~1.3 bits/char means English is about 72% redundant — most characters are highly predictable from context. This massive redundancy is what LLMs exploit. Shannon estimated this in 1951 using human prediction experiments. Modern LLMs approach (and perhaps reach) this bound."
@@ -84,42 +84,42 @@ export const entropyAssessment = {
     {
       type: "mc",
       question: "When fine-tuning with **label smoothing** (mixing the hard target with a uniform distribution), the effective target becomes $P'(y) = (1 - \\alpha) \\cdot \\mathbf{1}[y = y^*] + \\alpha / K$. How does this affect the cross-entropy loss landscape?",
-      options: ["It has no effect on training dynamics", "It increases the entropy of the model to match the entropy of the smoothed labels", "It makes the model converge to a uniform distribution", "It prevents the model from driving logits to $\\pm \\infty$ — the optimal logit gap becomes finite, acting as implicit regularization on confidence"],
+      options: ["It has no measurable effect on training dynamics because the smoothing parameter $\\alpha$ is typically too small to alter gradient magnitudes", "It raises the entropy floor of the model's output distribution to match the nonzero entropy of the smoothed target labels", "It forces the model to converge toward a uniform distribution over all classes, eliminating any discriminative signal", "It prevents the model from driving logits to $\\pm \\infty$ — the optimal logit gap becomes finite, acting as implicit regularization on confidence"],
       correct: 3,
       explanation: "Without label smoothing, the optimal logits are $+\\infty$ for the correct class and $-\\infty$ for others. Label smoothing caps the optimal logit gap at a finite value (proportional to $\\log((1-\\alpha)K/\\alpha)$), preventing overconfident predictions. This acts as entropy regularization — the model's output entropy stays bounded away from zero, improving calibration and generalization."
     },
     {
       type: "mc",
       question: "A model's training cross-entropy loss converges to 2.5 nats per token but validation loss plateaus at 3.2 nats. What is the most informative interpretation?",
-      options: ["The model is underfitting — it needs more parameters to reduce training loss further", "The gap of 0.7 nats between train and val represents overfitting: the model memorizes training patterns that don't generalize, wasting capacity on spurious correlations", "The true entropy rate of the language is exactly 2.5 nats", "The validation set is from a different language or domain"],
+      options: ["The model is underfitting and needs more parameters or layers to reduce the training loss further below its current plateau", "The gap of 0.7 nats between train and val represents overfitting: the model memorizes training patterns that don't generalize, wasting capacity on spurious correlations", "The true entropy rate of the underlying language distribution is exactly 2.5 nats, and the model has achieved the theoretical optimum", "The validation set comes from a substantially different language or domain, making the two loss values fundamentally incomparable"],
       correct: 1,
       explanation: "The train-val gap (0.7 nats) indicates the model has memorized training-specific patterns. Training loss reflects both genuine language structure and training-set-specific memorization; the difference (generalization gap) quantifies the latter. The true entropy rate $H(P)$ is at most the validation loss (3.2 nats), since $H(P, Q_{\\text{val}}) = H(P) + \\text{KL}(P \\| Q)$ and KL is non-negative. The training loss can go below $H(P)$ precisely because of memorization."
     },
     {
       type: "mc",
       question: "You apply temperature scaling with $T = 2.0$ to a model's logits during inference. If the original top-1 probability was 0.95, approximately what will it become?",
-      options: ["$0.95 / 2 = 0.475$ — probabilities scale linearly with temperature", "Still close to 0.95 — temperature only affects low-probability tokens", "Significantly reduced (roughly $0.95^{1/2} \\approx 0.87$ to $0.90$, depending on logit structure) — dividing logits by 2 compresses them toward zero, spreading mass to other tokens", "Exactly $0.5$ — doubling temperature always halves the top probability"],
+      options: ["Approximately $0.95 / 2 = 0.475$ — token probabilities scale linearly and inversely with temperature in the softmax function", "Still close to 0.95 — temperature scaling primarily redistributes mass among low-probability tokens and leaves the top token nearly unchanged", "Significantly reduced (roughly $0.87$ to $0.90$, depending on the logit structure) — dividing logits by 2 compresses them toward zero, spreading mass to other tokens", "Exactly $0.5$ regardless of the original distribution — doubling the temperature parameter always halves the top token's probability"],
       correct: 2,
       explanation: "Temperature scaling divides logits by $T$ before softmax. If the top logit was much larger than others (giving 0.95), dividing by 2 halves the logit gap, spreading probability to other tokens. The exact new probability depends on the logit distribution, but for a sharply peaked distribution going from $T=1$ to $T=2$ typically reduces the top probability noticeably. The relationship is NOT linear in $T$ — it goes through the softmax nonlinearity."
     },
     {
       type: "mc",
       question: "In contrastive learning (e.g., SimCLR), why does using a very small batch size (e.g., 32) limit performance even with longer training?",
-      options: ["Small batches cause gradient noise that prevents convergence", "The InfoNCE bound on MI is $\\log N$ where $N$ is batch size — a batch of 32 can estimate at most $\\log_2(32) = 5$ bits of MI, regardless of training duration", "Small batches cause mode collapse in the representation space", "Small batches violate the i.i.d. assumption required for contrastive learning"],
+      options: ["Small batches introduce excessive gradient noise that prevents the optimization from converging to a good minimum in the loss landscape", "The InfoNCE bound on MI is $\\log N$ where $N$ is batch size — a batch of 32 can estimate at most $\\log_2(32) = 5$ bits of MI, regardless of training duration", "Small batches inevitably cause complete mode collapse in the learned representation space, mapping all inputs to identical embeddings", "Small batches violate the i.i.d. sampling assumption required by the contrastive loss, introducing systematic bias into the gradient estimates"],
       correct: 1,
       explanation: "The InfoNCE loss provides a lower bound: $I(X;Y) \\geq \\log N - \\mathcal{L}$. Even if the loss reaches 0, you can only estimate $\\log N$ bits of MI. With batch size 32: $\\log_2(32) = 5$ bits maximum. If the true MI between views is much higher, this ceiling prevents the model from learning fine-grained distinctions. This is why CLIP uses batch sizes of 32K+ ($\\log_2(32768) \\approx 15$ bits) — it raises the MI ceiling, enabling richer representations."
     },
     {
       type: "mc",
       question: "For a Markov chain $X \\to Y \\to Z$, when does $I(X; Z) = I(X; Y)$ (equality in the data processing inequality)?",
-      options: ["When $Z$ is a higher-dimensional version of $Y$ (e.g., zero-padding)", "When $Z$ is a sufficient statistic of $Y$ for $X$ — meaning $X \\to Z \\to Y$ is also a valid Markov chain, so no information about $X$ is lost", "Equality never holds — processing always loses some information", "Only when $Y = Z$ (the identity mapping)"],
+      options: ["When $Z$ is a higher-dimensional version of $Y$ constructed by zero-padding, which increases the representation size without adding information", "When $Z$ is a sufficient statistic of $Y$ for $X$ — meaning $X \\to Z \\to Y$ is also a valid Markov chain, so no information about $X$ is lost", "Equality can never hold in practice — any deterministic or stochastic processing of $Y$ must strictly lose some information content", "Only when $Y = Z$ exactly (the identity mapping), since any nontrivial transformation necessarily destroys mutual information"],
       correct: 1,
       explanation: "DPI gives equality when $Z$ retains all information that $Y$ has about $X$, formally when $Z$ is a sufficient statistic of $Y$ for $X$. This means $P(X \\mid Y) = P(X \\mid Z)$ — knowing $Z$ is just as good as knowing $Y$ for predicting $X$. An invertible transformation $Z = g(Y)$ trivially satisfies this (since $Y$ can be recovered from $Z$), but sufficiency is the general condition. Identity is sufficient but not necessary."
     },
     {
       type: "mc",
       question: "A language model trained on English text achieves perplexity 8.0. Shannon estimated English entropy at ~1.3 bits/char, and BPE tokens average ~4 chars. How does this model compare to the theoretical limit?",
-      options: ["The model has nearly reached the entropy limit — $\\log_2(8) = 3$ bits/token vs theoretical ~$4 \\times 1.3 = 5.2$ bits/token, actually beating it because the tokenizer absorbs spelling redundancy", "The model is far above the limit — perplexity 8 is very high", "The comparison is invalid because Shannon's estimate is per character, not per token", "The model exactly matches the entropy limit"],
+      options: ["The model has nearly reached the entropy limit — $\\log_2(8) = 3$ bits/token vs theoretical ~$4 \\times 1.3 = 5.2$ bits/token, actually beating it because the tokenizer absorbs spelling redundancy", "The model is far above the theoretical limit — a perplexity of 8 is very high and indicates the model has failed to capture most statistical structure", "The comparison is fundamentally invalid because Shannon's character-level entropy estimate cannot be meaningfully converted to a per-token entropy bound", "The model exactly matches the entropy limit — perplexity 8 on a 4-char-per-token vocabulary corresponds precisely to Shannon's 1.3 bits/char estimate"],
       correct: 0,
       explanation: "At perplexity 8: cross-entropy $= \\log_2(8) = 3$ bits/token. Shannon's character-level entropy rate (~1.3 bits/char) times ~4 chars/token gives ~5.2 bits/token as a crude token-level estimate. But BPE tokenization already encodes spelling patterns (absorbing ~1-2 bits/char of redundancy), so the effective per-token entropy limit is lower than 5.2 bits. The model at 3 bits/token is performing well, suggesting it captures most of the remaining (post-tokenization) statistical structure."
     }

--- a/src/modules/prob-assessment-exponential-family.js
+++ b/src/modules/prob-assessment-exponential-family.js
@@ -18,14 +18,14 @@ export const exponentialFamilyAssessment = {
     {
       type: "mc",
       question: "An exponential family distribution has the form $p(x \\mid \\theta) = h(x) \\exp(\\eta(\\theta)^\\top T(x) - A(\\theta))$. What role does $A(\\theta)$ (the log-partition function) play?",
-      options: ["It defines the prior distribution over $\\theta$", "It computes the mode of the distribution", "It is a normalization constant ensuring the distribution sums/integrates to 1", "It measures the divergence between the model and the true distribution"],
+      options: ["It defines the prior distribution over $\\theta$ in the Bayesian conjugate update, controlling how much the posterior is influenced by the likelihood", "It computes the mode of the distribution by finding the value of $x$ that maximizes the unnormalized density $h(x)\\exp(\\eta^\\top T(x))$", "It is a normalization constant ensuring the distribution sums or integrates to 1, and its derivatives yield the moments of the distribution", "It measures the divergence between the model distribution and the true data-generating distribution, acting as an implicit regularizer"],
       correct: 2,
       explanation: "$A(\\theta) = \\log \\int h(x) \\exp(\\eta(\\theta)^\\top T(x))\\, dx$ is the log-partition function. It ensures normalization. Crucially, its derivatives give the moments: $\\nabla_\\eta A = \\mathbb{E}[T(x)]$ and $\\nabla^2_\\eta A = \\text{Cov}[T(x)]$. This means the log-partition function encodes everything about the distribution's moments."
     },
     {
       type: "mc",
       question: "The softmax output layer of an LLM defines a **categorical distribution** over tokens. In exponential family form, the natural parameters $\\eta_i$ correspond to:",
-      options: ["The token embeddings", "The attention weights", "The softmax probabilities themselves", "The logits (pre-softmax scores)"],
+      options: ["The token embeddings produced by the final transformer layer, which encode semantic meaning before being converted to a probability distribution", "The attention weights computed across all heads in the last layer, which determine how much each token in the context influences the next-token prediction", "The softmax probabilities themselves, since the natural parameterization of the categorical distribution is in terms of the normalized output values", "The logits (pre-softmax scores), since the categorical distribution in exponential form is $P(w=i) = \\exp(\\eta_i - \\log\\sum_j \\exp(\\eta_j))$"],
       correct: 3,
       explanation: "The categorical distribution in exponential family form is $P(w = i) = \\exp(\\eta_i - A(\\eta))$ where $A(\\eta) = \\log \\sum_j \\exp(\\eta_j)$ (the log-sum-exp). The logits **are** the natural parameters. This is why working in logit space (rather than probability space) is natural for optimization — gradients in the natural parameterization have nice properties."
     },
@@ -33,10 +33,10 @@ export const exponentialFamilyAssessment = {
       type: "mc",
       question: "A **sufficient statistic** $T(x)$ for parameter $\\theta$ means that $T(x)$ captures all information about $\\theta$ in the data. For the Gaussian $\\mathcal{N}(\\mu, \\sigma^2)$, the sufficient statistics of a sample $x_1, \\dots, x_n$ are:",
       options: [
-        "The sample median and range",
-        "$\\sum_i x_i$ and $\\sum_i x_i^2$ (or equivalently, sample mean and sample variance)",
-        "The minimum and maximum values",
-        "All individual data points — no compression is possible"
+        "The sample median and range, which together capture the location and spread of the data under the assumption of symmetry",
+        "$\\sum_i x_i$ and $\\sum_i x_i^2$ (or equivalently, sample mean and sample variance) — these capture all information about $(\\mu, \\sigma^2)$",
+        "The minimum and maximum values, which define the convex hull of the data and bound all possible parameter estimates",
+        "All individual data points with no compression possible, because the Gaussian likelihood depends on every observation individually"
       ],
       correct: 1,
       explanation: "For the Gaussian, $T(X) = (\\sum x_i, \\sum x_i^2)$ are sufficient for $(\\mu, \\sigma^2)$. This means you can throw away the raw data and keep only these two numbers without losing any information about the parameters. For exponential families in general, the sufficient statistics are exactly the $T(x)$ appearing in the exponential family form."
@@ -45,10 +45,10 @@ export const exponentialFamilyAssessment = {
       type: "mc",
       question: "The MLE for an exponential family distribution satisfies the **moment matching** condition. What does this mean?",
       options: [
-        "The MLE parameters are the sample moments themselves",
+        "The MLE parameters are the sample moments themselves, so the estimated natural parameters equal the empirical mean and variance directly",
         "The model's expected sufficient statistics equal the empirical sufficient statistics: $\\mathbb{E}_{\\hat{\\theta}}[T(x)] = \\frac{1}{n}\\sum_i T(x_i)$",
-        "All moments of the model distribution must be finite",
-        "The distribution must have the same number of moments as parameters"
+        "All moments of the model distribution must be finite for the MLE to exist, which restricts the family to light-tailed distributions only",
+        "The distribution must have the same number of moments as free parameters, creating a square system of equations that uniquely determines the MLE"
       ],
       correct: 1,
       explanation: "Setting the gradient of the log-likelihood to zero gives $\\nabla_\\eta A(\\hat{\\eta}) = \\frac{1}{n} \\sum_i T(x_i)$. Since $\\nabla_\\eta A = \\mathbb{E}[T(x)]$, the MLE solution matches model moments to empirical moments. This is why cross-entropy training of a language model matches the model's predicted token frequencies to the training data's token frequencies."
@@ -57,10 +57,10 @@ export const exponentialFamilyAssessment = {
       type: "mc",
       question: "Why is the **negative log-likelihood** loss function convex in the natural parameters $\\eta$ for exponential family models?",
       options: [
-        "Because neural networks are convex models",
-        "Because $A(\\eta)$ is convex (its Hessian $\\nabla^2 A = \\text{Cov}[T(x)]$ is positive semi-definite), and the NLL is $A(\\eta) - \\eta^\\top T(x)$ which is convex in $\\eta$",
-        "Because the data is always well-conditioned",
-        "Convexity is not guaranteed — it depends on the data"
+        "Because neural networks are convex models when parameterized in terms of their final-layer logits, making the entire optimization landscape globally convex",
+        "Because $A(\\eta)$ is convex (its Hessian $\\nabla^2 A = \\text{Cov}[T(x)]$ is PSD), and the NLL is $A(\\eta) - \\eta^\\top T(x)$ which is convex in $\\eta$",
+        "Because the data is always well-conditioned when drawn from an exponential family, ensuring the Hessian of the loss remains positive definite everywhere",
+        "Convexity is not guaranteed in general — it depends on the specific dataset and whether the sufficient statistics span the natural parameter space"
       ],
       correct: 1,
       explanation: "The NLL per sample is $-\\log p(x \\mid \\eta) = A(\\eta) - \\eta^\\top T(x) + \\text{const}$. The Hessian w.r.t. $\\eta$ is $\\nabla^2 A(\\eta) = \\text{Cov}[T(x)] \\succeq 0$, which is PSD. So the NLL is convex in $\\eta$. Note: for neural networks, $\\eta$ is a nonlinear function of the weights, so the overall loss is non-convex in the weights — but the final layer (logits → loss) is convex."
@@ -68,21 +68,21 @@ export const exponentialFamilyAssessment = {
     {
       type: "mc",
       question: "The **Fisher information matrix** $\\mathcal{I}(\\theta) = \\mathbb{E}\\left[\\nabla \\log p(x \\mid \\theta) \\nabla \\log p(x \\mid \\theta)^\\top\\right]$ plays what role in MLE?",
-      options: ["It gives the asymptotic covariance of the MLE: $\\hat{\\theta}_{\\text{MLE}} \\sim \\mathcal{N}(\\theta, \\mathcal{I}(\\theta)^{-1}/n)$ as $n \\to \\infty$", "It determines the learning rate for SGD", "It measures the distance between the model and the data", "It equals the Hessian of the log-prior"],
+      options: ["It gives the asymptotic covariance of the MLE: $\\hat{\\theta}_{\\text{MLE}} \\sim \\mathcal{N}(\\theta, \\mathcal{I}(\\theta)^{-1}/n)$ as $n \\to \\infty$, achieving the Cramér-Rao lower bound", "It determines the optimal learning rate schedule for SGD by measuring the local curvature of the loss surface at each point in parameter space", "It measures the divergence between the model's predicted distribution and the empirical data distribution, serving as an alternative to cross-entropy loss", "It equals the Hessian of the log-prior in Bayesian inference, connecting the Fisher matrix to the curvature of the regularization term in MAP estimation"],
       correct: 0,
       explanation: "The Cramér-Rao bound says no unbiased estimator can have variance lower than $\\mathcal{I}(\\theta)^{-1}/n$, and the MLE achieves this bound asymptotically. The Fisher matrix also defines the **natural gradient** $\\mathcal{I}^{-1} \\nabla \\ell$ — a direction that accounts for the geometry of the parameter space. This connects to Adam (which approximates diagonal Fisher) and to natural gradient methods in RL."
     },
     {
       type: "mc",
       question: "In practice, we train LLMs by minimizing cross-entropy on finite data. MLE is known to **overfit** without regularization. From a Bayesian perspective, L2 regularization ($\\lambda \\|\\theta\\|^2$) corresponds to:",
-      options: ["A uniform prior over $\\theta$", "A Laplace prior over $\\theta$", "A Gaussian prior $\\theta \\sim \\mathcal{N}(0, \\frac{1}{2\\lambda} I)$ — making the loss a MAP estimate", "Minimizing the Fisher information"],
+      options: ["A uniform prior over $\\theta$ that assigns equal probability to all parameter values, making the regularized estimate equivalent to constrained maximum likelihood", "A Laplace prior over $\\theta$ that places a sharp peak at zero, promoting sparsity by driving small weights exactly to zero during optimization", "A Gaussian prior $\\theta \\sim \\mathcal{N}(0, \\frac{1}{2\\lambda} I)$ — making the regularized loss equivalent to a MAP (maximum a posteriori) estimate under that prior", "A minimization of the Fisher information matrix trace, which reduces the model's sensitivity to small perturbations in the input data distribution"],
       correct: 2,
       explanation: "Adding $\\lambda \\|\\theta\\|^2$ to the NLL gives $-\\log p(x \\mid \\theta) + \\lambda \\|\\theta\\|^2 = -\\log p(x \\mid \\theta) - \\log p(\\theta) + \\text{const}$ where $p(\\theta) \\propto \\exp(-\\lambda \\|\\theta\\|^2)$ is a Gaussian. This makes the solution a **MAP** (maximum a posteriori) estimate rather than pure MLE. L1 regularization corresponds to a Laplace prior and promotes sparsity."
     },
     {
       type: "mc",
       question: "When computing the MLE for a mixture model $p(x) = \\sum_k \\pi_k p_k(x \\mid \\theta_k)$, the log-likelihood has a log-sum that makes direct optimization hard. What standard algorithm addresses this?",
-      options: ["Gradient descent on the log-likelihood directly", "Grid search over all parameter values", "Gibbs sampling from the posterior", "The EM (Expectation-Maximization) algorithm, which alternates between computing posterior cluster assignments (E-step) and updating parameters (M-step)"],
+      options: ["Gradient descent on the log-likelihood directly, using automatic differentiation to handle the log-sum-exp and its derivatives without any special treatment", "Grid search over all parameter values in a discretized space, evaluating the likelihood at each grid point to find the global maximum by exhaustive enumeration", "Gibbs sampling from the joint posterior over parameters and latent assignments, producing a Markov chain whose stationary distribution is the exact posterior", "The EM (Expectation-Maximization) algorithm, which alternates between computing posterior cluster assignments (E-step) and updating parameters to maximize expected complete-data log-likelihood (M-step)"],
       correct: 3,
       explanation: "EM handles the intractable log-sum by introducing latent variables $z$ (cluster assignments). The E-step computes $q(z) = P(z \\mid x, \\theta^{\\text{old}})$, and the M-step maximizes $\\mathbb{E}_q[\\log p(x, z \\mid \\theta)]$. Each iteration is guaranteed to increase the log-likelihood. EM is a special case of variational inference where the E-step is exact."
     }

--- a/src/modules/prob-assessment-foundations.js
+++ b/src/modules/prob-assessment-foundations.js
@@ -25,7 +25,7 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "You have a classifier with 95% true positive rate ($P(\\text{pos} \\mid \\text{spam}) = 0.95$) and 3% false positive rate ($P(\\text{pos} \\mid \\text{ham}) = 0.03$). If only 1% of emails are spam ($P(\\text{spam}) = 0.01$), what is $P(\\text{spam} \\mid \\text{pos})$ approximately?",
-      options: ["About 95% — the classifier is very accurate", "About 50% — it's a coin flip", "About 1% — the prior barely changes", "About 24% — the low base rate dominates"],
+      options: ["About 95% — the high true positive rate directly translates into high posterior confidence about spam classification", "About 50% — the competing evidence from prior and likelihood roughly cancels out, making it effectively a coin flip", "About 1% — the extremely low base rate completely overwhelms any discriminative signal from the classifier's likelihood", "About 24% — the low base rate substantially dilutes the classifier's signal despite the high true positive rate"],
       correct: 3,
       explanation: "By Bayes' theorem: $P(\\text{spam} \\mid \\text{pos}) = \\frac{0.95 \\times 0.01}{0.95 \\times 0.01 + 0.03 \\times 0.99} = \\frac{0.0095}{0.0095 + 0.0297} \\approx 0.242$. This is the base rate fallacy — even with a good classifier, a low prior dramatically reduces the posterior. This is critical intuition for understanding how priors interact with likelihoods."
     },
@@ -33,10 +33,10 @@ export const probabilityFoundationsAssessment = {
       type: "mc",
       question: "Which property distinguishes the **Gaussian distribution** from other distributions, making it appear so frequently in machine learning?",
       options: [
-        "It is the only distribution with finite variance",
+        "It is the only continuous distribution that has a well-defined and finite variance parameter",
         "Among all distributions with a given mean and variance, it maximizes entropy",
-        "It is the only continuous distribution that is also an exponential family member",
-        "It is the only distribution closed under multiplication"
+        "It is the only continuous distribution that belongs to the exponential family of distributions",
+        "It is the only distribution that remains closed under the operation of multiplication"
       ],
       correct: 1,
       explanation: "The Gaussian is the **maximum entropy distribution** for a given mean and variance. This means it makes the fewest assumptions beyond those two constraints. This is why Gaussian assumptions appear everywhere — they're the most \"uninformative\" choice given first and second moments. The central limit theorem reinforces this: sums of many independent variables converge to Gaussian regardless of individual distributions."
@@ -44,14 +44,14 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "In a language model's output layer, the **softmax** function converts logits $z_i$ to probabilities. Which distribution does this define over the vocabulary?",
-      options: ["A multinomial (categorical) distribution", "A Bernoulli distribution", "A Poisson distribution", "A Dirichlet distribution"],
+      options: ["A multinomial (categorical) distribution where one token is sampled from the vocabulary according to the computed probabilities", "A Bernoulli distribution representing a binary choice between the most likely token and all remaining alternatives", "A Poisson distribution modeling the expected count of each token type appearing in the generated sequence", "A Dirichlet distribution parameterizing a distribution over probability vectors across the full vocabulary space"],
       correct: 0,
       explanation: "Softmax produces a **categorical distribution** over the vocabulary: $P(w = i) = \\frac{e^{z_i}}{\\sum_j e^{z_j}}$. Each token gets a probability, probabilities sum to 1, and we sample one token. When we sample multiple tokens with replacement, the counts follow a multinomial. The Dirichlet would be a distribution *over* such probability vectors, not a single draw."
     },
     {
       type: "mc",
       question: "The **law of total expectation** states $\\mathbb{E}[X] = \\mathbb{E}[\\mathbb{E}[X \\mid Y]]$. In the context of language modeling, if $X$ is the log-probability of a sequence and $Y$ is the topic, this means:",
-      options: ["The overall log-probability equals the best topic-conditional log-probability", "The log-probability is independent of the topic", "The overall expected log-probability is the topic-weighted average of per-topic expected log-probabilities", "You must know the topic to compute the log-probability"],
+      options: ["The overall log-probability equals the best topic-conditional log-probability, computed by selecting the highest-scoring topic assignment", "The log-probability is statistically independent of the topic, so conditioning on topic provides no additional predictive information", "The overall expected log-probability is the topic-weighted average of per-topic expected log-probabilities", "You must first identify the exact topic before you can compute any meaningful estimate of the sequence log-probability"],
       correct: 2,
       explanation: "The law of total expectation says you can decompose an unconditional expectation by first conditioning on $Y$, computing the conditional expectation, then averaging over $Y$. Here: $\\mathbb{E}[\\log P] = \\sum_{\\text{topic}} P(\\text{topic}) \\cdot \\mathbb{E}[\\log P \\mid \\text{topic}]$. This is fundamental to understanding mixture models and how perplexity varies across data subsets."
     },
@@ -59,10 +59,10 @@ export const probabilityFoundationsAssessment = {
       type: "mc",
       question: "Random variables $X$ and $Y$ are **independent** if and only if:",
       options: [
-        "$\\mathbb{E}[XY] = 0$",
-        "$P(X, Y) = P(X) \\cdot P(Y)$ for all values",
-        "$\\text{Cov}(X, Y) = 0$",
-        "$P(X \\mid Y) > P(X)$ for all values"
+        "$\\mathbb{E}[XY] = 0$, meaning the expected value of the product of $X$ and $Y$ is exactly zero",
+        "$P(X, Y) = P(X) \\cdot P(Y)$ for all values, meaning the joint distribution fully factorizes into marginals",
+        "$\\text{Cov}(X, Y) = 0$, meaning the linear correlation between $X$ and $Y$ vanishes completely",
+        "$P(X \\mid Y) > P(X)$ for all values, meaning observing $Y$ always increases the probability of $X$"
       ],
       correct: 1,
       explanation: "Independence means the joint factorizes: $P(X, Y) = P(X) P(Y)$. This is stronger than zero covariance — uncorrelated variables can still be dependent (e.g., $X \\sim \\text{Uniform}(-1,1)$ and $Y = X^2$ have $\\text{Cov}(X,Y) = 0$ but are clearly dependent). In LLMs, tokens are NOT independent — the whole point of the model is to capture dependencies."
@@ -70,7 +70,7 @@ export const probabilityFoundationsAssessment = {
     {
       type: "mc",
       question: "The **law of total probability** says $P(A) = \\sum_i P(A \\mid B_i) P(B_i)$ for a partition $\\{B_i\\}$. When marginalizing over latent variable $z$ in a latent variable model, we compute:",
-      options: ["$P(x) = \\max_z P(x \\mid z) P(z)$", "$P(x) = \\sum_z P(z \\mid x) P(x)$", "$P(x) = P(x \\mid z^*) $ where $z^* = \\arg\\max P(z)$", "$P(x) = \\sum_z P(x \\mid z) P(z)$ (or $\\int$ for continuous $z$)"],
+      options: ["$P(x) = \\max_z P(x \\mid z) P(z)$, selecting the single latent configuration that maximizes the joint probability", "$P(x) = \\sum_z P(z \\mid x) P(x)$, weighting by the posterior distribution over the latent variable given the observation", "$P(x) = P(x \\mid z^*)$ where $z^* = \\arg\\max P(z)$, conditioning on the most probable latent state from the prior", "$P(x) = \\sum_z P(x \\mid z) P(z)$ (or $\\int$ for continuous $z$), summing the likelihood weighted by the prior over all latent states"],
       correct: 3,
       explanation: "Marginalization is exactly the law of total probability applied to a latent variable: $P(x) = \\sum_z P(x, z) = \\sum_z P(x \\mid z) P(z)$. This integral is often intractable, which is why we need variational inference (ELBO) or sampling methods. The max version gives the MAP estimate, not the marginal."
     },
@@ -90,10 +90,10 @@ export const probabilityFoundationsAssessment = {
       type: "mc",
       question: "A token $w$ is drawn from a categorical distribution with probabilities $p_1 = 0.5, p_2 = 0.3, p_3 = 0.2$. What is $\\mathbb{E}[-\\log_2 p(w)]$, the expected number of bits needed to encode this draw?",
       options: [
-        "$-\\log_2(0.5) = 1$ bit",
+        "$-\\log_2(0.5) = 1$ bit, using only the most probable token",
         "$0.5 \\cdot 1 + 0.3 \\cdot \\log_2(10/3) + 0.2 \\cdot \\log_2(5) \\approx 1.49$ bits",
-        "$\\log_2(3) \\approx 1.58$ bits",
-        "$3$ bits"
+        "$\\log_2(3) \\approx 1.58$ bits, the entropy of a uniform three-outcome distribution",
+        "$3$ bits, since there are three tokens and each requires one bit of encoding"
       ],
       correct: 1,
       explanation: "This is the **entropy** $H(W) = -\\sum_i p_i \\log_2 p_i = 0.5(1) + 0.3(1.737) + 0.2(2.322) \\approx 1.49$ bits. It's less than $\\log_2(3) \\approx 1.58$ (the uniform case) because the distribution is non-uniform. Entropy is maximized when all outcomes are equally likely."

--- a/src/modules/prob-assessment-sampling.js
+++ b/src/modules/prob-assessment-sampling.js
@@ -18,14 +18,14 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Monte Carlo estimation** approximates $\\mathbb{E}_P[f(x)] \\approx \\frac{1}{N} \\sum_{i=1}^N f(x_i)$ where $x_i \\sim P$. The variance of this estimator decreases as:",
-      options: ["$O(1/N)$ — halving the variance requires doubling the samples, regardless of dimension", "$O(1/N^2)$", "$O(1/\\sqrt{N})$", "$O(e^{-N})$ — exponentially fast"],
+      options: ["$O(1/N)$ — halving the variance requires doubling the number of samples, regardless of the dimensionality of the space", "$O(1/N^2)$ — the variance decreases quadratically, making larger sample sizes dramatically more effective per sample", "$O(1/\\sqrt{N})$ — the standard error and variance both decrease at the same square-root rate with more samples", "$O(e^{-N})$ — the variance decreases exponentially fast, meaning a few hundred samples suffice for arbitrary precision"],
       correct: 0,
       explanation: "By the CLT, the variance of the sample mean is $\\text{Var}[f(X)] / N$, so it decreases as $O(1/N)$. The standard error decreases as $O(1/\\sqrt{N})$. Crucially, this rate is **dimension-independent** — this is why Monte Carlo methods scale to high dimensions where grid-based methods fail exponentially. This $O(1/N)$ rate drives many design choices in how many samples to use."
     },
     {
       type: "mc",
       question: "**Importance sampling** estimates $\\mathbb{E}_P[f(x)]$ using samples from a different distribution $Q$ via $\\mathbb{E}_P[f(x)] = \\mathbb{E}_Q\\left[f(x) \\frac{P(x)}{Q(x)}\\right]$. The ratio $w(x) = P(x)/Q(x)$ is called the importance weight. When can this go badly wrong?",
-      options: ["When $P$ and $Q$ are identical distributions", "When $f(x)$ is a constant function", "When $Q$ has lighter tails than $P$ — the weights $P(x)/Q(x)$ can become enormous in the tails, causing high variance and unstable estimates", "When $N$ is very large"],
+      options: ["When $P$ and $Q$ are identical distributions, because the importance weights degenerate to a constant and provide no variance reduction benefit", "When $f(x)$ is a constant function, because the importance weights amplify noise without contributing any useful signal to the estimate", "When $Q$ has lighter tails than $P$ — the weights $P(x)/Q(x)$ can become enormous in the tails, causing high variance and unstable estimates", "When $N$ is very large, because accumulated floating-point errors in the importance weight computation eventually dominate the estimate"],
       correct: 2,
       explanation: "If $Q$ has lighter tails than $P$, then in regions where $P(x) \\gg Q(x)$, the weight $P(x)/Q(x)$ explodes. A few samples may dominate the entire estimate, giving high variance. This is the \"weight degeneracy\" problem. In off-policy RL, this manifests when the learned policy differs significantly from the behavior policy — importance weights become degenerate, which is why PPO clips them."
     },
@@ -33,10 +33,10 @@ export const samplingAssessment = {
       type: "mc",
       question: "In **PPO** (Proximal Policy Optimization), the clipped surrogate objective involves $\\min\\left(r_t(\\theta) A_t, \\, \\text{clip}(r_t(\\theta), 1-\\epsilon, 1+\\epsilon) A_t\\right)$ where $r_t = \\frac{\\pi_\\theta(a_t|s_t)}{\\pi_{\\theta_{\\text{old}}}(a_t|s_t)}$ is an importance weight. The clipping addresses:",
       options: [
-        "Numerical overflow in the softmax",
-        "The high-variance problem of importance sampling — by preventing the policy ratio from deviating too far, it bounds the variance of the policy gradient estimate",
-        "The mode-seeking behavior of reverse KL",
-        "The computational cost of computing the ratio"
+        "Numerical overflow in the softmax layer that occurs when logits become very large during policy optimization steps",
+        "The high-variance problem of importance sampling — by preventing the policy ratio from deviating too far, it bounds the variance of the gradient estimate",
+        "The mode-seeking behavior of reverse KL divergence, which would otherwise cause the policy to collapse onto a single high-reward action",
+        "The computational cost of computing the importance ratio, which becomes prohibitively expensive when policies diverge significantly"
       ],
       correct: 1,
       explanation: "Without clipping, if $\\pi_\\theta$ diverges far from $\\pi_{\\theta_{\\text{old}}}$, the importance ratio $r_t$ can become very large, causing destructively large policy updates. Clipping $r_t$ to $[1-\\epsilon, 1+\\epsilon]$ bounds the effective step size, keeping the new policy close to the old. This is a practical solution to the importance sampling variance problem, complementary to the KL penalty approach in earlier TRPO."
@@ -44,21 +44,21 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Top-k sampling** from an LLM restricts sampling to the $k$ highest-probability tokens and redistributes probability mass. From a sampling theory perspective, this is equivalent to:",
-      options: ["Importance sampling with a uniform proposal", "Gibbs sampling over the vocabulary", "Rejection sampling where we reject low-probability tokens", "Sampling from a truncated version of the original distribution — renormalizing the top-k probabilities"],
+      options: ["Importance sampling with a uniform proposal distribution over the entire vocabulary, reweighted by the model's token probabilities", "Gibbs sampling over the vocabulary that iteratively updates each token position conditioned on all other positions in the sequence", "Rejection sampling where tokens drawn from the full distribution are rejected if they fall outside the top-$k$ probability set", "Sampling from a truncated version of the original distribution — zeroing out low-probability tokens and renormalizing the top-$k$ probabilities"],
       correct: 3,
       explanation: "Top-k sets $P(w) = 0$ for all tokens outside the top $k$, then renormalizes: $P'(w) = P(w) / \\sum_{w' \\in \\text{top-k}} P(w')$ for $w \\in \\text{top-k}$. This is distribution truncation. Nucleus (top-p) sampling is similar but adaptive — it truncates at the smallest set whose cumulative probability exceeds $p$, making it more robust to varying entropy across positions."
     },
     {
       type: "mc",
       question: "**MCMC** (Markov Chain Monte Carlo) methods construct a Markov chain whose stationary distribution is the target $P$. The **Metropolis-Hastings** acceptance probability $\\alpha = \\min\\left(1, \\frac{P(x') Q(x|x')}{P(x) Q(x'|x)}\\right)$ ensures:",
-      options: ["**Detailed balance**: the chain is reversible with respect to $P$, guaranteeing $P$ is the stationary distribution", "That the chain converges in finite time", "That all states are visited equally often", "That the proposal $Q$ matches $P$ exactly"],
+      options: ["**Detailed balance**: the chain is reversible with respect to $P$, guaranteeing that $P$ is the unique stationary distribution of the chain", "That the Markov chain converges to the target distribution within a finite and bounded number of transition steps", "That all states in the state space are visited with exactly equal frequency, ensuring uniform coverage of the support", "That the proposal distribution $Q$ converges to match the target $P$ exactly as the number of accepted samples increases"],
       correct: 0,
       explanation: "The acceptance ratio enforces detailed balance: $P(x) T(x'|x) = P(x') T(x|x')$ where $T$ is the transition kernel. Detailed balance implies $P$ is stationary (but is stronger — it also implies reversibility). Note that we only need the ratio $P(x')/P(x)$, so we don't need to know the normalizing constant of $P$ — this is why MCMC works for Bayesian posteriors where the evidence is intractable."
     },
     {
       type: "mc",
       question: "The **Gumbel-max trick** provides exact samples from a categorical distribution: $\\arg\\max_i (\\log p_i + G_i)$ where $G_i \\sim \\text{Gumbel}(0, 1)$ are i.i.d. The **Gumbel-Softmax** relaxation replaces argmax with softmax to make this:",
-      options: ["More numerically stable", "Faster to compute", "Differentiable — enabling gradient-based optimization through discrete sampling operations using a continuous relaxation with temperature $\\tau$", "Exact rather than approximate"],
+      options: ["More numerically stable by avoiding the overflow issues that arise when computing argmax over large logit vectors with extreme values", "Faster to compute by replacing the sequential argmax scan with a parallelizable softmax operation across all vocabulary entries", "Differentiable — enabling gradient-based optimization through discrete sampling operations using a continuous relaxation with temperature $\\tau$", "Exact rather than approximate, eliminating the sampling noise inherent in the stochastic Gumbel perturbations of the original method"],
       correct: 2,
       explanation: "The argmax is non-differentiable, blocking backpropagation. Gumbel-Softmax replaces it with $\\text{softmax}((\\log p_i + G_i)/\\tau)$, which is differentiable and approaches a one-hot vector as $\\tau \\to 0$. This enables end-to-end training of models with discrete choices (e.g., hard attention, discrete latent variables). The temperature $\\tau$ controls the bias-variance trade-off: low $\\tau$ is more accurate but higher variance."
     },
@@ -66,10 +66,10 @@ export const samplingAssessment = {
       type: "mc",
       question: "When estimating $\\mathbb{E}_P[f(x)]$ with MCMC samples, the samples are **correlated** (not i.i.d.). The **effective sample size** (ESS) accounts for this. If you draw 10,000 MCMC samples but the ESS is 500, this means:",
       options: [
-        "9,500 samples should be discarded as burn-in",
+        "Exactly 9,500 of the samples should be discarded as burn-in because the chain had not yet reached its stationary distribution",
         "The correlated chain provides the same statistical power as 500 independent samples — autocorrelation has reduced the information content by 20×",
-        "The chain has not converged",
-        "You need exactly 500 more samples"
+        "The chain has failed to converge to the target distribution and the samples should not be used for any downstream estimation",
+        "You need to draw exactly 500 additional samples from an independent chain to reach the minimum threshold for reliable estimates"
       ],
       correct: 1,
       explanation: "ESS = $N / (1 + 2\\sum_{k=1}^\\infty \\rho_k)$ where $\\rho_k$ is the autocorrelation at lag $k$. High autocorrelation (slow mixing) drastically reduces ESS. An ESS of 500 from 10,000 samples means consecutive samples are highly correlated — the chain is \"exploring slowly.\" This is why mixing time and thinning (keeping every $k$-th sample) matter. In practice, ESS guides how long to run the chain."
@@ -77,14 +77,14 @@ export const samplingAssessment = {
     {
       type: "mc",
       question: "**Rejection sampling** draws $x \\sim Q$, then accepts with probability $\\frac{P(x)}{M \\cdot Q(x)}$ where $M \\geq \\sup_x \\frac{P(x)}{Q(x)}$. In high dimensions, this method:",
-      options: ["Becomes more efficient due to the law of large numbers", "Is replaced by importance sampling, which has the same problem", "Works exactly the same as in low dimensions", "Becomes exponentially inefficient — the acceptance rate drops exponentially with dimension because $M$ must be exponentially large to bound $P/Q$ everywhere"],
+      options: ["Becomes more efficient because the law of large numbers ensures better concentration of the acceptance probability around its mean", "Is naturally replaced by importance sampling, which suffers from the same exponential inefficiency due to weight degeneracy in high dimensions", "Works with identical efficiency as in low dimensions because the acceptance probability depends only on the density ratio, not dimensionality", "Becomes exponentially inefficient — the acceptance rate drops exponentially with dimension because $M$ must be exponentially large to bound $P/Q$ everywhere"],
       correct: 3,
       explanation: "In $d$ dimensions, the acceptance rate $1/M$ typically decays as $e^{-\\Theta(d)}$ because the proposal $Q$ must cover the tails of $P$ in all dimensions simultaneously. This is the \"curse of dimensionality\" for rejection sampling. MCMC avoids this by not requiring a global bound — it only needs local moves. This is why rejection sampling is practical only in low dimensions, while MCMC and variational methods scale to millions of parameters."
     },
     {
       type: "mc",
       question: "**Speculative decoding** uses a small draft model to generate $k$ candidate tokens, then verifies them against the large target model in parallel. The verification uses a form of:",
-      options: ["Rejection sampling — each draft token is accepted with probability $\\min(1, P_{\\text{target}}(w_t) / P_{\\text{draft}}(w_t))$, and on rejection, we resample from a corrected distribution, ensuring the final output distribution exactly matches the target model", "Beam search with pruning", "Importance sampling with the draft model as the proposal", "Gibbs sampling alternating between draft and target"],
+      options: ["Rejection sampling — each draft token is accepted with probability $\\min(1, P_{\\text{target}}(w_t) / P_{\\text{draft}}(w_t))$, and on rejection we resample from a corrected distribution to match the target exactly", "Beam search with pruning, where the draft model proposes candidate beams and the target model scores and selects among the top-scoring continuations", "Importance sampling with the draft model as the proposal distribution, reweighting each candidate token by the ratio of target to draft probabilities", "Gibbs sampling that alternates between the draft and target model distributions, iteratively refining each token position conditioned on its neighbors"],
       correct: 0,
       explanation: "Speculative decoding is mathematically exact: the output distribution matches what the target model would produce with standard autoregressive sampling. The trick is that acceptance probability $\\min(1, P_{\\text{target}}/P_{\\text{draft}})$ is high when the draft model is good, so most tokens are accepted without running the large model sequentially. On rejection, sampling from the residual $(P_{\\text{target}} - P_{\\text{draft}})_+$ corrects for the draft model's errors."
     }


### PR DESCRIPTION
Expanded short distractors with plausible technical detail so all options in each MC question match the correct answer's length and style, preventing test-taking shortcuts based on option length alone.
